### PR TITLE
Extend native schema for polars engine migration (#13, phase 1)

### DIFF
--- a/.issueflows/01-current-issues/issue13_original.md
+++ b/.issueflows/01-current-issues/issue13_original.md
@@ -1,0 +1,39 @@
+# Issue #13: Migrate the step/summary compute engine to polars (native schema)
+
+Source: https://github.com/cellpy/cellpy-core/issues/13
+
+## Original issue text
+
+Follow-up spun out of #12 (which was descoped to bringing `CellpyLimits` + settling the step-type constants).
+
+## Goal
+
+Migrate the cellpy-core compute engine (`make_step_table` **and** the summary path) from pandas to **polars-native**, operating on the native `config` schema, while keeping the `cellpy` integration seam working.
+
+## Why this is non-trivial (blockers found in #12)
+
+1. **The whole engine is pandas + legacy-schema only.** Both `summarizers.py` and `selectors.py` use `pandas.groupby` and read legacy `*_txt` names (`charge_capacity_txt`, `cycle_index_txt`, …) that exist only on `HeadersNormal`; they operate on pandas `data.raw` / `data.summary`. There is no working native polars path today — it must be written from scratch while keeping the legacy seam byte-stable for cellpy.
+2. **Native `RawCols` lacks columns the step engine needs:** no `step_time`, `internal_resistance`, `ref_voltage`; capacity is only `step_cumulative_charge_capacity` / `step_cumulative_discharge_capacity` (no plain `charge_capacity`); no energy/power.
+3. **Native `StepCols` != legacy `HeadersStepTable`:** native uses `_mean`/`potential`/`charge_capacity`; legacy uses `_avr`/`voltage`/`charge` and additionally has `rate_avr`, `ir`, `ir_pct_change`, `type`, `info`, `ustep` (produced by the engine and consumed by cellpy). Native `StepCols` also lists `power_capacity_*` / `*_energy_*` that the native raw cannot supply.
+
+## Decisions to honour (from #12 planning)
+
+- Migrate step **and** summary paths together (avoid a split engine).
+- Native step table always emits the full `StepCols` set, filling null/NaN where the source signal is absent from `data.raw`.
+- Keep the cellpy seam working: either a pandas<->polars + legacy<->native bridge in `OldCellpyCellCore`, or **extend the native schema first** (preferred — resolves blockers 2 & 3) then rewrite.
+- Step-detection thresholds come from `CellpyLimits` (already in `legacy.py`, landed in #12); cellpy passes its own `raw_limits` by value.
+
+## Tasks
+
+- [ ] Extend native `RawCols`/`StepCols` to represent the step-table output (step_time, internal_resistance, capacity vs cumulative, rate/type/ir columns).
+- [ ] Rewrite `make_step_table` to polars-native + full `StepCols` (null/NaN for absent signals).
+- [ ] Rewrite the summary path (`summarizers` summary functions + `selectors`) to polars-native.
+- [ ] pandas<->polars / legacy<->native bridge in `OldCellpyCellCore` (handle pandas index + duplicate-column tolerance vs polars).
+- [ ] Cross-repo parity tests vs cellpy's `make_step_table` / `make_summary`.
+
+## References
+
+- Design note: `.issueflows/04-designs-and-guides/step-table-polars-migration.md`
+- Origin issue: #12
+- Integration design: `.issueflows/04-designs-and-guides/cellpy-core-integration-into-cellpy.md`
+- Consumer-side tracking: jepegit/cellpy#377

--- a/.issueflows/01-current-issues/issue13_plan.md
+++ b/.issueflows/01-current-issues/issue13_plan.md
@@ -1,0 +1,146 @@
+# Plan for issue #13: Migrate the step/summary compute engine to polars (native schema)
+
+## Goal
+
+Replace the pandas + legacy-schema compute engine (`make_step_table` **and** the summary
+path in `summarizers.py` / `selectors.py`) with a **polars-native** engine that operates on
+the native `config` schema, while keeping the `cellpy` integration seam
+(`OldCellpyCellCore`) byte-stable against the golden oracle in `tests/test_golden.py`.
+
+## Constraints
+
+- **KISS / scope:** this is large. Plan proposes a **phased split** (see Approach) and asks
+  the user before implementing past Phase 1.
+- **Golden oracle stays green.** `tests/test_golden.py` pins the engine against cellpy's
+  published numbers (103 steps / 18 cycles / cyc-1 `data_point` 1457) plus a frozen
+  step-table snapshot (`tests/data/arbin_cc_steps_expected.parquet`). Any intentional change
+  to step-table output must be a deliberate snapshot regen, not an accident.
+- **Legacy headers must not drift.** `legacy.HeadersNormal/Summary/StepTable` are verbatim
+  mirrors of cellpy's `internal_settings` and are contract-tested (jepegit/cellpy#378). They
+  keep their `*_txt` / `type` / `rate_avr` attribute names and values.
+- **Schema-agnostic + thread-safe** engine design (per `config.Schema`, injected per cell)
+  is preserved.
+- **Units by value** — the engine takes precomputed conversion factors / `nom_cap` /
+  `raw_limits` as arguments; no pint in the engine.
+- `requires-python >=3.13`; deps already include `polars>=1.29`, `narwhals>=1.38`, `pandas`.
+- Project rule: run via `uv run` (`uv run pytest`).
+
+### Prior art
+
+- `summarizers.make_step_table` (`cellpycore.summarizers`) — pandas `groupby().agg([...])`
+  on raw, reads schema attrs **by legacy names** (`schema.raw.data_point_txt`,
+  `schema.step.type`, `schema.step.rate_avr`, …); emits flattened `<col>_<stat>` columns +
+  `type`/`sub_type`/`info`/`rate_avr`. New work: re-implement in polars; decide vocabulary
+  (see Open questions).
+- Summary path `summarizers.{generate_absolute_summary_columns, end_voltage_to_summary,
+  c_rates_to_summary, ir_to_summary, equivalent_cycles_to_summary,
+  generate_specific_summary_columns}` + `selectors.{create_selector,
+  summary_selector_exluder, get_step_numbers, get_cycle_numbers, get_rates}` — all pandas,
+  read legacy schema attrs, operate on `data.raw` / `data.summary` / `data.steps`. New work:
+  migrate together (avoid split engine).
+- `config.RawCols/StepCols/CycleCols` (`cellpycore.config`) — native names (`potential`,
+  `charge_capacity`, `step_type`, `_mean`). Missing raw inputs the engine needs (`step_time`,
+  `internal_resistance`, `ref_voltage`, plain non-cumulative capacity). New work: extend
+  (Phase 1).
+- `CellpyCellCore.schema` / `make_core_step_table` / `make_core_summary`
+  (`cellpycore.cell_core`) — the seam that injects the schema and calls the engine. The
+  bridge work lands here.
+- `tests/test_schema.py`, `tests/test_golden.py` — current behavior pins. Mirror their
+  intent for the native path.
+- None found for an existing polars step engine in-repo (grep checked) — greenfield rewrite.
+
+## Approach
+
+**Decision pending (Open question 1) on engine vocabulary** — the rest assumes the
+recommended option **A** (engine targets native schema; `OldCellpyCellCore` bridges
+legacy↔native + pandas↔polars at the seam). Phasing:
+
+**Phase 1 — Extend the native schema (low-risk, unblocks 2 & 3).**
+- Add to `config.RawCols` the inputs the engine consumes: `step_time`,
+  `internal_resistance`, `ref_voltage`, and a single **cumulative capacity** signal per
+  direction (see Capacity finding below). Decide spec stance (Open question 3).
+
+  **Capacity finding (from the real Arbin fixture, verified):** legacy raw
+  `charge_capacity` / `discharge_capacity` are **cycle-cumulative, per direction** — they
+  accumulate across a cycle's steps for their direction and reset to 0 at each cycle
+  boundary. They are *not* per-step. The harmonized spec's `step_cumulative_charge_capacity`
+  name is therefore misleading relative to the data. **Per-step** capacity is *derived* by
+  the engine (delta = last−first within a step group); **per-cycle** capacity is the
+  cycle-end value. So native raw carries one cumulative-capacity column per direction (=
+  legacy `charge_capacity`), and the engine computes per-step / per-cycle from it.
+- Confirm `config.StepCols` already covers the full output set (it lists
+  energy/power stats); add any legacy-equivalent extras the engine produces that have no
+  native home (`rate_avr`→? , `step_type`/`sub_step_type` exist; `info`/`ustep`→ decide).
+- Tests: extend `tests/test_config_columns.py`.
+
+**Phase 2 — Polars-native `make_step_table` + bridge.**
+- Re-implement `make_step_table` in polars: `group_by([cycle, step, sub_step])` →
+  `agg(mean/std/min/max/first/last/delta)`; C-rate; step-type classification masks; emit full
+  native `StepCols`, null for absent signals (energy/power/IR when raw lacks them).
+- Bridge in `OldCellpyCellCore.make_core_step_table`: pandas(legacy)→polars(native) in,
+  run native engine, polars(native)→pandas(legacy) out (rename to legacy columns, restore
+  the pandas index/duplicate-column behavior cellpy expects).
+- Fix the tiny-fixture blank-`type` edge case (design note calls for it).
+- Tests: port `tests/test_schema.py` step assertions to native; keep `tests/test_golden.py`
+  green through the bridge (regen snapshot only if a change is intended & approved).
+
+**Phase 3 — Polars-native summary path (`summarizers` summary fns + `selectors`).**
+- Migrate `generate_absolute_summary_columns`, `end_voltage_to_summary`,
+  `c_rates_to_summary`, `ir_to_summary`, `equivalent_cycles_to_summary`,
+  `generate_specific_summary_columns`, and all of `selectors.py` to polars-native.
+- Bridge `make_core_summary` / `add_scaled_summary_columns` the same way.
+
+**Phase 4 — Cross-repo parity tests.**
+- Parity vs cellpy's `make_step_table` / `make_summary` (the golden parquets are already the
+  oracle; extend with summary goldens if needed). Coordinate with jepegit/cellpy#377/#378.
+
+## Files to touch
+
+- `src/cellpycore/config.py` — extend `RawCols` (+ maybe `StepCols`) (Phase 1).
+- `docs/data_format_specifications/harmonized_raw.md` — only if we amend the spec (Open q 3).
+- `src/cellpycore/summarizers.py` — polars rewrite (Phases 2–3).
+- `src/cellpycore/selectors.py` — polars rewrite (Phase 3).
+- `src/cellpycore/cell_core.py` — legacy↔native + pandas↔polars bridge in
+  `OldCellpyCellCore` / `make_core_*` (Phases 2–3).
+- `tests/test_config_columns.py`, `tests/test_schema.py`, `tests/test_golden.py`,
+  plus new native/parity tests (all phases).
+- Possibly update `.issueflows/04-designs-and-guides/step-table-polars-migration.md` with the
+  final vocabulary decision.
+
+## Test strategy
+
+- Re-run `uv run pytest` after each phase; the golden suite is the regression gate.
+- New: native-schema step/summary tests mirroring `test_schema.py`; parity tests (Phase 4).
+- Snapshot regen (`dev/regenerate_test_data.py`) only on intentional, approved output change.
+
+## Open questions
+
+1. **Engine vocabulary (pivotal).** (A) Engine targets the **native** schema; bridge
+   legacy↔native in `OldCellpyCellCore` (recommended; matches the design doc's "extend native
+   schema then rewrite"). vs (B) keep the engine reading whatever attr names are injected and
+   add native aliases so current legacy attr names resolve on native too (less rewrite, but
+   muddies the native schema). Which one?
+2. **polars vs narwhals.** Issue says "polars-native"; repo also ships `narwhals`. Pure
+   polars in the engine, or narwhals for dataframe-agnosticism? (Recommend pure polars per the
+   issue title.)
+3. **RawCols vs the authoritative spec (capacity naming).** Verified finding above: legacy
+   raw capacity is **cycle-cumulative per direction**, so the spec's
+   `step_cumulative_charge_capacity` / `step_cumulative_discharge_capacity` names are
+   misleading. Resolution options for the native raw capacity column:
+   - **(3a, recommended)** Rename the spec columns to `cumulative_charge_capacity` /
+     `cumulative_discharge_capacity` (drop the misleading `step_`), map the bridge
+     legacy `charge_capacity` ↔ native `cumulative_charge_capacity`, and have the engine
+     derive per-step (delta) and per-cycle (cycle-end) capacities. Amends
+     `harmonized_raw.md`.
+   - **(3b)** Leave the spec names as-is and just map legacy `charge_capacity` ↔ native
+     `step_cumulative_charge_capacity` in the bridge (no doc change, but the name stays
+     misleading).
+   Also still needed in raw: `step_time`, `internal_resistance`, `ref_voltage` — add as
+   optional input columns (derive `step_time` from `test_time` per step if a cycler omits it;
+   IR/ref_voltage null when absent). Confirm spec stance.
+4. **Scope / sequencing.** OK to land this as **separate PRs per phase** (1→4), or do you
+   want it as one branch? (Recommend phased PRs; Phase 1 is safe to start immediately.)
+5. **Bridge return contract.** Confirm the seam must keep returning **pandas + legacy
+   column names** (so cellpy and the golden tests are unaffected), with the native polars path
+   used internally only.
+```

--- a/.issueflows/01-current-issues/issue13_status.md
+++ b/.issueflows/01-current-issues/issue13_status.md
@@ -1,0 +1,50 @@
+# Status — issue #13: Migrate the step/summary compute engine to polars (native schema)
+
+- [ ] Done
+
+Phased migration (see `issue13_plan.md`). **Phase 1 complete; Phases 2–4 remain.**
+
+## Confirmed decisions (2026-06-14)
+
+- **Engine vocabulary:** Option A — polars engine targets the **native** schema;
+  `OldCellpyCellCore` bridges legacy↔native + pandas↔polars at the seam.
+- **Dataframe lib:** pure **polars** in the engine.
+- **Sequencing:** separate PR per phase.
+- **Capacity:** raw capacity/energy are **cumulative per cycle, per direction** (mandated).
+  Renamed `step_cumulative_*` → `cumulative_*`. Per-step (delta) and per-cycle (cycle-end)
+  are derived. Verified on the real Arbin fixture. Full rationale in
+  `.issueflows/04-designs-and-guides/step-table-polars-migration.md`.
+
+## Phase 1 — extend native schema (DONE)
+
+- `docs/data_format_specifications/harmonized_raw.md`: renamed the 4 `step_cumulative_*`
+  capacity/energy columns to `cumulative_*`; added `step_time` and `internal_resistance`;
+  added a *Capacity convention* section + Conventions bullet.
+- `docs/data_format_specifications/step_table.md`: added `step_time` aggregates,
+  `internal_resistance` aggregates, and `c_rate`.
+- `src/cellpycore/config.py`: `RawCols` renamed cumulative columns + added `step_time`,
+  `internal_resistance`; `StepCols` added `step_time_*`, `internal_resistance_*` aggregates
+  and `c_rate`.
+- `src/cellpycore/_helpers.py`: mock raw updated for the renamed/new columns.
+- `tests/test_config_columns.py`: `RAW_EXPECTED` / `STEP_EXPECTED` updated to the new specs.
+- `legacy.py` and the legacy/golden path are **unchanged** (cellpy contract intact).
+- **Tests:** `uv run pytest` → 26 passed (golden suite unaffected).
+
+## Deferred / notes
+
+- `ref_potential` not added — **not present** in the golden Arbin data, so not needed for
+  parity yet. Add when a consumer needs it.
+- Power columns (`step_charge_power` / `step_discharge_power`) left as-is (instantaneous, not
+  cumulative); a separate naming cleanup if desired.
+- Whether native `test_time` / `datapoint_num` need **full** aggregates (vs first/last) for
+  byte-exact legacy parity through the bridge is a **Phase 2** reconciliation decision
+  (expand native StepCols vs regenerate the golden snapshot under the native column set).
+
+## Remaining
+
+- **Phase 2:** polars-native `make_step_table` + legacy↔native / pandas↔polars bridge in
+  `OldCellpyCellCore`; keep `tests/test_golden.py` green; fix tiny-fixture blank-`type` edge
+  case.
+- **Phase 3:** polars-native summary path (`summarizers` summary fns + all of `selectors.py`)
+  + bridge `make_core_summary` / `add_scaled_summary_columns`.
+- **Phase 4:** cross-repo parity tests vs cellpy's `make_step_table` / `make_summary`.

--- a/.issueflows/04-designs-and-guides/step-table-polars-migration.md
+++ b/.issueflows/04-designs-and-guides/step-table-polars-migration.md
@@ -51,6 +51,42 @@ tracked in **issue #13**.
 - **Edge case to fix during the rewrite:** on the tiny 47-row fixture the engine
   leaves one step's `type` blank (`''`) — revisit step-type classification.
 
+## Decisions taken in issue #13 (the follow-up itself)
+
+- **Engine vocabulary:** Option A — the polars engine targets the **native** schema;
+  `OldCellpyCellCore` bridges legacy↔native (column rename) + pandas↔polars at the seam.
+  Confirmed 2026-06-14.
+- **Dataframe lib:** pure **polars** in the engine (not narwhals).
+- **Sequencing:** phased PRs — (1) extend native schema, (2) polars step engine + bridge,
+  (3) polars summary path, (4) cross-repo parity.
+- **Capacity semantics (verified on the real Arbin fixture):** legacy raw
+  `charge_capacity` / `discharge_capacity` are **cycle-cumulative, per direction** (accumulate
+  across a cycle's steps for their direction, reset to 0 at each cycle boundary). They are
+  *not* per-step. The summary path depends on this: `selectors.summary_selector_exluder`
+  reads the cycle's **last** raw datapoint as that cycle's capacity, which is only correct for
+  cycle-cumulative raw. Taking the harmonized spec's `step_cumulative_*` name literally
+  (step-cumulative values) would **break** the summary.
+  - **Decision:** the harmonized raw capacity column **mandates cycle-cumulative** (per
+    cycle, per direction). Renamed the native columns
+    `step_cumulative_charge_capacity`→`cumulative_charge_capacity` and
+    `step_cumulative_discharge_capacity`→`cumulative_discharge_capacity` (energy renamed the
+    same way). The bridge maps legacy `charge_capacity` ↔ native `cumulative_charge_capacity`
+    (pure rename, no value transform). Per-step capacity is **derived** by the engine
+    (delta = last−first within a step); per-cycle is the cycle-end cumulative value.
+  - Reset-granularity normalization in the engine (to also accept step-/test-cumulative raw
+    from other cyclers) is a deliberate **future follow-up**, not done now.
+
+### Phase 1 native-schema changes (this PR)
+
+- `RawCols`: rename the 4 `step_cumulative_*` capacity/energy columns to `cumulative_*`;
+  add `step_time` and `internal_resistance` (engine inputs present in legacy raw / needed for
+  parity). `ref_potential` deferred — **not present** in the golden Arbin data, so not needed
+  for parity yet (note kept here so the gap is tracked).
+- `StepCols`: add `step_time` and `internal_resistance` aggregate sets (mean/std/min/max/
+  first/last/delta) and a per-step `c_rate` (native name for legacy `rate_avr`).
+- The legacy `Headers*` mirrors in `legacy.py` are **unchanged** (cellpy contract); the
+  legacy/golden path is unaffected by these native-schema edits.
+
 ## Related
 
 - Issue #12 (this work's origin): `.issueflows/03-solved-issues/issue12_*` once closed.

--- a/docs/data_format_specifications/harmonized_raw.md
+++ b/docs/data_format_specifications/harmonized_raw.md
@@ -17,6 +17,9 @@ Original cycler files are converted to this format, in order to unify the format
 - Time columns (`test_time`, etc.) are in **seconds**.
 - The cycler step mode column is **`step_mode`**. There is no `channel_status` column
   (it was dropped in issue #10).
+- Capacity / energy columns are **cumulative per cycle, per direction** — see *Capacity
+  convention* below. (Renamed from `step_cumulative_*` in issue #13; the old name was
+  misleading.)
 
 ## Column Headers
 
@@ -29,6 +32,7 @@ Set up a flexible structure that allows for more columns.
 | mask | boolean | - | True | default: True (meaning: this value is selected and used) |
 | epoch_time_utc | float | second | 1715609528.578140 | - |
 | test_time | float | second | 12.43212 | - |
+| step_time | float | second | 12.43212 | optional value; time elapsed since the start of the current step |
 | source_type | str(10) | - | "Neware" | - |
 | source_uuid | str(36) | - | "e15b46ca-e584-467f-a176-8bf98b8090e5" | will not be used, only kept for info and tracability |
 | test_id | int | - | 0 | compact per-test key within a (possibly merged) object; 0 for a single test. Group keys are (test_id, cycle_num, step_num, ...). Global identity: source_uuid |
@@ -41,18 +45,36 @@ Set up a flexible structure that allows for more columns.
 | cycle_type | str(36) | - | "Standard", "GITT", "ICI", "Characterization" | categorial column; in first version: pre-defined input |
 | potential | float | Volt | 3.6500 | - |
 | current | float | Ampere | 96.4413 | - |
-| step_cumulative_charge_capacity | float | Ah | 34.5678 | - |
-| step_cumulative_discharge_capacity | float | Ah | 34.5678 | - |
-| step_cumulative_charge_energy | float | Wh | 34.5678 | ** |
-| step_cumulative_discharge_energy | float | Wh | 34.5678 | ** |
+| cumulative_charge_capacity | float | Ah | 34.5678 | cumulative per cycle, per direction (resets at each cycle boundary); per-step / per-cycle values are derived downstream — see *Capacity convention* below |
+| cumulative_discharge_capacity | float | Ah | 34.5678 | cumulative per cycle, per direction (see *Capacity convention*) |
+| cumulative_charge_energy | float | Wh | 34.5678 | ** ; cumulative per cycle, per direction (see *Capacity convention*) |
+| cumulative_discharge_energy | float | Wh | 34.5678 | ** ; cumulative per cycle, per direction (see *Capacity convention*) |
 | step_charge_power | float | W | 34.5678 | ** |
 | step_discharge_power | float | W | 34.5678 | ** |
+| internal_resistance | float | ohm | 56.4866 | optional value; instrument-reported internal resistance |
 | aux_temperature_cell | float | degrees celcius | 25.3 | - |
 | aux_temperature_chamber | float | degrees celcius | 25.0 | - |
 | aux_pressure_cell | float | mbar | 123.4 | - |
 
 
 ** calculate if empty; keep if filled (can be overridden by argument)
+
+### Capacity convention
+
+`cumulative_charge_capacity` / `cumulative_discharge_capacity` (and the matching energy
+columns) are **cumulative per cycle, per direction**: within a cycle they accumulate across
+that cycle's steps for their direction, and reset to `0` at each cycle boundary. This matches
+how legacy cellpy raw data is supplied (verified on real Arbin data in issue #13) and is what
+the summary path relies on (the per-cycle capacity is read from the cycle's last datapoint).
+
+Downstream values are **derived**, not stored in raw:
+- **per-step** capacity = the in-step delta (last − first within a step group), produced in
+  the step table;
+- **per-cycle** capacity = the cycle-end cumulative value, produced in the cycle/summary
+  table.
+
+Importers must deliver cycle-cumulative capacity. (Accepting step-/test-cumulative raw and
+normalizing the reset granularity inside the engine is a possible future extension.)
 
 ### Auxillary columns  
 Option for more auxillary columns; naming scheme:

--- a/docs/data_format_specifications/step_table.md
+++ b/docs/data_format_specifications/step_table.md
@@ -27,6 +27,13 @@ calculations and to classify steps.
 | datapoint_num_last | int | - | 123 | Last datapoint number in step |
 | test_time_first | float | second (s) | 14.1231 | Test time at start of step |
 | test_time_last | float | second (s) | 15.1231 | Test time at end of step |
+| step_time_mean | float | second (s) | 15.1231 | 
+| step_time_std | float | second (s) | 15.1231 | 
+| step_time_min | float | second (s) | 15.1231 | 
+| step_time_max | float | second (s) | 15.1231 | 
+| step_time_first | float | second (s) | 15.1231 | 
+| step_time_last | float | second (s) | 15.1231 | 
+| step_time_delta | float | % | 15.1231 |
 | current_mean | float | Ampere (A) | 15.1231 | 
 | current_std | float | Ampere (A) | 15.1231 | 
 | current_min | float | Ampere (A) | 15.1231 | 
@@ -76,3 +83,11 @@ calculations and to classify steps.
 | discharge_energy_first | float | Watt-hour (Wh) | 15.1231 | 
 | discharge_energy_last | float | Watt-hour (Wh) | 15.1231 | 
 | discharge_energy_delta | float | % | 15.1231 |      
+| internal_resistance_mean | float | ohm | 56.4866 | 
+| internal_resistance_std | float | ohm | 56.4866 | 
+| internal_resistance_min | float | ohm | 56.4866 | 
+| internal_resistance_max | float | ohm | 56.4866 | 
+| internal_resistance_first | float | ohm | 56.4866 | 
+| internal_resistance_last | float | ohm | 56.4866 | 
+| internal_resistance_delta | float | % | 56.4866 |
+| c_rate | float | 1/h (C) | 0.05 | Per-step C-rate estimate (legacy `rate_avr`) |

--- a/src/cellpycore/_helpers.py
+++ b/src/cellpycore/_helpers.py
@@ -86,9 +86,9 @@ def create_raw_data() -> DataFrame:
 
     potential = pl.Series(raw_cols.potential, potential, dtype=pl.Float64)
 
-    # Generate cumulative capacities
-    step_cumulative_charge_capacity = []
-    step_cumulative_discharge_capacity = []
+    # Generate cumulative capacities (cumulative per cycle, per direction).
+    cumulative_charge_capacity = []
+    cumulative_discharge_capacity = []
     charge_cap = 0.0
     discharge_cap = 0.0
 
@@ -97,18 +97,26 @@ def create_raw_data() -> DataFrame:
             charge_cap += abs(curr) * 0.1  # Assuming 0.1 hour time step
         elif st == "discharge":
             discharge_cap += abs(curr) * 0.1
-        step_cumulative_charge_capacity.append(charge_cap)
-        step_cumulative_discharge_capacity.append(discharge_cap)
+        cumulative_charge_capacity.append(charge_cap)
+        cumulative_discharge_capacity.append(discharge_cap)
 
-    step_cumulative_charge_capacity = pl.Series(
-        raw_cols.step_cumulative_charge_capacity,
-        step_cumulative_charge_capacity,
+    cumulative_charge_capacity = pl.Series(
+        raw_cols.cumulative_charge_capacity,
+        cumulative_charge_capacity,
         dtype=pl.Float64,
     )
-    step_cumulative_discharge_capacity = pl.Series(
-        raw_cols.step_cumulative_discharge_capacity,
-        step_cumulative_discharge_capacity,
+    cumulative_discharge_capacity = pl.Series(
+        raw_cols.cumulative_discharge_capacity,
+        cumulative_discharge_capacity,
         dtype=pl.Float64,
+    )
+
+    # Step time (seconds since the start of the current step) and instrument IR.
+    step_time = pl.Series(
+        raw_cols.step_time, [float(i % 10) for i in range(n_points)], dtype=pl.Float64
+    )
+    internal_resistance = pl.Series(
+        raw_cols.internal_resistance, [0.05] * n_points, dtype=pl.Float64
     )
 
     # Generate auxiliary temperature data
@@ -145,16 +153,18 @@ def create_raw_data() -> DataFrame:
         raw_cols.cycle_num: cycle_num,
         raw_cols.epoch_time_utc: epoch_time_utc,
         raw_cols.test_time: test_time,
+        raw_cols.step_time: step_time,
         raw_cols.step_mode: step_mode,
         raw_cols.step_type: step_type,
         raw_cols.step_type_detail: step_type_detail,
         raw_cols.potential: potential,
         raw_cols.current: current,
+        raw_cols.internal_resistance: internal_resistance,
         raw_cols.aux_temperature_cell: temperature_cell,
         raw_cols.aux_temperature_chamber: temperature_chamber,
         raw_cols.aux_pressure_cell: pressure,
-        raw_cols.step_cumulative_charge_capacity: step_cumulative_charge_capacity,
-        raw_cols.step_cumulative_discharge_capacity: step_cumulative_discharge_capacity,
+        raw_cols.cumulative_charge_capacity: cumulative_charge_capacity,
+        raw_cols.cumulative_discharge_capacity: cumulative_discharge_capacity,
     }
 
     return pl.DataFrame(data)

--- a/src/cellpycore/config.py
+++ b/src/cellpycore/config.py
@@ -178,6 +178,13 @@ class StepCols(Cols):
     datapoint_num_last: str = "datapoint_num_last"
     test_time_first: str = "test_time_first"
     test_time_last: str = "test_time_last"
+    step_time_mean: str = "step_time_mean"
+    step_time_std: str = "step_time_std"
+    step_time_min: str = "step_time_min"
+    step_time_max: str = "step_time_max"
+    step_time_first: str = "step_time_first"
+    step_time_last: str = "step_time_last"
+    step_time_delta: str = "step_time_delta"
     current_mean: str = "current_mean"
     current_std: str = "current_std"
     current_min: str = "current_min"
@@ -227,6 +234,15 @@ class StepCols(Cols):
     discharge_energy_first: str = "discharge_energy_first"
     discharge_energy_last: str = "discharge_energy_last"
     discharge_energy_delta: str = "discharge_energy_delta"
+    internal_resistance_mean: str = "internal_resistance_mean"
+    internal_resistance_std: str = "internal_resistance_std"
+    internal_resistance_min: str = "internal_resistance_min"
+    internal_resistance_max: str = "internal_resistance_max"
+    internal_resistance_first: str = "internal_resistance_first"
+    internal_resistance_last: str = "internal_resistance_last"
+    internal_resistance_delta: str = "internal_resistance_delta"
+    # Per-step C-rate estimate (legacy ``rate_avr``).
+    c_rate: str = "c_rate"
 
 
 class RawCols(Cols):
@@ -237,6 +253,7 @@ class RawCols(Cols):
     mask: str = "mask"
     epoch_time_utc: str = "epoch_time_utc"
     test_time: str = "test_time"
+    step_time: str = "step_time"
     source_type: str = "source_type"
     source_uuid: str = "source_uuid"
     test_id: str = "test_id"
@@ -249,12 +266,15 @@ class RawCols(Cols):
     cycle_type: str = "cycle_type"
     potential: str = "potential"
     current: str = "current"
-    step_cumulative_charge_capacity: str = "step_cumulative_charge_capacity"
-    step_cumulative_discharge_capacity: str = "step_cumulative_discharge_capacity"
-    step_cumulative_charge_energy: str = "step_cumulative_charge_energy"
-    step_cumulative_discharge_energy: str = "step_cumulative_discharge_energy"
+    # Capacity / energy are cumulative per cycle, per direction (reset each cycle).
+    # See docs/data_format_specifications/harmonized_raw.md ("Capacity convention").
+    cumulative_charge_capacity: str = "cumulative_charge_capacity"
+    cumulative_discharge_capacity: str = "cumulative_discharge_capacity"
+    cumulative_charge_energy: str = "cumulative_charge_energy"
+    cumulative_discharge_energy: str = "cumulative_discharge_energy"
     step_charge_power: str = "step_charge_power"
     step_discharge_power: str = "step_discharge_power"
+    internal_resistance: str = "internal_resistance"
     # Auxiliary columns (aux_<quantity>_<name> scheme). Defaults below cover the
     # cell/chamber temperatures and cell pressure named in the spec.
     aux_temperature_cell: str = "aux_temperature_cell"

--- a/tests/test_config_columns.py
+++ b/tests/test_config_columns.py
@@ -22,12 +22,13 @@ def _aggregates(signal: str) -> list:
 # --- harmonized_raw.md (authoritative, 2025-09-17) ---------------------------
 RAW_EXPECTED = [
     "datapoint_num", "source_datapoint_num", "mask", "epoch_time_utc",
-    "test_time", "source_type", "source_uuid", "test_id", "step_num",
+    "test_time", "step_time", "source_type", "source_uuid", "test_id", "step_num",
     "source_step_num",
     "step_type", "step_type_detail", "step_mode", "cycle_num", "cycle_type",
-    "potential", "current", "step_cumulative_charge_capacity",
-    "step_cumulative_discharge_capacity", "step_cumulative_charge_energy",
-    "step_cumulative_discharge_energy", "step_charge_power", "step_discharge_power",
+    "potential", "current", "cumulative_charge_capacity",
+    "cumulative_discharge_capacity", "cumulative_charge_energy",
+    "cumulative_discharge_energy", "step_charge_power", "step_discharge_power",
+    "internal_resistance",
     "aux_temperature_cell", "aux_temperature_chamber", "aux_pressure_cell",
 ]
 
@@ -35,10 +36,12 @@ RAW_EXPECTED = [
 STEP_EXPECTED = [
     "cycle_num", "step_num", "sub_step_num", "step_type", "sub_step_type", "mask",
     "datapoint_num_first", "datapoint_num_last", "test_time_first", "test_time_last",
+    *_aggregates("step_time"),
     *_aggregates("current"), *_aggregates("potential"),
     *_aggregates("charge_capacity"), *_aggregates("discharge_capacity"),
     *_aggregates("power"), *_aggregates("charge_energy"),
-    *_aggregates("discharge_energy"),
+    *_aggregates("discharge_energy"), *_aggregates("internal_resistance"),
+    "c_rate",
 ]
 
 # --- cycle_table.md ---------------------------------------------------------


### PR DESCRIPTION
## Summary

Phase 1 of the polars-native step/summary engine migration (#13): extend the **native** `config` schema so the upcoming polars engine can operate on it, while leaving the legacy/golden path (and the cellpy contract) untouched.

Key finding, verified on the real Arbin fixture: legacy raw `charge_capacity` / `discharge_capacity` are **cumulative per cycle, per direction** (they reset each cycle), *not* step-cumulative — and the summary path depends on this (it reads each cycle's last datapoint as the cycle capacity). So the harmonized spec's `step_cumulative_*` name was misleading. We **mandate cycle-cumulative** and rename accordingly; per-step (delta) and per-cycle (cycle-end) values are derived downstream.

- **RawCols:** rename `step_cumulative_*` capacity/energy → `cumulative_*`; add `step_time` and `internal_resistance`.
- **StepCols:** add `step_time_*` and `internal_resistance_*` aggregates and `c_rate`.
- Sync `harmonized_raw.md` / `step_table.md` specs + the `test_config_columns.py` conformance test; update the mock raw helper.
- `legacy.py` and the legacy/golden path are **unchanged**.
- Decision rationale + phasing recorded in `.issueflows/04-designs-and-guides/step-table-polars-migration.md`.

This is the first of a phased migration: (1) schema — this PR; (2) polars `make_step_table` + legacy↔native bridge; (3) polars summary path; (4) cross-repo parity tests.

## Test plan

- [x] `uv run pytest` — 26 passed (golden suite unaffected; legacy path untouched)
- [x] Conformance test locks RawCols/StepCols to the amended specs

## Notes / deferred

- `ref_potential` not added (absent from the golden Arbin data; add when needed).
- Whether native `test_time` / `datapoint_num` need full aggregates for byte-exact bridge parity is a Phase 2 decision (expand StepCols vs regen the golden snapshot).

Made with [Cursor](https://cursor.com)