### PR TITLE
Issue #13 Phase 3b: polars-native summary engine + legacy bridge

### DIFF
--- a/.issueflows/01-current-issues/issue13_status.md
+++ b/.issueflows/01-current-issues/issue13_status.md
@@ -2,7 +2,7 @@
 
 - [ ] Done
 
-Phased migration (see `issue13_plan.md`). **Phases 1–2 complete; Phases 3–4 remain.**
+Phased migration (see `issue13_plan.md`). **Phases 1–3 complete; Phase 4 remains.**
 
 ## Confirmed decisions (2026-06-14)
 
@@ -78,9 +78,34 @@ summary functions + bridge.
   datapoint) and `test_arbin_summary_matches_snapshot`.
 - **Tests:** `uv run pytest` → 28 passed.
 
+## Phase 3b — polars-native summary engine + bridge (DONE)
+
+Architecture decision **`bridge_extras`** (keep the curated native cycle schema clean):
+
+- `src/cellpycore/summarizers.py`: new **polars-native** `make_summary` (+ `_add_end_potentials`)
+  that produces only the **clean native `CycleCols` subset** (per-cycle capacities, CE,
+  coulombic difference, capacity losses, `test_cumulated_*`, end-of-charge/discharge potentials).
+  It does the cycle-end raw selection inline (no `selectors.create_selector`).
+- `src/cellpycore/cell_core.py`:
+  - `CellpyCellCore.make_core_summary` now calls the native engine (clean subset).
+  - `OldCellpyCellCore.make_core_summary` is the **legacy↔native + pandas↔polars bridge**:
+    native engine → rename native→legacy → add the **legacy-only "extras"** the curated native
+    design deliberately omits (`cumulated_coulombic_efficiency`, `shifted_*`, `cumulated_ric*`,
+    IR via `ir_to_summary`, C-rates via `c_rates_to_summary`) → legacy column order. Reproduces
+    the Phase 3a summary oracle **byte-for-byte**.
+- **Why bridge_extras (not extend CycleCols):** `cycle_table.md` is a curated forward design;
+  the ~11 legacy-only summary columns are exactly the cruft it drops. Keeping them in the bridge
+  leaves `CycleCols`/`cycle_table.md`/`CYCLE_EXPECTED` untouched.
+- **Parity semantics verified:** polars `cum_sum`/`shift`/÷-by-zero match pandas exactly, so the
+  rewrite is byte-faithful.
+- `tests/test_schema.py`: + `test_make_summary_native_schema` (asserts the native summary has the
+  clean subset and **no** legacy cruft). `tests/test_golden.py` summary oracle unchanged + green.
+- **Superseded (transitional, left in place):** `summarizers.generate_absolute_summary_columns`,
+  `summarizers.end_voltage_to_summary`, `selectors.create_selector`,
+  `selectors.summary_selector_exluder` are no longer used inside cellpy-core but kept (the
+  external `cellpy` repo may import them); prune in a later cleanup once usage is confirmed.
+- **Tests:** `uv run pytest` → 29 passed.
+
 ## Remaining
 
-- **Phase 3b:** polars-native rewrite of `selectors.py` + summary functions in `summarizers.py`
-  + `OldCellpyCellCore.make_core_summary` / `add_scaled_summary_columns` bridge; keep the new
-  summary oracle green.
 - **Phase 4:** cross-repo parity tests vs cellpy's `make_step_table` / `make_summary`.

--- a/.issueflows/04-designs-and-guides/step-table-polars-migration.md
+++ b/.issueflows/04-designs-and-guides/step-table-polars-migration.md
@@ -103,6 +103,34 @@ tracked in **issue #13**.
   from cellpy and break the parity guarantee). A holistic classification review, if wanted,
   belongs in its own issue.
 
