### PR TITLE
Issue #22: resolve superseded summary/selector cleanup (docs-only)

### DIFF
--- a/.issueflows/03-solved-issues/issue22_original.md
+++ b/.issueflows/03-solved-issues/issue22_original.md
@@ -1,0 +1,20 @@
+# Issue #22: Remove superseded pandas summary/selector functions
+
+Source: https://github.com/cellpy/cellpy-core/issues/22
+
+## Original issue text
+
+Follow-up to #13. After the polars summary rewrite these functions are no longer used inside cellpy-core — they were superseded by the native `make_summary` / `_add_end_potentials` engine and the legacy extras computed in `OldCellpyCellCore._add_legacy_summary_extras`. They were kept only because the external `jepegit/cellpy` repo *might* still import them.
+
+### Candidates for removal
+- [ ] `summarizers.generate_absolute_summary_columns` (superseded by `make_summary` + bridge extras)
+- [ ] `summarizers.end_voltage_to_summary` (superseded by `_add_end_potentials`)
+- [ ] `selectors.create_selector` (native `make_summary` does cycle-end selection inline)
+- [ ] `selectors.summary_selector_exluder` (legacy-only; relies on `StepCols.point/.voltage/.type`)
+
+### Before deleting
+- [ ] Confirm `jepegit/cellpy` (current pinned version) does not import these names. (`cellreader.py` and `tests/test_slim.py` referenced some of them historically — verify.)
+- [ ] If still needed externally, coordinate a deprecation rather than a hard removal.
+
+### Acceptance
+- Dead code removed; `uv run pytest` green; no import breakage in cellpy after its core pin is bumped.

