### PR TITLE
Rewrite make_step_table in polars-native + legacy bridge (#13, phase 2)

### DIFF
--- a/.issueflows/01-current-issues/issue13_status.md
+++ b/.issueflows/01-current-issues/issue13_status.md
@@ -2,7 +2,7 @@
 
 - [ ] Done
 
-Phased migration (see `issue13_plan.md`). **Phase 1 complete; Phases 2–4 remain.**
+Phased migration (see `issue13_plan.md`). **Phases 1–2 complete; Phases 3–4 remain.**
 
 ## Confirmed decisions (2026-06-14)
 
@@ -40,11 +40,25 @@ Phased migration (see `issue13_plan.md`). **Phase 1 complete; Phases 2–4 remai
   byte-exact legacy parity through the bridge is a **Phase 2** reconciliation decision
   (expand native StepCols vs regenerate the golden snapshot under the native column set).
 
+## Phase 2 — polars step engine + bridge (DONE)
+
+- `src/cellpycore/summarizers.py`: `make_step_table` rewritten **polars-native** on the
+  native schema (full per-signal aggregates + `delta`, `c_rate`, step-type classification via
+  `_classify_steps`). Removed the pandas `_ustep`/`delta`/groupby path.
+- `src/cellpycore/cell_core.py`: `OldCellpyCellCore.make_core_step_table` is the
+  **legacy↔native + pandas↔polars bridge**, reproducing the legacy 64-column step frame
+  byte-for-byte.
+- `tests/test_golden.py`: drives the step table through the bridge; the existing
+  cellpy-parity snapshot stays the gate (no regen). `tests/test_schema.py`: step tests moved
+  to the native schema.
+- Parity choice **Path P** (reproduce legacy frame exactly) over Path N (regen golden); see
+  the design note.
+- Blank step-type "edge case": resolved as a **degenerate-fixture artifact** (matches legacy
+  cellpy); classification left unchanged to preserve parity.
+- **Tests:** `uv run pytest` → 26 passed.
+
 ## Remaining
 
-- **Phase 2:** polars-native `make_step_table` + legacy↔native / pandas↔polars bridge in
-  `OldCellpyCellCore`; keep `tests/test_golden.py` green; fix tiny-fixture blank-`type` edge
-  case.
 - **Phase 3:** polars-native summary path (`summarizers` summary fns + all of `selectors.py`)
   + bridge `make_core_summary` / `add_scaled_summary_columns`.
 - **Phase 4:** cross-repo parity tests vs cellpy's `make_step_table` / `make_summary`.

--- a/.issueflows/04-designs-and-guides/step-table-polars-migration.md
+++ b/.issueflows/04-designs-and-guides/step-table-polars-migration.md
@@ -76,7 +76,34 @@ tracked in **issue #13**.
   - Reset-granularity normalization in the engine (to also accept step-/test-cumulative raw
     from other cyclers) is a deliberate **future follow-up**, not done now.
 
-### Phase 1 native-schema changes (this PR)
+### Phase 2 step engine + bridge (done)
+
+- `summarizers.make_step_table` is now **polars-native** and operates on the **native**
+  schema. It aggregates every present native raw signal (`datapoint_num`, `test_time`,
+  `step_time`, `current`, `potential`, `cumulative_charge_*capacity`, `internal_resistance`)
+  with the full mean/std/min/max/first/last/delta set, derives the per-step `c_rate`, and
+  classifies step types via the same threshold logic as legacy (later rules win; helper
+  `_classify_steps`). Output is a polars `data.steps` frame.
+- `OldCellpyCellCore.make_core_step_table` is the **legacy↔native + pandas↔polars bridge**:
+  legacy pandas raw → rename to native → polars → engine → native polars steps → rename to
+  legacy → pandas, reproducing the legacy `HeadersStepTable` 64-column frame **byte-for-byte**
+  (incl. the leading `index` column and the `test_time_first` sort). This keeps
+  `tests/test_golden.py` green against the existing cellpy-parity snapshot **without
+  regenerating it** — the strongest parity guarantee.
+- Parity decision: the bridge reproduces the exact legacy frame (Path P), chosen over
+  adopting the native StepCols shape + regenerating the golden (Path N). The native step
+  frame is a *superset* of `StepCols` (it also carries full `test_time`/`datapoint_num`
+  aggregates needed for legacy parity); `StepCols` remains the canonical/guaranteed set.
+- `tests/test_schema.py` step tests rewritten to the native schema/raw (the engine is
+  native-only now). The summary-path test is unchanged (Phase 3 still pandas).
+- **Blank step-type "edge case" — resolved as a non-bug.** The tiny fixture's `step 2` is a
+  degenerate synthetic slice (non-monotonic/duplicated `data_point`, mixed current signs,
+  zero capacity-delta); leaving it blank matches legacy cellpy and is a fixture artifact, not
+  a defect. Classification logic was deliberately **not** changed (changing it would diverge
+  from cellpy and break the parity guarantee). A holistic classification review, if wanted,
+  belongs in its own issue.
+
+### Phase 1 native-schema changes (PR #16, merged)
 
 - `RawCols`: rename the 4 `step_cumulative_*` capacity/energy columns to `cumulative_*`;
   add `step_time` and `internal_resistance` (engine inputs present in legacy raw / needed for

--- a/src/cellpycore/cell_core.py
+++ b/src/cellpycore/cell_core.py
@@ -386,3 +386,144 @@ class OldCellpyCellCore(CellpyCellCore):
         self.raw_cols = HeadersNormal()
         self.cycle_cols = HeadersSummary()
         self.step_cols = HeadersStepTable()
+
+    # ---- legacy <-> native bridge for the polars step engine ----------------
+    # cellpy hands us pandas frames with legacy (``HeadersNormal``) column names.
+    # The step engine is polars-native and operates on the native schema, so we
+    # translate at this seam: legacy pandas raw -> native polars raw -> engine ->
+    # native polars steps -> legacy pandas steps. The output frame reproduces the
+    # legacy ``HeadersStepTable`` layout byte-for-byte (the golden oracle).
+
+    _NATIVE_STAT_TO_LEGACY = {
+        "mean": "avr",
+        "std": "std",
+        "min": "min",
+        "max": "max",
+        "first": "first",
+        "last": "last",
+        "delta": "delta",
+    }
+
+    def _legacy_to_native_raw_rename(self, columns) -> dict:
+        leg, nat = self.raw_cols, config.RawCols()
+        mapping = {
+            leg.data_point_txt: nat.datapoint_num,
+            leg.test_time_txt: nat.test_time,
+            leg.step_time_txt: nat.step_time,
+            leg.cycle_index_txt: nat.cycle_num,
+            leg.step_index_txt: nat.step_num,
+            leg.current_txt: nat.current,
+            leg.voltage_txt: nat.potential,
+            leg.charge_capacity_txt: nat.cumulative_charge_capacity,
+            leg.discharge_capacity_txt: nat.cumulative_discharge_capacity,
+            leg.internal_resistance_txt: nat.internal_resistance,
+        }
+        return {k: v for k, v in mapping.items() if k in columns}
+
+    def _native_to_legacy_step_rename(self) -> dict:
+        leg, nat = self.step_cols, config.StepCols()
+        base_map = {
+            "datapoint_num": leg.point,
+            "test_time": leg.test_time,
+            "step_time": leg.step_time,
+            "current": leg.current,
+            "potential": leg.voltage,
+            "charge_capacity": leg.charge,
+            "discharge_capacity": leg.discharge,
+            "internal_resistance": leg.internal_resistance,
+        }
+        rename = {}
+        for nbase, lbase in base_map.items():
+            for nstat, lstat in self._NATIVE_STAT_TO_LEGACY.items():
+                rename[f"{nbase}_{nstat}"] = f"{lbase}_{lstat}"
+        rename[nat.cycle_num] = leg.cycle
+        rename[nat.step_num] = leg.step
+        rename[nat.sub_step_num] = leg.sub_step
+        rename[nat.step_type] = leg.type
+        rename[nat.sub_step_type] = leg.sub_type
+        rename[nat.c_rate] = leg.rate_avr
+        return rename
+
+    def _legacy_step_column_order(self) -> list:
+        leg = self.step_cols
+        order = [leg.cycle, leg.step, leg.sub_step]
+        bases = [
+            leg.point, leg.test_time, leg.step_time, leg.current, leg.voltage,
+            leg.charge, leg.discharge, leg.internal_resistance,
+        ]
+        for base in bases:
+            order += [f"{base}_{stat}" for stat in self._NATIVE_STAT_TO_LEGACY.values()]
+        order += [leg.rate_avr, leg.type, leg.sub_type, leg.info]
+        return order
+
+    def _native_steps_to_legacy(self, native_steps, sort_rows: bool):
+        leg = self.step_cols
+        pdf = native_steps.to_pandas()
+        pdf = pdf.rename(columns=self._native_to_legacy_step_rename())
+
+        order = self._legacy_step_column_order()
+        if sort_rows:
+            # sort + reset_index reproduces the legacy 'index' column (the
+            # pre-sort, group-key-ordered position).
+            pdf = pdf.sort_values(by=f"{leg.test_time}_first").reset_index()
+            order = ["index"] + order
+
+        order = [c for c in order if c in pdf.columns]
+        return pdf[order]
+
+    def make_core_step_table(
+        self,
+        data: Data,
+        raw_limits: Optional[dict] = None,
+        step_specifications=None,
+        short: bool = False,
+        override_step_types: Optional[dict] = None,
+        override_raw_limits: Optional[dict] = None,
+        usteps: bool = False,
+        add_c_rate: bool = True,
+        nom_cap: Optional[float] = None,
+        skip_steps: Optional[Sequence] = None,
+        sort_rows: bool = True,
+        from_data_point: Optional[int] = None,
+    ) -> Union[Data, "DataFrame"]:
+        """Build the step table via the polars engine, in/out in legacy form.
+
+        See the bridge note above. Returns a pandas frame with legacy
+        ``HeadersStepTable`` columns (or that frame directly when
+        ``from_data_point`` is given).
+        """
+        import polars as pl
+
+        from cellpycore import summarizers
+        from cellpycore.config import default_schema
+
+        native_raw = pl.from_pandas(
+            data.raw.rename(columns=self._legacy_to_native_raw_rename(data.raw.columns))
+        )
+        tmp = Data()
+        tmp.raw = native_raw
+
+        kwargs = dict(
+            schema=default_schema(),
+            step_specifications=step_specifications,
+            short=short,
+            override_step_types=override_step_types,
+            override_raw_limits=override_raw_limits,
+            usteps=usteps,
+            add_c_rate=add_c_rate,
+            nom_cap=nom_cap,
+            skip_steps=skip_steps,
+            sort_rows=False,  # the bridge handles legacy sorting + 'index' column
+            from_data_point=from_data_point,
+        )
+        if raw_limits is not None:
+            kwargs["raw_limits"] = raw_limits
+
+        result = summarizers.make_step_table(tmp, **kwargs)
+        native_steps = result if from_data_point is not None else result.steps
+
+        legacy_steps = self._native_steps_to_legacy(native_steps, sort_rows=sort_rows)
+        if from_data_point is not None:
+            return legacy_steps
+        data.steps = legacy_steps
+        return data

--- a/src/cellpycore/summarizers.py
+++ b/src/cellpycore/summarizers.py
@@ -2,6 +2,7 @@ import logging
 from dataclasses import asdict
 from typing import Optional, Sequence, TypeVar, Union
 
+import polars as pl
 
 from cellpycore import selectors
 from cellpycore.config import Schema, default_schema
@@ -31,24 +32,135 @@ DEFAULT_RAW_LIMITS = asdict(CellpyLimits())
 DIGITS_C_RATE = 5
 
 
-def _ustep(n: Array) -> list:
-    # not tested
-    """Create u-steps from a pandas Series.
+# Per-step aggregate statistics produced for every raw signal column. The
+# arithmetic mean is named ``mean`` natively (the legacy bridge renames it to
+# ``avr``). ``delta`` is computed separately (it needs first + last).
+_STATS = ("mean", "std", "min", "max", "first", "last")
 
-    Args:
-        n (Array): The input series.
+# Mapping of native raw signal columns -> native step-table base name. The
+# cumulative (per-cycle) capacities/energies become the step-table capacity
+# aggregates; per-step capacity is the in-step ``delta``.
+_SIGNAL_BASES = (
+    ("datapoint_num", "datapoint_num"),
+    ("test_time", "test_time"),
+    ("step_time", "step_time"),
+    ("current", "current"),
+    ("potential", "potential"),
+    ("cumulative_charge_capacity", "charge_capacity"),
+    ("cumulative_discharge_capacity", "discharge_capacity"),
+    ("internal_resistance", "internal_resistance"),
+)
 
-    Returns:
-        list: The u-steps.
+
+def _delta_expr(base: str) -> pl.Expr:
+    """Per-step delta in percent (mirrors legacy cellpy's ``delta``).
+
+    ``100 * last`` when the step starts at zero, else
+    ``100 * (last - first) / abs(first)``.
     """
-    un = []
-    c = 0
-    dn = n.diff()
-    for i in dn:
-        if i != 0:
-            c += 1
-        un.append(c)
-    return un
+    first = pl.col(f"{base}_first")
+    last = pl.col(f"{base}_last")
+    return (
+        pl.when(first == 0.0)
+        .then(100.0 * last)
+        .otherwise(100.0 * (last - first) / first.abs())
+        .alias(f"{base}_delta")
+    )
+
+
+def _classify_from_specifications(step_specifications, short: bool, nhdr) -> pl.Expr:
+    """Build a step-type expression from explicit step specifications."""
+    expr = pl.lit("")
+    for row in step_specifications.itertuples():
+        if short:
+            mask = pl.col(nhdr.step_num) == row.step
+        else:
+            mask = (pl.col(nhdr.step_num) == row.step) & (
+                pl.col(nhdr.cycle_num) == row.cycle
+            )
+        expr = pl.when(mask).then(pl.lit(row.type)).otherwise(expr)
+    return expr
+
+
+def _classify_steps(
+    bases: set,
+    step_specifications,
+    short: bool,
+    override_step_types: Optional[dict],
+    override_raw_limits: Optional[dict],
+    raw_limits: dict,
+    nhdr,
+) -> pl.Expr:
+    """Return a polars expression classifying each step into a step type.
+
+    Mirrors legacy cellpy's threshold logic; later rules win (so e.g. ``ir``
+    overrides ``rest``). Returns ``""`` for steps that match no rule.
+    """
+    if step_specifications is not None:
+        return _classify_from_specifications(step_specifications, short, nhdr)
+
+    # Need the current/potential/capacity aggregates to classify; if the raw
+    # frame lacks them, leave every step uncategorized.
+    required = {"current", "potential", "charge_capacity", "discharge_capacity"}
+    if not required <= bases:
+        return pl.lit("")
+
+    orl = override_raw_limits or {}
+    current_hard = orl.get("current_hard") or raw_limits["current_hard"]
+    stable_current_soft = (
+        orl.get("stable_current_soft") or raw_limits["stable_current_soft"]
+    )
+    stable_voltage_hard = (
+        orl.get("stable_voltage_hard") or raw_limits["stable_voltage_hard"]
+    )
+    stable_charge_hard = (
+        orl.get("stable_charge_hard") or raw_limits["stable_charge_hard"]
+    )
+
+    cur_mean = pl.col("current_mean")
+    cur_min = pl.col("current_min")
+    cur_max = pl.col("current_max")
+    cur_delta = pl.col("current_delta")
+    v_delta = pl.col("potential_delta")
+    ch_delta = pl.col("charge_capacity_delta")
+    dch_delta = pl.col("discharge_capacity_delta")
+
+    m_no_cur = (cur_max.abs() + cur_min.abs()) < current_hard / 2
+    m_v_down = v_delta < -stable_voltage_hard
+    m_v_up = v_delta > stable_voltage_hard
+    m_v_stable = v_delta.abs() < stable_voltage_hard
+    m_cur_down = cur_delta < -stable_current_soft
+    m_cur_neg = cur_mean < -current_hard
+    m_cur_pos = cur_mean > current_hard
+    m_ch_changed = ch_delta.abs() > stable_charge_hard
+    m_dch_changed = dch_delta.abs() > stable_charge_hard
+    m_no_change = (
+        (v_delta == 0) & (cur_delta == 0) & (ch_delta == 0) & (dch_delta == 0)
+    )
+
+    # Order matters: later rules override earlier ones (matches legacy cellpy).
+    rules = [
+        (m_no_cur & m_v_stable, "rest"),
+        (m_no_cur & m_v_up, "ocvrlx_up"),
+        (m_no_cur & m_v_down, "ocvrlx_down"),
+        (m_dch_changed & m_cur_neg, "discharge"),
+        (m_ch_changed & m_cur_pos, "charge"),
+        (m_v_stable & m_cur_neg & m_cur_down, "cv_discharge"),
+        (m_v_stable & m_cur_pos & m_cur_down, "cv_charge"),
+        (m_no_change, "ir"),
+    ]
+    expr = pl.lit("")
+    for mask, label in rules:
+        expr = pl.when(mask).then(pl.lit(label)).otherwise(expr)
+
+    if override_step_types:
+        for step_no, stype in override_step_types.items():
+            expr = (
+                pl.when(pl.col(nhdr.step_num) == step_no)
+                .then(pl.lit(stype))
+                .otherwise(expr)
+            )
+    return expr
 
 
 def make_step_table(
@@ -114,298 +226,115 @@ def make_step_table(
     nhdr = schema.raw
     shdr = schema.step
 
-    def delta(x):
-        # Remark! this will not work if x is a TimeDelta object
-        if x.iloc[0] == 0.0:
-            # starts from a zero value
-            difference = 100.0 * x.iloc[-1]
-        else:
-            difference_factor = 100.0 * (x.iloc[-1] - x.iloc[0])
-            difference_dividend = abs(x.iloc[0])
-            difference = difference_factor / difference_dividend
-
-        return difference
+    raw = data.raw
+    # The engine is polars-native; accept a pandas frame for convenience.
+    if not isinstance(raw, pl.DataFrame):
+        raw = pl.from_pandas(raw)
 
     if from_data_point is not None:
-        df = data.raw.loc[data.raw[nhdr.data_point_txt] >= from_data_point]
-    else:
-        df = data.raw
-    # df[shdr.internal_resistance_change] = \
-    #     df[nhdr.internal_resistance_txt].pct_change()
+        raw = raw.filter(pl.col(nhdr.datapoint_num) >= from_data_point)
 
-    # selecting only the most important columns from raw:
-    keep = [
-        nhdr.data_point_txt,
-        nhdr.test_time_txt,
-        nhdr.step_time_txt,
-        nhdr.step_index_txt,
-        nhdr.cycle_index_txt,
-        nhdr.current_txt,
-        nhdr.voltage_txt,
-        nhdr.ref_voltage_txt,
-        nhdr.charge_capacity_txt,
-        nhdr.discharge_capacity_txt,
-        nhdr.internal_resistance_txt,
-        # "ir_pct_change"
+    # Sort by datapoint so per-step first()/last() are well-defined.
+    raw = raw.sort(nhdr.datapoint_num)
+
+    # Resolve which native raw signals are present (mapping each to its
+    # step-table base name). Cumulative capacities/energies feed the capacity
+    # aggregates; the per-step capacity is the in-step ``delta``.
+    raw_for_base = {
+        "datapoint_num": nhdr.datapoint_num,
+        "test_time": nhdr.test_time,
+        "step_time": nhdr.step_time,
+        "current": nhdr.current,
+        "potential": nhdr.potential,
+        "cumulative_charge_capacity": nhdr.cumulative_charge_capacity,
+        "cumulative_discharge_capacity": nhdr.cumulative_discharge_capacity,
+        "internal_resistance": nhdr.internal_resistance,
+    }
+    signals = [
+        (raw_for_base[raw_attr], base)
+        for raw_attr, base in _SIGNAL_BASES
+        if raw_for_base[raw_attr] in raw.columns
     ]
 
-    # only use col-names that exist:
-    keep = [col for col in keep if col in df.columns]
-    df = df[keep]
-    # preparing for implementation of sub_steps (will come in the future):
-    df = df.assign(**{f"{nhdr.sub_step_index_txt}": 1})
-
-    # using headers as defined in the schema
-    rename_dict = {
-        nhdr.cycle_index_txt: shdr.cycle,
-        nhdr.step_index_txt: shdr.step,
-        nhdr.sub_step_index_txt: shdr.sub_step,
-        nhdr.data_point_txt: shdr.point,
-        nhdr.test_time_txt: shdr.test_time,
-        nhdr.step_time_txt: shdr.step_time,
-        nhdr.current_txt: shdr.current,
-        nhdr.voltage_txt: shdr.voltage,
-        nhdr.charge_capacity_txt: shdr.charge,
-        nhdr.discharge_capacity_txt: shdr.discharge,
-        nhdr.internal_resistance_txt: shdr.internal_resistance,
-    }
-
-    df = df.rename(columns=rename_dict)
-    by = [shdr.cycle, shdr.step, shdr.sub_step]
+    # sub-step is a constant 1 for now (real sub-step support comes later).
+    sub_col = nhdr.step_num + "__sub"
+    raw = raw.with_columns(pl.lit(1).alias(sub_col))
 
     if skip_steps is not None:
         logging.debug(f"omitting steps {skip_steps}")
-        df = df.loc[~df[shdr.step].isin(skip_steps)]
+        raw = raw.filter(~pl.col(nhdr.step_num).is_in(skip_steps))
 
+    by = [nhdr.cycle_num, nhdr.step_num, sub_col]
     if usteps:
-        by.append(shdr.ustep)
-        df[shdr.ustep] = _ustep(df[shdr.step])
+        raw = raw.with_columns(
+            (pl.col(nhdr.step_num).diff().fill_null(1) != 0)
+            .cast(pl.Int64)
+            .cum_sum()
+            .alias("ustep")
+        )
+        by = by + ["ustep"]
 
-    logging.debug(f"groupby: {by}")
+    agg_exprs = []
+    for col, base in signals:
+        for stat in _STATS:
+            agg_exprs.append(getattr(pl.col(col), stat)().alias(f"{base}_{stat}"))
 
-    # TODO: make sure that all columns are numeric
+    steps = raw.group_by(by, maintain_order=True).agg(agg_exprs)
+    steps = steps.with_columns([_delta_expr(base) for _, base in signals])
+    # Mirror pandas groupby key ordering (ascending) for stable row positions.
+    steps = steps.sort(by)
 
-    gf = df.groupby(by=by)
-
-    # TODO: FutureWarning: The provided callable <function mean at 0x000002BD4D332840>
-    #  is currently using SeriesGroupBy.mean. In a future version of pandas, the provided
-    #  callable will be used directly. To keep current behavior pass the string "mean" instead.
-    df_steps = gf.agg(["mean", "std", "min", "max", "first", "last", delta]).rename(
-        columns={"amin": "min", "amax": "max", "mean": "avr"}
-    )
-
-    df_steps = df_steps.reset_index()
-
-    # column with C-rates (rate_avr = abs(current_avr / nom_cap)). The nominal
-    # capacity is supplied by the caller (by value); no unit conversion is done
-    # with the current values here (matching legacy cellpy).
+    # Per-step C-rate (legacy ``rate_avr`` = abs(current_avr / nom_cap)); the
+    # nominal capacity is supplied by the caller (by value).
     if add_c_rate:
         _nom_cap = nom_cap if nom_cap is not None else 1.0
-        df_steps[shdr.rate_avr] = abs(
-            round(
-                df_steps.loc[:, (shdr.current, "avr")] / _nom_cap,
-                DIGITS_C_RATE,
-            )
+        steps = steps.with_columns(
+            (pl.col("current_mean") / _nom_cap)
+            .round(DIGITS_C_RATE)
+            .abs()
+            .alias(shdr.c_rate)
         )
 
-    df_steps[shdr.type] = ""
-    df_steps[shdr.sub_type] = ""
-    df_steps[shdr.info] = ""
+    bases = {base for _, base in signals}
+    step_type = _classify_steps(
+        bases,
+        step_specifications,
+        short,
+        override_step_types,
+        override_raw_limits,
+        raw_limits,
+        nhdr,
+    )
+    steps = steps.with_columns(
+        step_type.alias(shdr.step_type),
+        pl.lit(None, dtype=pl.Utf8).alias(shdr.sub_step_type),
+        pl.lit("").alias("info"),
+    )
 
-    if step_specifications is None:
-        # TODO: refactor this:
-        if override_raw_limits is None:
-            override_raw_limits = {}
-        current_limit_value_hard = (
-            override_raw_limits.get("current_hard", None) or raw_limits["current_hard"]
-        )
-        stable_current_limit_soft = (
-            override_raw_limits.get("stable_current_soft", None)
-            or raw_limits["stable_current_soft"]
-        )
-        stable_voltage_limit_hard = (
-            override_raw_limits.get("stable_voltage_hard", None)
-            or raw_limits["stable_voltage_hard"]
-        )
-        stable_charge_limit_hard = (
-            override_raw_limits.get("stable_charge_hard", None)
-            or raw_limits["stable_charge_hard"]
-        )
-
-        mask_no_current_hard = (
-            df_steps.loc[:, (shdr.current, "max")].abs()
-            + df_steps.loc[:, (shdr.current, "min")].abs()
-        ) < current_limit_value_hard / 2
-
-        mask_voltage_down = (
-            df_steps.loc[:, (shdr.voltage, "delta")] < -stable_voltage_limit_hard
-        )
-
-        mask_voltage_up = (
-            df_steps.loc[:, (shdr.voltage, "delta")] > stable_voltage_limit_hard
-        )
-
-        mask_voltage_stable = (
-            df_steps.loc[:, (shdr.voltage, "delta")].abs() < stable_voltage_limit_hard
-        )
-
-        mask_current_down = (
-            df_steps.loc[:, (shdr.current, "delta")] < -stable_current_limit_soft
-        )
-
-        mask_current_negative = (
-            df_steps.loc[:, (shdr.current, "avr")] < -current_limit_value_hard
-        )
-
-        mask_current_positive = (
-            df_steps.loc[:, (shdr.current, "avr")] > current_limit_value_hard
-        )
-
-        mask_charge_changed = (
-            df_steps.loc[:, (shdr.charge, "delta")].abs() > stable_charge_limit_hard
-        )
-
-        mask_discharge_changed = (
-            df_steps.loc[:, (shdr.discharge, "delta")].abs() > stable_charge_limit_hard
-        )
-
-        mask_no_change = (
-            (df_steps.loc[:, (shdr.voltage, "delta")] == 0)
-            & (df_steps.loc[:, (shdr.current, "delta")] == 0)
-            & (df_steps.loc[:, (shdr.charge, "delta")] == 0)
-            & (df_steps.loc[:, (shdr.discharge, "delta")] == 0)
-        )
-
-        # TODO: make an option for only checking unique steps
-        #     e.g.
-        #     df_x = df_steps.where.steps.are.unique
-
-        # TODO: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise in a future error
-        #  of pandas. Value 'rest' has dtype incompatible with float64, please explicitly cast to a
-        #  compatible dtype first.
-
-        df_steps.loc[
-            mask_no_current_hard & mask_voltage_stable,
-            (shdr.type, slice(None)),
-        ] = "rest"
-
-        df_steps.loc[
-            mask_no_current_hard & mask_voltage_up, (shdr.type, slice(None))
-        ] = "ocvrlx_up"
-
-        df_steps.loc[
-            mask_no_current_hard & mask_voltage_down, (shdr.type, slice(None))
-        ] = "ocvrlx_down"
-
-        df_steps.loc[
-            mask_discharge_changed & mask_current_negative,
-            (shdr.type, slice(None)),
-        ] = "discharge"
-
-        df_steps.loc[
-            mask_charge_changed & mask_current_positive,
-            (shdr.type, slice(None)),
-        ] = "charge"
-
-        df_steps.loc[
-            mask_voltage_stable & mask_current_negative & mask_current_down,
-            (shdr.type, slice(None)),
-        ] = "cv_discharge"
-
-        df_steps.loc[
-            mask_voltage_stable & mask_current_positive & mask_current_down,
-            (shdr.type, slice(None)),
-        ] = "cv_charge"
-
-        # --- internal resistance ----
-        df_steps.loc[mask_no_change, (shdr.type, slice(None))] = "ir"
-        # assumes that IR is stored in just one row
-
-        # --- sub-step-txt -----------
-        df_steps[shdr.sub_type] = None
-
-        # --- CV steps ----
-
-        # "voltametry_charge"
-        # mask_charge_changed
-        # mask_voltage_up
-        # (could also include abs-delta-cumsum current)
-
-        # "voltametry_discharge"
-        # mask_discharge_changed
-        # mask_voltage_down
-
-        if override_step_types is not None:
-            for step, step_type in override_step_types.items():
-                df_steps.loc[
-                    df_steps[shdr.step] == step,
-                    (shdr.type, slice(None)),
-                ] = step_type
-
-    else:
-        # not tested!
-        logger.debug("parsing custom step definition")
-        if not short:
-            logger.debug("using long format (cycle,step)")
-            for row in step_specifications.itertuples():
-                df_steps.loc[
-                    (df_steps[shdr.step] == row.step)
-                    & (df_steps[shdr.cycle] == row.cycle),
-                    (shdr.type, slice(None)),
-                ] = row.type
-                df_steps.loc[
-                    (df_steps[shdr.step] == row.step)
-                    & (df_steps[shdr.cycle] == row.cycle),
-                    (shdr.info, slice(None)),
-                ] = row.info
-        else:
-            logger.debug("using short format (step)")
-            for row in step_specifications.itertuples():
-                df_steps.loc[
-                    df_steps[shdr.step] == row.step,
-                    (shdr.type, slice(None)),
-                ] = row.type
-                df_steps.loc[
-                    df_steps[shdr.step] == row.step,
-                    (shdr.info, slice(None)),
-                ] = row.info
-
-    # check if all the steps got categorizes
-    logger.debug("looking for un-categorized steps")
-    empty_rows = df_steps.loc[df_steps[shdr.type].isnull()]
-    if not empty_rows.empty:
+    n_uncategorized = steps.filter(pl.col(shdr.step_type) == "").height
+    if n_uncategorized:
         logger.warning(
-            f"found {len(empty_rows)}:{len(df_steps)} non-categorized steps (please, check your raw-limits)"
+            f"found {n_uncategorized}:{steps.height} non-categorized steps "
+            "(please, check your raw-limits)"
         )
-        # logging.debug(empty_rows)
 
-    # flatten (possible remove in the future),
+    # Rename group-key columns to the (native) step schema names.
+    steps = steps.rename(
+        {
+            nhdr.cycle_num: shdr.cycle_num,
+            nhdr.step_num: shdr.step_num,
+            sub_col: shdr.sub_step_num,
+        }
+    )
 
-    logger.debug("flatten columns")
-    flat_cols = []
-    for col in df_steps.columns:
-        if isinstance(col, tuple):
-            if col[-1]:
-                col = "_".join(col)
-            else:
-                col = col[0]
-        flat_cols.append(col)
-
-    df_steps.columns = flat_cols
-    if sort_rows:
+    if sort_rows and "test_time_first" in steps.columns:
         logger.debug("sorting the step rows")
-        # TODO: [#index]
-        # if this throws a KeyError: 'test_time_first' it probably
-        # means that the df contains a non-nummeric 'test_time' column.
-        df_steps = df_steps.sort_values(
-            by=shdr.test_time + "_first"
-        ).reset_index()
+        steps = steps.sort("test_time_first")
 
     if from_data_point is not None:
-        return df_steps
-    else:
-        data.steps = df_steps
-        return data
+        return steps
+    data.steps = steps
+    return data
 
 
 def generate_absolute_summary_columns(

--- a/tests/test_golden.py
+++ b/tests/test_golden.py
@@ -16,8 +16,7 @@ import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal
 
-from cellpycore import summarizers
-from cellpycore.cell_core import Data
+from cellpycore.cell_core import Data, OldCellpyCellCore
 from cellpycore.config import Schema
 from cellpycore.legacy import HeadersNormal, HeadersStepTable, HeadersSummary
 
@@ -38,9 +37,12 @@ def _legacy_schema() -> Schema:
 
 
 def _step_table(raw_path: Path) -> pd.DataFrame:
+    # The engine is polars-native; cellpy drives it through the legacy bridge
+    # (OldCellpyCellCore), which takes/returns pandas frames in legacy naming.
+    core = OldCellpyCellCore(initialize=False)
     data = Data()
     data.raw = pd.read_parquet(raw_path)
-    result = summarizers.make_step_table(data, schema=_legacy_schema(), nom_cap=1.0)
+    result = core.make_core_step_table(data, nom_cap=1.0)
     return result.steps.reset_index(drop=True)
 
 
@@ -82,9 +84,11 @@ def test_arbin_step_table_matches_snapshot():
 def test_small_step_table_runs_on_real_data():
     """Smoke test: a tiny (47-row, 3-step) real raw frame flows through the engine.
 
-    Note: on this tiny frame the engine currently leaves one step's ``type`` blank
-    (an edge case to revisit during the issue #13 rewrite); we only assert the
-    structural result here.
+    Note: this fixture's ``step 2`` is a degenerate synthetic slice (non-monotonic
+    duplicated ``data_point``, mixed current signs, zero capacity-delta), so the
+    engine leaves its ``type`` blank. That matches legacy cellpy classification and
+    is a fixture artifact, not an engine defect; we only assert the structural
+    result here.
     """
     schema = _legacy_schema()
     steps = _step_table(ARBIN_SMALL_RAW)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -7,16 +7,17 @@ the injected ``raw_limits``.
 """
 
 import pandas as pd
+import polars as pl
 import pytest
 
 from cellpycore import selectors, summarizers
 from cellpycore.cell_core import CellpyCellCore, OldCellpyCellCore, Data
 from cellpycore.config import RawCols, CycleCols, StepCols, Schema, default_schema
-from cellpycore.legacy import HeadersNormal, HeadersSummary, HeadersStepTable
+from cellpycore.legacy import HeadersNormal
 
 
-def _build_raw(nhdr: HeadersNormal) -> pd.DataFrame:
-    """Build a minimal legacy-named raw DataFrame (2 cycles x charge/discharge/rest)."""
+def _build_raw(nhdr: RawCols) -> pd.DataFrame:
+    """Build a minimal native-named raw DataFrame (2 cycles x charge/discharge/rest)."""
     records = []
     dp = 0
     for cyc in (1, 2):
@@ -33,35 +34,35 @@ def _build_raw(nhdr: HeadersNormal) -> pd.DataFrame:
                     ch, dch = 0.0, 0.0
                 records.append(
                     {
-                        nhdr.data_point_txt: dp,
-                        nhdr.test_time_txt: float(dp),
-                        nhdr.step_time_txt: float(k),
-                        nhdr.step_index_txt: step,
-                        nhdr.cycle_index_txt: cyc,
-                        nhdr.current_txt: cur,
-                        nhdr.voltage_txt: volt,
-                        nhdr.ref_voltage_txt: 0.0,
-                        nhdr.charge_capacity_txt: ch,
-                        nhdr.discharge_capacity_txt: dch,
-                        nhdr.internal_resistance_txt: 0.0,
+                        nhdr.datapoint_num: dp,
+                        nhdr.test_time: float(dp),
+                        nhdr.step_time: float(k),
+                        nhdr.step_num: step,
+                        nhdr.cycle_num: cyc,
+                        nhdr.current: cur,
+                        nhdr.potential: volt,
+                        nhdr.cumulative_charge_capacity: ch,
+                        nhdr.cumulative_discharge_capacity: dch,
+                        nhdr.internal_resistance: 0.0,
                     }
                 )
                 dp += 1
     return pd.DataFrame(records)
 
 
-def _legacy_schema(step: HeadersStepTable = None) -> Schema:
-    return Schema(
-        raw=HeadersNormal(),
-        cycle=HeadersSummary(),
-        step=step or HeadersStepTable(),
-    )
+def _native_schema(step: StepCols = None) -> Schema:
+    return Schema(raw=RawCols(), cycle=CycleCols(), step=step or StepCols())
 
 
-def _data_with_raw(nhdr: HeadersNormal) -> Data:
+def _data_with_raw(nhdr: RawCols) -> Data:
     data = Data()
     data.raw = _build_raw(nhdr)
     return data
+
+
+def _types(steps) -> set:
+    """Distinct step-type labels from a (polars) native step table."""
+    return set(steps[StepCols.step_type].to_list())
 
 
 def test_no_module_header_globals():
@@ -98,33 +99,33 @@ def test_default_schema_is_native():
 
 
 def test_make_step_table_uses_injected_schema():
-    """The output column names follow the injected schema, not any global."""
-    nhdr = HeadersNormal()
-    shdr = HeadersStepTable()
-    shdr.cycle = "CYCLE_MARKER"  # custom step-table column name
-    schema = Schema(raw=nhdr, cycle=HeadersSummary(), step=shdr)
+    """The output column names follow the injected (native) schema, not any global."""
+    nhdr = RawCols()
+    shdr = StepCols()
+    shdr.cycle_num = "CYCLE_MARKER"  # custom step-table column name
+    schema = Schema(raw=nhdr, cycle=CycleCols(), step=shdr)
 
     data = _data_with_raw(nhdr)
     result = summarizers.make_step_table(data, schema=schema, nom_cap=1.0)
 
     assert "CYCLE_MARKER" in result.steps.columns
-    assert "charge" in set(result.steps["type"])
+    assert "charge" in set(result.steps[shdr.step_type].to_list())
 
 
 def test_two_schemas_do_not_share_state():
     """Two cells with different schemas each emit their own column names."""
-    nhdr = HeadersNormal()
+    nhdr = RawCols()
 
-    shdr_a = HeadersStepTable()
-    shdr_a.cycle = "CYCLE_A"
+    shdr_a = StepCols()
+    shdr_a.cycle_num = "CYCLE_A"
     res_a = summarizers.make_step_table(
-        _data_with_raw(nhdr), schema=Schema(nhdr, HeadersSummary(), shdr_a), nom_cap=1.0
+        _data_with_raw(nhdr), schema=Schema(nhdr, CycleCols(), shdr_a), nom_cap=1.0
     )
 
-    shdr_b = HeadersStepTable()
-    shdr_b.cycle = "CYCLE_B"
+    shdr_b = StepCols()
+    shdr_b.cycle_num = "CYCLE_B"
     res_b = summarizers.make_step_table(
-        _data_with_raw(nhdr), schema=Schema(nhdr, HeadersSummary(), shdr_b), nom_cap=1.0
+        _data_with_raw(nhdr), schema=Schema(nhdr, CycleCols(), shdr_b), nom_cap=1.0
     )
 
     assert "CYCLE_A" in res_a.steps.columns and "CYCLE_A" not in res_b.steps.columns
@@ -132,27 +133,31 @@ def test_two_schemas_do_not_share_state():
 
 
 def test_nom_cap_scales_c_rate_by_value():
-    """rate_avr = abs(current_avr / nom_cap): doubling nom_cap halves the rate."""
-    nhdr = HeadersNormal()
-    schema = _legacy_schema()
+    """c_rate = abs(current_mean / nom_cap): doubling nom_cap halves the rate."""
+    nhdr = RawCols()
+    schema = _native_schema()
 
     res1 = summarizers.make_step_table(_data_with_raw(nhdr), schema=schema, nom_cap=1.0)
     res2 = summarizers.make_step_table(_data_with_raw(nhdr), schema=schema, nom_cap=2.0)
 
-    charge1 = res1.steps.loc[res1.steps["type"] == "charge", "rate_avr"].iloc[0]
-    charge2 = res2.steps.loc[res2.steps["type"] == "charge", "rate_avr"].iloc[0]
-    assert charge1 == pytest.approx(2 * charge2)
+    def _charge_rate(steps):
+        return (
+            steps.filter(pl.col(StepCols.step_type) == "charge")[StepCols.c_rate]
+            .to_list()[0]
+        )
+
+    assert _charge_rate(res1.steps) == pytest.approx(2 * _charge_rate(res2.steps))
 
 
 def test_raw_limits_affect_classification():
     """Step-type classification uses the supplied raw_limits, not a fixed default."""
-    nhdr = HeadersNormal()
-    schema = _legacy_schema()
+    nhdr = RawCols()
+    schema = _native_schema()
 
     res_default = summarizers.make_step_table(
         _data_with_raw(nhdr), schema=schema, nom_cap=1.0
     )
-    assert "charge" in set(res_default.steps["type"])
+    assert "charge" in _types(res_default.steps)
 
     huge_current_limit = dict(summarizers.DEFAULT_RAW_LIMITS)
     huge_current_limit["current_hard"] = 1.0e6
@@ -160,7 +165,7 @@ def test_raw_limits_affect_classification():
         _data_with_raw(nhdr), schema=schema, nom_cap=1.0, raw_limits=huge_current_limit
     )
     # with a huge current limit, the charge/discharge steps are no longer detected
-    assert "charge" not in set(res_huge.steps["type"])
+    assert "charge" not in _types(res_huge.steps)
 
 
 def test_generate_specific_columns_takes_factor_by_value():


### PR DESCRIPTION
## Summary

Phase 2 of the polars migration (#13): replace the pandas/legacy-schema step engine with a **polars-native** one operating on the native `config` schema, and add a **legacy↔native + pandas↔polars bridge** so `cellpy` keeps receiving its legacy step table unchanged.

- `summarizers.make_step_table`: polars `group_by`/`agg` over every present raw signal (mean/std/min/max/first/last/delta), per-step `c_rate`, and step-type classification (`_classify_steps`, later-rule-wins). Returns a polars `data.steps` frame. Removed the pandas `_ustep`/`delta`/`groupby` path.
- `OldCellpyCellCore.make_core_step_table`: the bridge — legacy pandas raw → native polars → engine → native polars steps → legacy pandas, reproducing the legacy `HeadersStepTable` 64-column frame **byte-for-byte** (incl. the leading `index` column and `test_time_first` sort).
- The existing cellpy-parity **golden snapshot stays the gate, unchanged** (Path P: reproduce the legacy frame exactly, chosen over regenerating it). Strongest parity guarantee through the rewrite.
- `tests/test_golden.py` now drives the step table through the bridge; `tests/test_schema.py` step tests moved to the native schema/raw.

## Notes

- **Blank step-type "edge case"** flagged in the design note is resolved as a **degenerate-fixture artifact** (the tiny fixture's `step 2` has non-monotonic/duplicated `data_point`, mixed current signs, zero capacity-delta). It matches legacy cellpy; classification was deliberately left unchanged to preserve parity. A holistic classification review, if desired, belongs in its own issue.
- The native step frame is a *superset* of `StepCols` (it also carries full `test_time`/`datapoint_num` aggregates needed for legacy parity); `StepCols` stays the canonical guaranteed set.

## Test plan

- [x] `uv run pytest` — 26 passed
- [x] Golden step-table snapshot reproduced byte-for-byte through the bridge (no regen)

## Follow-ups

- Phase 3: polars-native summary path (`summarizers` summary fns + `selectors.py`) + summary bridge.
- Phase 4: cross-repo parity tests vs cellpy.

Made with [Cursor](https://cursor.com)