+### Phase 3b polars-native summary engine + bridge (done)
+
+- **Key finding:** the native per-cycle vocabulary (`config.CycleCols` / `cycle_table.md`) is a
+  curated, forward-looking design — **not** a renamed legacy summary. ~14 legacy summary columns
+  map cleanly to native concepts (e.g. legacy `cumulated_charge_capacity` → native
+  `test_cumulated_charge_capacity`; `end_voltage_charge` → `potential_end_charge`), but ~11 are
+  legacy cruft the native design intentionally drops (`cumulated_coulombic_efficiency`,
+  `shifted_charge/discharge_capacity`, `cumulated_ric/_sei/_disconnect`,
+  `charge_c_rate/discharge_c_rate`, `ir_charge/ir_discharge`, `normalized_cycle_index`).
+- **Decision: `bridge_extras`** (over extending `CycleCols`, and over a separate clean impl).
+  The native polars engine (`summarizers.make_summary`) produces **only** the clean native
+  subset; the `OldCellpyCellCore` bridge renames native→legacy and **computes the legacy-only
+  extras** to reproduce the Phase 3a oracle byte-for-byte. Keeps `cycle_table.md`/`CycleCols`/
+  `CYCLE_EXPECTED` untouched; legacy cruft lives only in the legacy bridge (reusing the legacy
+  pandas `ir_to_summary` / `c_rates_to_summary` helpers — appropriate, they *are* legacy).
+- **Selection:** `make_summary` does the cycle-end raw-row selection inline (last step's last
+  datapoint per cycle); the advanced `selectors.create_selector` exclude-types machinery is
+  legacy-only and now unused.
+- **Parity semantics:** verified polars `cum_sum` (skips nulls like pandas), `shift` (null fill),
+  and ÷-by-zero (inf/NaN) match pandas exactly, so the polars rewrite is byte-faithful.
+- **Cell convention:** native `make_summary` assumes full-/cathode (charge = first); anode mode
+  (discharge-first) is not yet handled in the native engine (legacy bridge default is full, which
+  the oracle uses). Add when an anode consumer needs it.
+- **Superseded but kept (transitional):** `generate_absolute_summary_columns`,
+  `end_voltage_to_summary`, `selectors.create_selector`, `selectors.summary_selector_exluder` —
+  no longer used inside cellpy-core but may be imported by the external `cellpy` repo; prune in a
+  later cleanup once cross-repo usage is confirmed.
+
 ### Phase 3a data-model fix + summary oracle (done)
 
 - Phase 3 is **split**: 3a = make the summary path runnable + freeze a regression oracle;