--- a/.issueflows/03-solved-issues/issue22_plan.md
+++ b/.issueflows/03-solved-issues/issue22_plan.md
@@ -1,0 +1,77 @@
+# Plan for issue #22: Remove superseded pandas summary/selector functions
+
+## Goal
+
+Resolve the dead-code cleanup from #22 by confirming what is already gone, deleting
+anything still dead, and explicitly **not** removing functions that the external
+`cellpy` repo still imports. End state: cellpy-core has no superseded summary/selector
+dead code, `uv run pytest` is green, and cellpy keeps importing what it needs.
+
+## Constraints
+
+- KISS: this is a deletion / verification task, not a refactor. No new abstractions.
+- Back-compat with the external `cellpy` repo: cellpy is pinned to
+  `cellpycore @ git+...@main`, so anything still imported there **must not** be hard-removed
+  (the issue's own "Before deleting" guard: coordinate a deprecation, not a hard removal).
+- Google-style docstrings; project loggers; tests stay green.
+- Scope: only the four named candidates. No drive-by edits to `get_step_numbers` /
+  `get_cycle_numbers` / `get_rates`.
+
+### Prior art
+
+- `summarizers.generate_absolute_summary_columns` / `summarizers.end_voltage_to_summary`
+  — **already removed in issue #24** (see `.issueflows/03-solved-issues/issue24_status.md`,
+  "Dead-code cleanup"). Grep confirms neither name exists in `src/cellpycore/` today.
+  New work: nothing to delete; optionally add a regression guard so they stay gone.
+- `selectors.create_selector` (`src/cellpycore/selectors.py:18`) — convention: `(data, schema,
+  selector_type, exclude_types, exclude_steps, final_data_points)`, returns a `functools.partial`
+  over `summary_selector_exluder`. **Still imported externally** by cellpy
+  (`cellpy/readers/cellreader.py:5798`, `tests/test_slim.py:91`). New work: **keep / coexist**;
+  removal deferred to a coordinated cellpy-side migration.
+- `selectors.summary_selector_exluder` (`src/cellpycore/selectors.py:63`) — the pandas engine
+  `create_selector` wraps (`selectors.py:52`). Not imported directly by cellpy but reachable
+  through `create_selector`. New work: **keep** while `create_selector` lives.
+- `tests/test_schema.py::test_no_module_header_globals` (`tests/test_schema.py:68`) — existing
+  pattern using `assert not hasattr(module, name)` to lock in removed module-level globals.
+  New work: mirror this pattern if we add a guard for the removed summarizer functions.
+
+## Approach
+
+The two summarizer functions named in the issue are already gone (#24); the two selector
+functions are **not dead** (cellpy actively calls `create_selector`). Per the resolved decisions
+below, #22 is closed as **documentation-only**: no code or test changes, selector removal deferred.
+
+Concrete steps:
+
+1. **Verify (read-only).** Re-confirm with grep that `generate_absolute_summary_columns` and
+   `end_voltage_to_summary` are absent from `src/cellpycore/`, and that `create_selector` /
+   `summary_selector_exluder` are present and still imported by cellpy
+   (`cellreader.py`, `test_slim.py`). (Already done during planning — findings above.)
+2. **Record the deferral decision.** Add a short note under `.issueflows/04-designs-and-guides/`
+   capturing: `create_selector` / `summary_selector_exluder` are kept because the external cellpy
+   consumer still imports `core_selectors.create_selector`; remove only after cellpy migrates off it.
+3. **Close out #22** via `issue22_status.md`: the two summarizer functions were removed in #24;
+   the two selector functions are intentionally retained (deferred follow-up, blocked on cellpy).
+
+## Files to touch
+
+- `.issueflows/04-designs-and-guides/selector-dead-code-deferral.md` (new, short) — record the
+  "keep `create_selector` until cellpy migrates" decision and link back to #22 / #24 / #13.
+- `.issueflows/01-current-issues/issue22_status.md` — created at `/issue-start`/`/issue-close`
+  time with the explicit `- [x] Done` checkbox and the per-candidate outcome.
+
+No changes to `src/cellpycore/summarizers.py`, `src/cellpycore/selectors.py`, or
+`tests/test_schema.py` (decision 2: close as documentation, no guard test).
+
+## Test strategy
+
+- `uv run pytest` — full suite should stay green; since no source/test changes are made, this is a
+  sanity check that the tree is still green (currently ~30 tests; #24 left it green).
+- No cellpy-side run needed: we are explicitly *not* removing anything cellpy imports.
+
+## Open questions — RESOLVED
+
+1. **Selector removal:** **Defer** (option a). Keep both functions, document the dependency, close
+   #22 noting selector removal is blocked on a future cellpy migration off
+   `core_selectors.create_selector`.
+2. **Guard test:** **Close as documentation** — no `tests/test_schema.py` change.

--- a/.issueflows/03-solved-issues/issue22_status.md
+++ b/.issueflows/03-solved-issues/issue22_status.md
@@ -1,0 +1,36 @@
+# Issue #22 status: Remove superseded pandas summary/selector functions
+
+- [x] Done
+
+## Summary
+
+Resolved as **documentation-only**. The practically removable dead code named in #22 was
+already deleted in #24; the two remaining functions are not dead (the external cellpy repo
+still imports them), so they are intentionally retained and the removal is deferred.
+
+## Per-candidate outcome
+
+| Candidate | Outcome |
+|---|---|
+| `summarizers.generate_absolute_summary_columns` | **Removed in #24.** Absent from `src/cellpycore/`. |
+| `summarizers.end_voltage_to_summary` | **Removed in #24.** Absent from `src/cellpycore/`. |
+| `selectors.create_selector` | **Kept (deferred).** Still imported by cellpy (`cellreader.py`, `tests/test_slim.py`); hard removal would break cellpy's pinned `@main` dependency. |
+| `selectors.summary_selector_exluder` | **Kept (deferred).** Pandas engine wrapped by `create_selector`; lives as long as `create_selector`. |
+
+## What was done
+
+- Verified (grep) that the two summarizer functions no longer exist in `src/cellpycore/` and
+  that `create_selector` / `summary_selector_exluder` are present and still imported by cellpy.
+- Recorded the deferral decision and removal trigger in
+  `.issueflows/04-designs-and-guides/selector-dead-code-deferral.md`.
+- Per agreed decisions: no source edits and no regression guard test (closed as documentation).
+
+## Verification
+
+- `uv run pytest` → see run output (green-tree sanity check; no source/test changes made).
+
+## Remaining / deferred (tracked, not part of this issue)
+
+- Remove `create_selector` + `summary_selector_exluder` once cellpy stops importing
+  `core_selectors.create_selector` (migrates onto the native `make_summary` path or its own
+  helper). See the deferral note above.

--- a/.issueflows/04-designs-and-guides/selector-dead-code-deferral.md
+++ b/.issueflows/04-designs-and-guides/selector-dead-code-deferral.md
@@ -1,0 +1,39 @@
+# Selector dead-code deferral: keep `create_selector` until cellpy migrates
+
+**Context.** Issue #22 (follow-up to #13) proposed removing four "superseded" pandas
+summary/selector helpers from cellpy-core after the polars summary rewrite:
+
+- `summarizers.generate_absolute_summary_columns`
+- `summarizers.end_voltage_to_summary`
+- `selectors.create_selector`
+- `selectors.summary_selector_exluder`
+
+**Findings (June 2026).**
+
+- The two `summarizers.*` functions were **already removed in issue #24** (see
+  `03-solved-issues/issue24_status.md`, "Dead-code cleanup"). They are absent from
+  `src/cellpycore/` today. (cellpy's own `_generate_absolute_summary_columns` /
+  `_end_voltage_to_summary` are private methods on its reader, not imports from the core.)
+- `selectors.create_selector` is **still imported by the external cellpy repo**:
+  `cellpy/readers/cellreader.py` (`core_selectors.create_selector(...)`) and
+  `cellpy/tests/test_slim.py`. cellpy pins `cellpycore @ git+...@main`, so removing it would
+  break cellpy at its next core-pin resolution.
+- `selectors.summary_selector_exluder` is the pandas engine that `create_selector` wraps
+  (`functools.partial`), so it must live as long as `create_selector` does.
+
+**Decision.** Keep `create_selector` and `summary_selector_exluder` in cellpy-core for now.
+They are **not** dead code from the consumer's point of view. The issue's own guard applies:
+"If still needed externally, coordinate a deprecation rather than a hard removal."
+
+**Removal trigger (future work).** Remove both functions only after cellpy stops importing
+`core_selectors.create_selector` (i.e. cellpy moves its summary selection onto the native
+`make_summary` path, or replaces it with its own helper). At that point this can be done as a
+small dead-code deletion in cellpy-core.
+
+**Alternatives considered.**
+
+- *Hard-remove now* — rejected: breaks cellpy's pinned `@main` dependency.
+- *Add a deprecation warning now + open a cellpy-side issue* — viable but deferred; spans two
+  repos and adds churn for no immediate benefit. Revisit when cellpy work touches that path.
+
+**Links.** Issues #22 (this), #24 (removed the summarizer pair), #13 (polars summary rewrite).


### PR DESCRIPTION
## Summary

Resolves #22 (follow-up to #13) as **documentation-only**:

- The two `summarizers.*` helpers named in #22 (`generate_absolute_summary_columns`, `end_voltage_to_summary`) were **already removed in #24** — confirmed absent from `src/cellpycore/`.
- The two `selectors.*` helpers (`create_selector`, `summary_selector_exluder`) are **still imported by the external cellpy repo** (`cellreader.py`, `tests/test_slim.py`), which pins `cellpycore @ ...@main`. Hard-removing them would break cellpy, so per the issue's own guard they are **intentionally retained** and their removal is **deferred**.
- Added `.issueflows/04-designs-and-guides/selector-dead-code-deferral.md` recording the decision, the removal trigger (remove once cellpy migrates off `core_selectors.create_selector`), and alternatives considered.
- Archived the issue docs to `.issueflows/03-solved-issues/`.

No changes to `src/cellpycore/` or `tests/`.

## Test plan

- [x] `uv run pytest` → 30 passed (green-tree sanity check; no source/test changes).

Closes #22

Made with [Cursor](https://cursor.com)