--- a/src/cellpycore/cell_core.py
+++ b/src/cellpycore/cell_core.py
@@ -182,71 +182,17 @@ class CellpyCellCore:  # Rename to CellpyCell when cellpy core is ready
             Data object with the summary.
         """
 
-        from cellpycore import selectors, summarizers
+        from cellpycore import summarizers
 
-        schema = self.schema
-
+        # The native summary engine is polars-native on the native schema and
+        # produces the clean ``CycleCols`` subset. The legacy-only summary
+        # columns (IR, C-rates, RIC, shifted/normalized capacities, …) are added
+        # only on the legacy bridge (``OldCellpyCellCore.make_core_summary``).
         time_00 = time.time()
-        logger.debug("start making summary")
-
-        if selector is None:
-            selector = selectors.create_selector(
-                data, schema, final_data_points=final_data_points
-            )
-        summary = selector()
-        column_names = summary.columns
-        # TODO @jepe: use pandas.DataFrame properties instead (.len, .reset_index), but maybe first
-        #  figure out if this is really needed and why it was implemented in the first place.
-        summary_length = len(summary[column_names[0]])
-        summary.index = list(range(summary_length))
-
-        if select_columns:
-            logger.debug("keeping only selected set of columns")
-            columns_to_keep = [
-                schema.raw.charge_capacity_txt,
-                schema.raw.cycle_index_txt,
-                schema.raw.data_point_txt,
-                schema.raw.datetime_txt,
-                schema.raw.discharge_capacity_txt,
-                schema.raw.test_time_txt,
-            ]
-            for cn in column_names:
-                if not columns_to_keep.count(cn):
-                    try:
-                        summary.pop(cn)
-                    except KeyError:
-                        logger.debug(f"could not pop {cn}")
-
-        data.summary = summary
-
-        if self.cycle_mode == config.CyclingMode.ANODE:
-            logger.info(
-                "Assuming cycling in anode half-data (discharge before charge) mode"
-            )
-            _first_step_txt = schema.cycle.discharge_capacity
-            _second_step_txt = schema.cycle.charge_capacity
-        else:
-            logger.info("Assuming cycling in full-data / cathode mode")
-            _first_step_txt = schema.cycle.charge_capacity
-            _second_step_txt = schema.cycle.discharge_capacity
-
-        # ---------------- absolute -------------------------------
-
-        data = summarizers.generate_absolute_summary_columns(
-            data, schema, _first_step_txt, _second_step_txt
+        logger.debug("start making summary (native polars engine)")
+        data = summarizers.make_summary(
+            data, self.schema, final_data_points=final_data_points
         )
-
-        # TODO @jepe: refactor this to method:
-        if find_end_voltage:
-            data = summarizers.end_voltage_to_summary(data, schema)
-
-        if find_ir and (schema.raw.internal_resistance_txt in data.raw.columns):
-            data = summarizers.ir_to_summary(data, schema)
-
-        data = summarizers.c_rates_to_summary(
-            data, schema, current_conversion_factor=current_conversion_factor
-        )
-
         logger.debug(f"(dt: {(time.time() - time_00):4.2f}s)")
         return data
 
@@ -541,4 +487,136 @@ class OldCellpyCellCore(CellpyCellCore):
         if from_data_point is not None:
             return legacy_steps
         data.steps = legacy_steps
+        return data
+
+    # ---- legacy <-> native bridge for the polars summary engine -------------
+    # The native engine (summarizers.make_summary) produces the clean native
+    # CycleCols subset. cellpy expects the full legacy HeadersSummary frame, so
+    # this bridge renames native->legacy and computes the legacy-only "extras"
+    # (cumulated CE, shifted capacities, RIC, IR, C-rates) that the curated
+    # native cycle schema deliberately omits. Those extras reuse the (legacy)
+    # pandas helpers, which is appropriate: they are legacy cruft.
+
+    def _legacy_to_native_step_rename(self) -> dict:
+        return {v: k for k, v in self._native_to_legacy_step_rename().items()}
+
+    def _native_to_legacy_summary_rename(self) -> dict:
+        leg, nat = self.cycle_cols, config.CycleCols()
+        return {
+            nat.cycle_num: leg.cycle_index,
+            nat.datapoint_num_last: leg.data_point,
+            nat.last_test_time: leg.test_time,
+            nat.charge_capacity: leg.charge_capacity,
+            nat.discharge_capacity: leg.discharge_capacity,
+            nat.coulombic_efficiency: leg.coulombic_efficiency,
+            nat.coulombic_difference: leg.coulombic_difference,
+            nat.charge_capacity_loss: leg.charge_capacity_loss,
+            nat.discharge_capacity_loss: leg.discharge_capacity_loss,
+            nat.test_cumulated_charge_capacity: leg.cumulated_charge_capacity,
+            nat.test_cumulated_discharge_capacity: leg.cumulated_discharge_capacity,
+            nat.test_cumulated_coulombic_difference: leg.cumulated_coulombic_difference,
+            nat.test_cumulated_charge_capacity_loss: leg.cumulated_charge_capacity_loss,
+            nat.test_cumulated_discharge_capacity_loss: leg.cumulated_discharge_capacity_loss,
+            nat.potential_end_charge: leg.end_voltage_charge,
+            nat.potential_end_discharge: leg.end_voltage_discharge,
+        }
+
+    def _legacy_summary_column_order(self, find_end_voltage: bool) -> list:
+        leg = self.cycle_cols
+        order = [
+            leg.ir_charge, leg.ir_discharge, leg.data_point, leg.test_time,
+            leg.datetime, leg.cycle_index, leg.charge_capacity,
+            leg.discharge_capacity, leg.coulombic_efficiency,
+            leg.cumulated_coulombic_efficiency, leg.cumulated_charge_capacity,
+            leg.cumulated_discharge_capacity, leg.discharge_capacity_loss,
+            leg.charge_capacity_loss, leg.coulombic_difference,
+            leg.cumulated_coulombic_difference, leg.cumulated_discharge_capacity_loss,
+            leg.cumulated_charge_capacity_loss, leg.shifted_charge_capacity,
+            leg.shifted_discharge_capacity, leg.cumulated_ric, leg.cumulated_ric_sei,
+            leg.cumulated_ric_disconnect,
+        ]
+        if find_end_voltage:
+            order += [leg.end_voltage_discharge, leg.end_voltage_charge]
+        order += [leg.charge_c_rate, leg.discharge_c_rate]
+        return order
+
+    def _add_legacy_summary_extras(
+        self, data: Data, find_ir: bool, current_conversion_factor: float
+    ) -> None:
+        from cellpycore import summarizers
+
+        leg = self.cycle_cols
+        s = data.summary
+        cc = s[leg.charge_capacity]
+        dc = s[leg.discharge_capacity]
+        s[leg.cumulated_coulombic_efficiency] = s[leg.coulombic_efficiency].cumsum()
+        s[leg.shifted_charge_capacity] = (cc - dc).cumsum()
+        s[leg.shifted_discharge_capacity] = s[leg.shifted_charge_capacity] + cc
+        s[leg.cumulated_ric] = ((cc.shift(1) - dc) / dc.shift(1)).cumsum()
+        s[leg.cumulated_ric_sei] = ((cc - dc.shift(1)) / dc.shift(1)).cumsum()
+        s[leg.cumulated_ric_disconnect] = ((dc.shift(1) - dc) / dc.shift(1)).cumsum()
+        data.summary = s
+
+        legacy_schema = config.Schema(self.raw_cols, self.cycle_cols, self.step_cols)
+        if find_ir and (self.raw_cols.internal_resistance_txt in data.raw.columns):
+            data = summarizers.ir_to_summary(data, legacy_schema)
+        data = summarizers.c_rates_to_summary(
+            data, legacy_schema, current_conversion_factor=current_conversion_factor
+        )
+
+    def make_core_summary(
+        self,
+        data: Data,
+        selector: Optional[Callable] = None,
+        find_ir: bool = True,
+        find_end_voltage: bool = False,
+        select_columns: bool = True,
+        final_data_points: Optional[Iterable[int]] = None,
+        current_conversion_factor: float = 1.0,
+    ) -> Data:
+        """Build the per-cycle summary via the polars engine, in/out in legacy form.
+
+        Runs the native ``make_summary`` engine, renames native->legacy, then adds
+        the legacy-only extras to reproduce the legacy ``HeadersSummary`` frame.
+        """
+        import polars as pl
+
+        from cellpycore import summarizers
+
+        native_raw = pl.from_pandas(
+            data.raw.rename(columns=self._legacy_to_native_raw_rename(data.raw.columns))
+        )
+        native_steps = pl.from_pandas(
+            data.steps.rename(columns=self._legacy_to_native_step_rename())
+        )
+        nd = Data()
+        nd.raw = native_raw
+        nd.steps = native_steps
+        summarizers.make_summary(
+            nd, config.default_schema(), final_data_points=final_data_points
+        )
+
+        leg = self.cycle_cols
+        summary = nd.summary.to_pandas().rename(
+            columns=self._native_to_legacy_summary_rename()
+        )
+
+        # date_time passthrough (native raw carries epoch time, not date_time)
+        dp_txt = self.raw_cols.data_point_txt
+        dt_txt = self.raw_cols.datetime_txt
+        if dt_txt in data.raw.columns:
+            dt_map = data.raw[[dp_txt, dt_txt]].drop_duplicates(subset=[dp_txt])
+            dt_map = dt_map.rename(columns={dp_txt: leg.data_point})
+            summary = summary.merge(dt_map, on=leg.data_point, how="left")
+
+        summary.index = list(range(len(summary)))
+        data.summary = summary
+
+        self._add_legacy_summary_extras(
+            data, find_ir=find_ir, current_conversion_factor=current_conversion_factor
+        )
+
+        order = self._legacy_summary_column_order(find_end_voltage)
+        order = [c for c in order if c in data.summary.columns]
+        data.summary = data.summary[order]
         return data

--- a/src/cellpycore/summarizers.py
+++ b/src/cellpycore/summarizers.py
@@ -337,6 +337,103 @@ def make_step_table(
     return data
 
 
+def _add_end_potentials(summary: "pl.DataFrame", steps: "pl.DataFrame", schema: Schema):
+    """Join per-cycle end-of-charge / end-of-discharge potentials onto ``summary``.
+
+    Mirrors legacy ``end_voltage_to_summary``: the last charge/discharge step in
+    each cycle (ordered by ``test_time_first``) contributes its ``potential_last``.
+    """
+    shdr, chdr = schema.step, schema.cycle
+    steps_sorted = steps.sort(shdr.test_time_first)
+
+    def _end(prefix: str, out_name: str) -> "pl.DataFrame":
+        return (
+            steps_sorted.filter(pl.col(shdr.step_type).str.starts_with(prefix))
+            .group_by(shdr.cycle_num, maintain_order=True)
+            .agg(pl.col(shdr.potential_last).last().alias(out_name))
+        )
+
+    discharge_end = _end("discharge", chdr.potential_end_discharge)
+    charge_end = _end("charge", chdr.potential_end_charge)
+    summary = summary.join(discharge_end, on=chdr.cycle_num, how="left")
+    summary = summary.join(charge_end, on=chdr.cycle_num, how="left")
+    return summary
+
+
+def make_summary(
+    data: Data,
+    schema: Optional[Schema] = None,
+    final_data_points: Optional[Sequence] = None,
+) -> Data:
+    """Polars-native per-cycle summary (the clean native ``CycleCols`` subset).
+
+    One row per cycle, built from the cycle-end raw values plus the step table.
+    Capacities are cycle-cumulative per direction, so the cycle-end raw value is
+    the per-cycle total. Assumes full-/cathode-cell convention (charge first).
+
+    The legacy-only summary columns (cumulated CE, shifted capacities, RIC,
+    C-rates, IR, normalized cycle index) are deliberately **not** produced here;
+    the legacy bridge (``OldCellpyCellCore``) adds those for cellpy compatibility.
+    """
+    if schema is None:
+        schema = default_schema()
+    nhdr, shdr, chdr = schema.raw, schema.step, schema.cycle
+
+    raw = data.raw
+    if not isinstance(raw, pl.DataFrame):
+        raw = pl.from_pandas(raw)
+    steps = data.steps
+    if not isinstance(steps, pl.DataFrame):
+        steps = pl.from_pandas(steps)
+
+    # cycle-end datapoint per cycle = the last step's last datapoint
+    if final_data_points is None:
+        finals = (
+            steps.sort(shdr.datapoint_num_last)
+            .group_by(shdr.cycle_num, maintain_order=True)
+            .agg(pl.col(shdr.datapoint_num_last).last().alias("__fp"))
+        )
+        final_data_points = finals["__fp"].to_list()
+
+    selected = raw.filter(
+        pl.col(nhdr.datapoint_num).is_in(list(final_data_points))
+    ).sort(nhdr.cycle_num)
+
+    summary = selected.select(
+        pl.col(nhdr.cycle_num).alias(chdr.cycle_num),
+        pl.col(nhdr.datapoint_num).alias(chdr.datapoint_num_last),
+        pl.col(nhdr.test_time).alias(chdr.last_test_time),
+        pl.col(nhdr.cumulative_charge_capacity).alias(chdr.charge_capacity),
+        pl.col(nhdr.cumulative_discharge_capacity).alias(chdr.discharge_capacity),
+    )
+
+    cc = pl.col(chdr.charge_capacity)
+    dc = pl.col(chdr.discharge_capacity)
+    summary = summary.with_columns(
+        (100.0 * dc / cc).alias(chdr.coulombic_efficiency),
+        (cc - dc).alias(chdr.coulombic_difference),
+        (cc.shift(1) - cc).alias(chdr.charge_capacity_loss),
+        (dc.shift(1) - dc).alias(chdr.discharge_capacity_loss),
+    )
+    summary = summary.with_columns(
+        cc.cum_sum().alias(chdr.test_cumulated_charge_capacity),
+        dc.cum_sum().alias(chdr.test_cumulated_discharge_capacity),
+        pl.col(chdr.coulombic_difference)
+        .cum_sum()
+        .alias(chdr.test_cumulated_coulombic_difference),
+        pl.col(chdr.charge_capacity_loss)
+        .cum_sum()
+        .alias(chdr.test_cumulated_charge_capacity_loss),
+        pl.col(chdr.discharge_capacity_loss)
+        .cum_sum()
+        .alias(chdr.test_cumulated_discharge_capacity_loss),
+    )
+
+    summary = _add_end_potentials(summary, steps, schema)
+    data.summary = summary
+    return data
+
+
 def generate_absolute_summary_columns(
     data: Data,
     schema: Optional[Schema] = None,

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -168,6 +168,33 @@ def test_raw_limits_affect_classification():
     assert "charge" not in _types(res_huge.steps)
 
 
+def test_make_summary_native_schema():
+    """The native polars summary engine emits the clean CycleCols subset only."""
+    nhdr = RawCols()
+    schema = _native_schema()
+    chdr = schema.cycle
+
+    data = _data_with_raw(nhdr)
+    summarizers.make_step_table(data, schema=schema, nom_cap=1.0)
+    summarizers.make_summary(data, schema=schema)
+    s = data.summary
+
+    assert s.height == 2  # one row per cycle
+    for col in (
+        chdr.cycle_num, chdr.charge_capacity, chdr.discharge_capacity,
+        chdr.coulombic_efficiency, chdr.coulombic_difference,
+        chdr.test_cumulated_charge_capacity, chdr.potential_end_charge,
+    ):
+        assert col in s.columns
+
+    # legacy-only cruft must NOT leak into the native summary (it lives in the bridge)
+    for col in (
+        "cumulated_ric", "shifted_charge_capacity", "charge_c_rate",
+        "normalized_cycle_index", "cumulated_coulombic_efficiency", "ir_charge",
+    ):
+        assert col not in s.columns
+
+
 def test_generate_specific_columns_takes_factor_by_value():
     """generate_specific_summary_columns multiplies by the given factor (no pint)."""
     data = Data()


### PR DESCRIPTION
Stacked on #18 (Phase 3a). Part of the phased issue #13 migration.

## Summary
- New **polars-native** `summarizers.make_summary` on the native schema, producing only the clean `CycleCols` subset (per-cycle capacities, CE, coulombic difference, capacity losses, `test_cumulated_*`, end-of-charge/discharge potentials). Cycle-end raw-row selection is done inline.
- `CellpyCellCore.make_core_summary` now calls the native engine.
- `OldCellpyCellCore.make_core_summary` is the **legacy↔native + pandas↔polars bridge**: rename native→legacy + compute the legacy-only "extras" the curated native cycle schema deliberately omits (`cumulated_coulombic_efficiency`, `shifted_*`, `cumulated_ric*`, IR, C-rates), reproducing the Phase 3a summary oracle **byte-for-byte**.

## Key decision: `bridge_extras`
`cycle_table.md`/`CycleCols` is a curated forward design; the ~11 legacy-only summary columns are exactly the cruft it drops. Rather than muddy the native schema, those columns are computed in the legacy bridge only (reusing the legacy pandas `ir_to_summary` / `c_rates_to_summary` helpers). `CycleCols` / `cycle_table.md` / `CYCLE_EXPECTED` are untouched.

Verified: polars `cum_sum` / `shift` / divide-by-zero match pandas exactly, so the rewrite is byte-faithful.

Superseded-but-kept (transitional, may be imported by the external `cellpy` repo): `generate_absolute_summary_columns`, `end_voltage_to_summary`, `selectors.create_selector`, `selectors.summary_selector_exluder`.

## Test plan
- [x] `uv run pytest` → 29 passed (summary oracle byte-green through the new bridge)
- [x] new `test_make_summary_native_schema` (native path emits the clean subset, no legacy cruft)
- [x] `add_scaled_summary_columns` bridge smoke test → 18×64

Made with [Cursor](https://cursor.com)