### PR TITLE
Complete the native polars summary path (#21)

### DIFF
--- a/.issueflows/03-solved-issues/issue21_original.md
+++ b/.issueflows/03-solved-issues/issue21_original.md
@@ -1,0 +1,24 @@
+# Issue #21: Complete the native polars summary path (port remaining helpers + anode mode + native add_scaled)
+
+Source: https://github.com/cellpy/cellpy-core/issues/21
+
+## Original issue text
+
+Follow-up to #13. The step engine and the **core** per-cycle summary subset (`summarizers.make_summary`) are polars-native, but several summary helpers are still pandas and are only reachable through the `OldCellpyCellCore` legacy bridge. To finish the migration the native path needs to stand on its own.
+
+### Port to polars-native (native schema)
+These are tagged with `TODO(#13)` in `src/cellpycore/summarizers.py`:
+- [ ] `c_rates_to_summary` (still used by the legacy summary bridge)
+- [ ] `ir_to_summary` (see separate correctness bug issue — keep behaviour oracle-locked while porting)
+- [ ] `equivalent_cycles_to_summary` (used by `add_scaled_summary_columns`)
+- [ ] `generate_specific_summary_columns` (used by `add_scaled_summary_columns`)
+- [ ] `_calculate_nominal_capacity_from_cycles` (helper for the two above)
+
+### Native-path gaps discovered during #13
+- [ ] **Anode (discharge-first) cycle mode.** `make_summary` currently assumes full-/cathode convention (charge = first). Add discharge-first handling (legacy `cycle_mode == ANODE`).
+- [ ] **Native `add_scaled_summary_columns`.** Only the legacy bridge path works today; the native `CellpyCellCore` path needs `normalized_cycle_index` + specific (gravimetric/areal/absolute) columns on the native `CycleCols`.
+
+### Acceptance
+- The native `CellpyCellCore` summary path runs end-to-end without the legacy bridge.
+- `tests/test_golden.py` summary oracle stays byte-green through the bridge.
+- New native-schema tests mirroring `test_make_summary_native_schema`.

--- a/.issueflows/03-solved-issues/issue21_plan.md
+++ b/.issueflows/03-solved-issues/issue21_plan.md
@@ -1,0 +1,137 @@
+# Plan for issue #21: Complete the native polars summary path (port remaining helpers + anode mode + native add_scaled)
+
+## Goal
+
+Make the native `CellpyCellCore` summary path stand on its own (no legacy bridge
+needed) by porting the five remaining pandas summary helpers to polars-native,
+adding anode (discharge-first) handling to `make_summary`, and making
+`add_scaled_summary_columns` work on the native polars `summary` — all while
+keeping the `tests/test_golden.py` summary oracle byte-green through the bridge.
+
+## Constraints
+
+- **Oracle stays byte-green.** `tests/test_golden.py::test_arbin_summary_matches_snapshot`
+  (and `..._matches_cellpy_goldens`) must keep passing unchanged. The legacy bridge
+  (`OldCellpyCellCore.make_core_summary`) output is the contract.
+- **Polars-only engine, schema-injected, thread-safe** (project rule + `step-table-polars-migration.md`).
+- **`ir_to_summary` correctness bug is out of scope.** It currently writes IR for
+  cycle *n* on *n+1* ("DOES NOT WORK PROPERLY"). Preserve current behaviour exactly
+  (oracle-locked); the real fix is a separate issue.
+- **KISS / dead-code:** avoid duplicating a pandas + a polars copy of each helper.
+  One polars-native implementation; the bridge converts at the seam.
+- Google-style docstrings; double-backtick code tokens.
+
+### Prior art
+
+- `summarizers.make_summary` (`cellpycore.summarizers`) — already polars-native on the
+  native schema (the model to mirror: read names off injected `Schema`, `pl.col(...).with_columns`,
+  `cum_sum`/`shift` parity verified against pandas). New work: **mirror** its style.
+- `summarizers._add_end_potentials` (`cellpycore.summarizers`) — polars per-cycle join helper
+  (group_by cycle → join onto summary). New work: **mirror** for the c-rate/IR joins.
+- `OldCellpyCellCore._add_legacy_summary_extras` / `_native_to_legacy_summary_rename`
+  (`cellpycore.legacy`) — the existing bridge that today computes the legacy-only extras
+  in pandas (`cumulated_coulombic_efficiency`, `shifted_*`, `cumulated_ric*`) and calls the
+  pandas `ir_to_summary` / `c_rates_to_summary`. New work: **migrate** these to run on the
+  native polars frame before the final →pandas rename.
+- Legacy cellpy `_generate_absolute_summary_columns` / `_equivalent_cycles_to_summary`
+  (`cellpy/readers/cellreader.py` ~line 6093) — the authoritative anode-mode reference:
+  `coulombic_efficiency = 100*second/first`, `coulombic_difference = first - second`, where
+  normal: first=charge,second=discharge; anode: first=discharge,second=charge. New work:
+  **mirror** the first/second flip in native `make_summary`.
+- `cellpycore.config.TestMode` (`NORMAL`/`INVERTED`) — the typed replacement for cellpy's
+  loose `cycle_mode` string, already defined but not wired up. New work: candidate to drive
+  the anode flag (see Open questions).
+
+## Approach
+
+Four work-items. Recommend landing as **phased PRs** (see Scope check).
+
+### A. Anode (discharge-first) mode in `make_summary`  — via `config.TestMode`
+
+In `summarizers.make_summary`, the only mode-dependent values are
+`coulombic_efficiency` and `coulombic_difference` (capacity-loss and cumulated
+columns are direction-independent). Add a `test_mode: TestMode = TestMode.NORMAL`
+parameter and compute:
+
+- `NORMAL`:   `CE = 100*dc/cc`, `coul_diff = cc - dc`  (current behaviour)
+- `INVERTED` (anode): `CE = 100*cc/dc`, `coul_diff = dc - cc`
+
+Wire up `config.TestMode` (currently defined but unused): `CellpyCellCore.make_core_summary`
+maps `self.cycle_mode == "anode"` → `TestMode.INVERTED`, else `TestMode.NORMAL`, and passes
+it down (also threaded through `equivalent_cycles_to_summary` / `c_rates_to_summary` for the
+first-step capacity choice). The bridge keeps passing `NORMAL` (oracle is full-cell), so the
+oracle is unaffected.
+
+### B. Port the 5 helpers to polars-native (native schema)
+
+Rewrite these to operate on a polars `data.summary` / `data.steps` using injected
+`Schema` names (mirroring `make_summary`):
+
+1. `generate_specific_summary_columns` — `summary.with_columns((factor*pl.col(col)).alias(f"{col}_{mode}"))`.
+2. `_calculate_nominal_capacity_from_cycles` — polars `filter(cycle.is_in(...))` + `mean()`; native cycle-num + capacity column.
+3. `equivalent_cycles_to_summary` — `normalized_cycle_index = test_cumulated_charge_capacity / nom_cap`.
+4. `c_rates_to_summary` — per-cycle first charge/discharge `c_rate` from the step table joined onto summary (mirror `_add_end_potentials`).
+5. `ir_to_summary` — **behaviour-preserving** port (keep the off-by-one), via `selectors.get_step_numbers`.
+
+### C. Make the legacy bridge feed polars (keep oracle byte-green)
+
+Move `OldCellpyCellCore._add_legacy_summary_extras` to compute the extras on the
+**native polars** frame (reuse the ported helpers + polars `cum_sum` for
+`cumulated_coulombic_efficiency` / `shifted_*` / `cumulated_ric*`), then do the
+single native→legacy rename →pandas at the end. The golden oracle proves parity.
+
+### D. Native `add_scaled_summary_columns` + extend `CycleCols` (Option A)
+
+Once B lands, the existing `CellpyCellCore.add_scaled_summary_columns` already calls
+`equivalent_cycles_to_summary` + `generate_specific_summary_columns`; it will work on
+the native polars summary.
+
+**Decision (confirmed): Option A — fully extend native `CycleCols`** so the native path
+is completely standalone (revises the Phase 3b "drop legacy-only columns" decision; record
+this in `step-table-polars-migration.md`). Add to `CycleCols`:
+
+- `normalized_cycle_index` (for `equivalent_cycles_to_summary` / `add_scaled`)
+- `charge_c_rate`, `discharge_c_rate` (for `c_rates_to_summary`)
+- `ir_charge`, `ir_discharge` (behaviour-preserving native targets for `ir_to_summary`;
+  the existing `ir_start/end_*` stay reserved/unpopulated — adding the legacy-shaped pair
+  keeps `ir_to_summary` oracle-locked rather than forcing a semantically wrong start/end split)
+- a `specific_columns` accessor (which columns get `_gravimetric/_areal/_absolute` variants)
+
+Then update `docs/data_format_specifications/cycle_table.md` and
+`tests/test_config_columns.py::CYCLE_EXPECTED` to match the new column set.
+
+## Files to touch
+
+- `src/cellpycore/summarizers.py` — anode mode in `make_summary`; port the 5 helpers to polars.
+- `src/cellpycore/legacy.py` — `OldCellpyCellCore` bridge: feed polars to the extras path.
+- `src/cellpycore/cell_core.py` — pass anode flag in `make_core_summary`; verify `add_scaled_summary_columns` native path.
+- `src/cellpycore/config.py` — add `normalized_cycle_index`, `charge_c_rate`, `discharge_c_rate`, `ir_charge`, `ir_discharge`, and a `specific_columns` accessor to `CycleCols` (Option A); wire `TestMode` into the summary path.
+- `docs/data_format_specifications/cycle_table.md` + `tests/test_config_columns.py` (`CYCLE_EXPECTED`) — sync with the extended `CycleCols`.
+- `tests/test_schema.py` — new native-schema tests mirroring `test_make_summary_native_schema` (anode CE/diff flip; native `add_scaled`; ported helpers).
+- `.issueflows/04-designs-and-guides/step-table-polars-migration.md` — record the Phase-3b follow-up decision (esp. the CycleCols question).
+
+## Test strategy
+
+- `uv run pytest tests/test_golden.py` — oracle must stay green (byte-parity through the bridge).
+- `uv run pytest tests/test_schema.py tests/test_config_columns.py` — native schema + spec parity.
+- New tests: anode CE/coul_diff flip vs normal; native `add_scaled_summary_columns`
+  end-to-end on polars (normalized_cycle_index + `*_gravimetric/_areal/_absolute`);
+  each ported helper on a tiny native frame.
+- `uv run pytest` — full suite green before close.
+
+## Resolved decisions (confirmed by user)
+
+1. **Native `CycleCols`: Option A — fully extend** (`normalized_cycle_index`,
+   `charge_c_rate`, `discharge_c_rate`, `ir_charge`, `ir_discharge`, `specific_columns`),
+   updating `cycle_table.md` + `CYCLE_EXPECTED`. This revises the Phase 3b "drop legacy-only
+   columns" decision; record the revision in `step-table-polars-migration.md`.
+2. **IR native targets:** add `ir_charge`/`ir_discharge` to `CycleCols` (behaviour-preserving;
+   keeps `ir_to_summary` oracle-locked). Existing `ir_start/end_*` stay reserved.
+3. **Anode flag:** wire up the existing `config.TestMode` enum (`NORMAL`/`INVERTED`) now.
+
+## Scope check
+
+This issue bundles 4 deliverables (anode mode, 5 helper ports, bridge migration, native
+add_scaled) + the `CycleCols` extension. **Confirmed: deliver as a single PR.** The golden
+oracle (`test_golden.py`) is the safety net for the bridge migration; new native-schema tests
+cover anode mode and `add_scaled`.

--- a/.issueflows/03-solved-issues/issue21_status.md
+++ b/.issueflows/03-solved-issues/issue21_status.md
@@ -1,0 +1,43 @@
+# Status — issue #21: Complete the native polars summary path
+
+- [x] Done
+
+## What landed
+
+Single PR (per confirmed plan). Native polars summary path now stands on its own.
+
+### Helpers ported to polars-native (`src/cellpycore/summarizers.py`)
+- `generate_specific_summary_columns` — polars `with_columns`; skips columns absent from the summary.
+- `_calculate_nominal_capacity_from_cycles` — polars `filter`/`mean` on `schema.cycle.cycle_num`.
+- `equivalent_cycles_to_summary` — `normalized_cycle_index = test_cumulated_charge_capacity / nom_cap`.
+- `c_rates_to_summary` — per-cycle first charge/discharge `c_rate` joined onto the summary.
+- `ir_to_summary` — self-contained (no `selectors.get_step_numbers`), **behaviour-preserving** (legacy off-by-one IR quirk kept oracle-locked).
+- All accept a pandas frame for convenience (convert to polars), matching `make_summary`.
+
+### Anode mode
+- `make_summary` gained `test_mode: TestMode` (`NORMAL`/`INVERTED`); `INVERTED` flips `coulombic_efficiency` and `coulombic_difference` only.
+- `CellpyCellCore.make_core_summary` derives the mode from `cycle_mode == "anode"` and now also adds native C-rate / IR columns.
+
+### Schema (Option A — revises Phase 3b; recorded in `04-designs-and-guides/step-table-polars-migration.md`)
+- `config.CycleCols`: added `normalized_cycle_index`, `charge_c_rate`, `discharge_c_rate`, `ir_charge`, `ir_discharge`, and a `specific_columns` accessor.
+- Synced `docs/data_format_specifications/cycle_table.md` and `tests/test_config_columns.py::CYCLE_EXPECTED`.
+
+### Bridge (`src/cellpycore/cell_core.py`)
+- `OldCellpyCellCore.make_core_summary` runs the native polars C-rate/IR helpers before the native→legacy rename; legacy-only cruft (`cumulated_coulombic_efficiency`, `shifted_*`, `cumulated_ric*`) stays pandas in `_add_legacy_summary_cruft`.
+- `OldCellpyCellCore.add_scaled_summary_columns` overridden to bridge pandas↔polars + legacy↔native (maps `{col}_{mode}` specific columns back to legacy names) — keeps cellpy's legacy call working.
+
+### Tests (`tests/test_schema.py`)
+- Updated `test_generate_specific_columns_takes_factor_by_value` to polars.
+- Added: anode CE/coulombic-difference flip, native `c_rates_to_summary`, native `ir_to_summary`, native `add_scaled_summary_columns` end-to-end.
+
+## Verification
+- `uv run pytest` — **34 passed**. Golden summary oracle (`test_golden.py`) stays byte-green through the bridge.
+
+## Acceptance check
+- [x] Native `CellpyCellCore` summary path runs end-to-end without the legacy bridge.
+- [x] `tests/test_golden.py` summary oracle byte-green through the bridge.
+- [x] New native-schema tests mirroring `test_make_summary_native_schema`.
+
+## Remaining / follow-ups (out of scope)
+- `ir_to_summary` correctness bug (writes IR for cycle n on n+1) — preserved here, fix in its own issue.
+- Cross-repo (cellpy) byte-parity for the bridge `add_scaled` path — covered when cellpy bumps its pinned core (cellpy#377/#378).

--- a/.issueflows/04-designs-and-guides/step-table-polars-migration.md
+++ b/.issueflows/04-designs-and-guides/step-table-polars-migration.md
@@ -182,6 +182,42 @@ tracked in **issue #13**.
 - The legacy `Headers*` mirrors in `legacy.py` are **unchanged** (cellpy contract); the
   legacy/golden path is unaffected by these native-schema edits.
 
+### Issue #21 — complete the native summary path (revises Phase 3b)
+
+- **Helpers ported to polars-native.** `c_rates_to_summary`, `ir_to_summary`,
+  `equivalent_cycles_to_summary`, `generate_specific_summary_columns` and
+  `_calculate_nominal_capacity_from_cycles` are now polars on the native schema
+  (no more pandas / legacy `*_txt` attribute access; they accept a pandas frame for
+  convenience and convert). `ir_to_summary` is **behaviour-preserving** (the legacy
+  off-by-one IR quirk is kept oracle-locked; a real fix is a separate issue) and is
+  self-contained (no longer depends on the pandas `selectors.get_step_numbers`).
+- **Anode mode** added to `make_summary` via the existing `config.TestMode` enum
+  (`NORMAL`/`INVERTED`). `INVERTED` flips only `coulombic_efficiency`
+  (`100*charge/discharge`) and `coulombic_difference` (`discharge-charge`);
+  capacity-loss / cumulated columns are direction-independent. `CellpyCellCore.make_core_summary`
+  derives the mode from `cycle_mode == "anode"`.
+- **CycleCols extended (Option A — revises the Phase 3b "drop legacy-only columns"
+  decision).** Added `normalized_cycle_index`, `charge_c_rate`, `discharge_c_rate`,
+  `ir_charge`, `ir_discharge` and a `specific_columns` accessor to native `CycleCols`
+  (and `cycle_table.md` + `CYCLE_EXPECTED`). The native path is now self-sufficient:
+  `CellpyCellCore.make_core_summary` adds C-rate/IR natively; `add_scaled_summary_columns`
+  adds `normalized_cycle_index` + gravimetric/areal/absolute variants on the native frame.
+  The `ir_start/end_*` columns remain reserved for the richer future IR model;
+  `ir_charge`/`ir_discharge` are the behaviour-preserving single-value targets.
+  *Alternative considered:* keep these bridge-only (Phase 3b's stance) — rejected by
+  the issue owner in favour of a fully standalone native path.
+- **Bridge restructured to feed polars.** `OldCellpyCellCore.make_core_summary` now runs
+  the native polars `ir_to_summary` / `c_rates_to_summary` on the native frame *before* the
+  single native→legacy rename (their native names equal the legacy names, so they survive
+  untouched). Only the genuinely legacy-only cruft (`cumulated_coulombic_efficiency`,
+  `shifted_*`, `cumulated_ric*`) stays pandas (`_add_legacy_summary_cruft`).
+  `OldCellpyCellCore.add_scaled_summary_columns` is overridden to bridge pandas↔polars +
+  legacy↔native (incl. mapping the produced `{col}_{mode}` specific columns back to legacy
+  names) so cellpy's call on the legacy pandas summary keeps working.
+- **Parity:** `tests/test_golden.py` summary oracle stays byte-green through the bridge
+  (the ported polars C-rate/IR reproduce the legacy values). New native-schema tests in
+  `tests/test_schema.py` cover anode flip, native C-rate/IR, and native `add_scaled`.
+
 ## Related
 
 - Issue #12 (this work's origin): `.issueflows/03-solved-issues/issue12_*` once closed.

--- a/docs/data_format_specifications/cycle_table.md
+++ b/docs/data_format_specifications/cycle_table.md
@@ -90,3 +90,8 @@ Date: 2025-09-08
 | cc_charge_capacity | float | Ampere-hour (Ah) | 3.1234 | Total cycle charge capacity from cycling in CC-mode |
 | cc_charge_energy | float | Watt-hour (Wh) | 3.1234 | Total cycle charge energy from cycling in CC-mode |
 | cc_charge_time | float | Seconds (s) | 3.1234 | Total cycle charge time cycling in CC-mode |
+| normalized_cycle_index | float | - | 3.14 | Equivalent cycle number (test_cumulated_charge_capacity / nominal capacity) |
+| charge_c_rate | float | C-rate (1/h) | 0.05 | C-rate of the first charge step in the cycle |
+| discharge_c_rate | float | C-rate (1/h) | 0.05 | C-rate of the first discharge step in the cycle |
+| ir_charge | float | Ohm (Ω) | 0.1234 | Internal resistance for the (first) charge step in the cycle |
+| ir_discharge | float | Ohm (Ω) | 0.1234 | Internal resistance for the (first) discharge step in the cycle |

--- a/src/cellpycore/cell_core.py
+++ b/src/cellpycore/cell_core.py
@@ -185,13 +185,26 @@ class CellpyCellCore:  # Rename to CellpyCell when cellpy core is ready
         from cellpycore import summarizers
 
         # The native summary engine is polars-native on the native schema and
-        # produces the clean ``CycleCols`` subset. The legacy-only summary
-        # columns (IR, C-rates, RIC, shifted/normalized capacities, …) are added
-        # only on the legacy bridge (``OldCellpyCellCore.make_core_summary``).
+        # produces the clean ``CycleCols`` subset plus C-rate / IR columns. The
+        # remaining legacy-only cruft (cumulated CE, shifted / RIC capacities) is
+        # added only on the legacy bridge (``OldCellpyCellCore.make_core_summary``).
         time_00 = time.time()
         logger.debug("start making summary (native polars engine)")
+        test_mode = (
+            config.TestMode.INVERTED
+            if self.cycle_mode == "anode"
+            else config.TestMode.NORMAL
+        )
         data = summarizers.make_summary(
-            data, self.schema, final_data_points=final_data_points
+            data,
+            self.schema,
+            final_data_points=final_data_points,
+            test_mode=test_mode,
+        )
+        if find_ir and (self.schema.raw.internal_resistance in data.raw.columns):
+            data = summarizers.ir_to_summary(data, self.schema)
+        data = summarizers.c_rates_to_summary(
+            data, self.schema, current_conversion_factor=current_conversion_factor
         )
         logger.debug(f"(dt: {(time.time() - time_00):4.2f}s)")
         return data
@@ -521,6 +534,9 @@ class OldCellpyCellCore(CellpyCellCore):
             nat.potential_end_discharge: leg.end_voltage_discharge,
         }
 
+    def _legacy_to_native_summary_rename(self) -> dict:
+        return {v: k for k, v in self._native_to_legacy_summary_rename().items()}
+
     def _legacy_summary_column_order(self, find_end_voltage: bool) -> list:
         leg = self.cycle_cols
         order = [
@@ -540,11 +556,14 @@ class OldCellpyCellCore(CellpyCellCore):
         order += [leg.charge_c_rate, leg.discharge_c_rate]
         return order
 
-    def _add_legacy_summary_extras(
-        self, data: Data, find_ir: bool, current_conversion_factor: float
-    ) -> None:
-        from cellpycore import summarizers
+    def _add_legacy_summary_cruft(self, data: Data) -> None:
+        """Add the pandas-only legacy summary columns the native schema omits.
 
+        ``cumulated_coulombic_efficiency``, ``shifted_*`` and ``cumulated_ric*`` are
+        legacy cruft with no native ``CycleCols`` equivalent (unlike the C-rates /
+        IR, which issue #21 moved onto the native schema). They are computed here in
+        pandas, after the native->legacy rename.
+        """
         leg = self.cycle_cols
         s = data.summary
         cc = s[leg.charge_capacity]
@@ -556,13 +575,6 @@ class OldCellpyCellCore(CellpyCellCore):
         s[leg.cumulated_ric_sei] = ((cc - dc.shift(1)) / dc.shift(1)).cumsum()
         s[leg.cumulated_ric_disconnect] = ((dc.shift(1) - dc) / dc.shift(1)).cumsum()
         data.summary = s
-
-        legacy_schema = config.Schema(self.raw_cols, self.cycle_cols, self.step_cols)
-        if find_ir and (self.raw_cols.internal_resistance_txt in data.raw.columns):
-            data = summarizers.ir_to_summary(data, legacy_schema)
-        data = summarizers.c_rates_to_summary(
-            data, legacy_schema, current_conversion_factor=current_conversion_factor
-        )
 
     def make_core_summary(
         self,
@@ -576,13 +588,15 @@ class OldCellpyCellCore(CellpyCellCore):
     ) -> Data:
         """Build the per-cycle summary via the polars engine, in/out in legacy form.
 
-        Runs the native ``make_summary`` engine, renames native->legacy, then adds
-        the legacy-only extras to reproduce the legacy ``HeadersSummary`` frame.
+        Runs the native ``make_summary`` engine plus the now-native polars C-rate /
+        IR helpers, renames native->legacy, then adds the remaining pandas-only
+        legacy cruft to reproduce the legacy ``HeadersSummary`` frame.
         """
         import polars as pl
 
         from cellpycore import summarizers
 
+        native_schema = config.default_schema()
         native_raw = pl.from_pandas(
             data.raw.rename(columns=self._legacy_to_native_raw_rename(data.raw.columns))
         )
@@ -593,7 +607,16 @@ class OldCellpyCellCore(CellpyCellCore):
         nd.raw = native_raw
         nd.steps = native_steps
         summarizers.make_summary(
-            nd, config.default_schema(), final_data_points=final_data_points
+            nd, native_schema, final_data_points=final_data_points
+        )
+
+        # C-rate / IR are now native-schema columns (issue #21): compute them on the
+        # native polars frame before the single native->legacy rename. Their native
+        # names match the legacy names, so they survive the rename untouched.
+        if find_ir and (native_schema.raw.internal_resistance in nd.raw.columns):
+            summarizers.ir_to_summary(nd, native_schema)
+        summarizers.c_rates_to_summary(
+            nd, native_schema, current_conversion_factor=current_conversion_factor
         )
 
         leg = self.cycle_cols
@@ -612,11 +635,67 @@ class OldCellpyCellCore(CellpyCellCore):
         summary.index = list(range(len(summary)))
         data.summary = summary
 
-        self._add_legacy_summary_extras(
-            data, find_ir=find_ir, current_conversion_factor=current_conversion_factor
-        )
+        self._add_legacy_summary_cruft(data)
 
         order = self._legacy_summary_column_order(find_end_voltage)
         order = [c for c in order if c in data.summary.columns]
         data.summary = data.summary[order]
+        return data
+
+    def add_scaled_summary_columns(
+        self,
+        data: Data,
+        nom_cap_abs: float,
+        normalization_cycles: Union[Sequence, int, None],
+        step_txt: Optional[str] = None,
+        specifics: Optional[List[str]] = None,
+        specific_converters: Optional[dict] = None,
+    ) -> Data:
+        """Legacy-bridge ``add_scaled_summary_columns`` (pandas<->polars seam).
+
+        The native helpers are polars-native on the native schema, but cellpy calls
+        this on the legacy pandas summary. So this bridges: legacy pandas summary ->
+        native polars -> native ``equivalent_cycles`` / ``generate_specific`` ->
+        legacy pandas, mapping the produced specific columns back to legacy names.
+        """
+        import polars as pl
+
+        from cellpycore import summarizers
+        from cellpycore.config import default_schema
+
+        native_schema = default_schema()
+        if specifics is None:
+            specifics = ["gravimetric", "areal", "absolute"]
+
+        nd = Data()
+        nd.summary = pl.from_pandas(
+            data.summary.rename(columns=self._legacy_to_native_summary_rename())
+        )
+
+        if step_txt is None:
+            step_txt = (
+                native_schema.cycle.discharge_capacity
+                if self.cycle_mode == "anode"
+                else native_schema.cycle.charge_capacity
+            )
+
+        summarizers.equivalent_cycles_to_summary(
+            nd, native_schema, nom_cap_abs, normalization_cycles, step_txt
+        )
+        specific_columns = native_schema.cycle.specific_columns
+        for mode in specifics:
+            converter = self._resolve_specific_converter(data, mode, specific_converters)
+            summarizers.generate_specific_summary_columns(
+                nd, mode, specific_columns, converter
+            )
+
+        # native -> legacy, incl. the generated ``{col}_{mode}`` specific columns.
+        rename = self._native_to_legacy_summary_rename()
+        for col in specific_columns:
+            legacy_col = rename.get(col, col)
+            for mode in specifics:
+                rename[f"{col}_{mode}"] = f"{legacy_col}_{mode}"
+        result = nd.summary.to_pandas().rename(columns=rename)
+        result.index = list(range(len(result)))
+        data.summary = result
         return data

--- a/src/cellpycore/config.py
+++ b/src/cellpycore/config.py
@@ -365,6 +365,41 @@ class CycleCols(Cols):
     cc_charge_capacity: str = "cc_charge_capacity"
     cc_charge_energy: str = "cc_charge_energy"
     cc_charge_time: str = "cc_charge_time"
+    # Derived/scaled columns produced by the standalone native summary path
+    # (``add_scaled_summary_columns`` + the C-rate / IR helpers). These were
+    # previously legacy-only "bridge extras" (see step-table-polars-migration.md,
+    # Phase 3b); issue #21 brings them onto the native schema so the native path
+    # is self-sufficient. ``ir_charge`` / ``ir_discharge`` are the behaviour-
+    # preserving single-value IR targets (the four ``ir_start/end_*`` columns
+    # above remain reserved for the richer future IR model).
+    normalized_cycle_index: str = "normalized_cycle_index"
+    charge_c_rate: str = "charge_c_rate"
+    discharge_c_rate: str = "discharge_c_rate"
+    ir_charge: str = "ir_charge"
+    ir_discharge: str = "ir_discharge"
+
+    @property
+    def specific_columns(self) -> list:
+        """Summary columns that get specific (per mass / area / volume) variants.
+
+        Returns the capacity-like columns that ``generate_specific_summary_columns``
+        scales into ``{col}_gravimetric`` / ``{col}_areal`` / ``{col}_absolute``
+        variants. Mirrors the legacy ``HeadersSummary.specific_columns`` list using
+        the native column names (the native schema has no ``shifted_*`` columns, so
+        those legacy entries are dropped).
+        """
+        return [
+            self.discharge_capacity,
+            self.charge_capacity,
+            self.test_cumulated_charge_capacity,
+            self.test_cumulated_discharge_capacity,
+            self.coulombic_difference,
+            self.test_cumulated_coulombic_difference,
+            self.discharge_capacity_loss,
+            self.charge_capacity_loss,
+            self.test_cumulated_discharge_capacity_loss,
+            self.test_cumulated_charge_capacity_loss,
+        ]
 
 
 class StepCols(Cols):

--- a/src/cellpycore/summarizers.py
+++ b/src/cellpycore/summarizers.py
@@ -4,8 +4,7 @@ from typing import Optional, Sequence, TypeVar, Union
 
 import polars as pl
 
-from cellpycore import selectors
-from cellpycore.config import Schema, default_schema
+from cellpycore.config import Schema, TestMode, default_schema
 from cellpycore.cell_core import Data
 from cellpycore.legacy import CellpyLimits
 
@@ -364,16 +363,34 @@ def make_summary(
     data: Data,
     schema: Optional[Schema] = None,
     final_data_points: Optional[Sequence] = None,
+    test_mode: TestMode = TestMode.NORMAL,
 ) -> Data:
     """Polars-native per-cycle summary (the clean native ``CycleCols`` subset).
 
     One row per cycle, built from the cycle-end raw values plus the step table.
     Capacities are cycle-cumulative per direction, so the cycle-end raw value is
-    the per-cycle total. Assumes full-/cathode-cell convention (charge first).
+    the per-cycle total.
 
-    The legacy-only summary columns (cumulated CE, shifted capacities, RIC,
-    C-rates, IR, normalized cycle index) are deliberately **not** produced here;
-    the legacy bridge (``OldCellpyCellCore``) adds those for cellpy compatibility.
+    Args:
+        data (Data): The data object (needs ``raw`` and ``steps``).
+        schema: The column-header schema to use. Defaults to the native
+            cellpy-core schema when not provided.
+        final_data_points: Optional explicit cycle-end datapoints (one per cycle);
+            computed from the step table when not given.
+        test_mode (TestMode): Cell convention. ``TestMode.NORMAL`` (full-/cathode
+            cell, charge first) uses ``CE = 100*discharge/charge`` and
+            ``coulombic_difference = charge - discharge``. ``TestMode.INVERTED``
+            (anode half-cell, discharge first) flips the reference electrode so
+            ``CE = 100*charge/discharge`` and ``coulombic_difference =
+            discharge - charge`` (mirrors legacy ``cycle_mode == "anode"``).
+
+    Returns:
+        Data: The data object with the per-cycle ``summary`` added.
+
+    Note:
+        The legacy-only summary columns (cumulated CE, shifted capacities, RIC)
+        are deliberately **not** produced here; the legacy bridge
+        (``OldCellpyCellCore``) adds those for cellpy compatibility.
     """
     if schema is None:
         schema = default_schema()
@@ -409,9 +426,18 @@ def make_summary(
 
     cc = pl.col(chdr.charge_capacity)
     dc = pl.col(chdr.discharge_capacity)
+    # Coulombic efficiency / difference are referenced to the *first* step of the
+    # cycle: charge for NORMAL (cathode/full), discharge for INVERTED (anode).
+    # Capacity-loss columns are per-direction and mode-independent.
+    if test_mode == TestMode.INVERTED:
+        coulombic_efficiency = (100.0 * cc / dc).alias(chdr.coulombic_efficiency)
+        coulombic_difference = (dc - cc).alias(chdr.coulombic_difference)
+    else:
+        coulombic_efficiency = (100.0 * dc / cc).alias(chdr.coulombic_efficiency)
+        coulombic_difference = (cc - dc).alias(chdr.coulombic_difference)
     summary = summary.with_columns(
-        (100.0 * dc / cc).alias(chdr.coulombic_efficiency),
-        (cc - dc).alias(chdr.coulombic_difference),
+        coulombic_efficiency,
+        coulombic_difference,
         (cc.shift(1) - cc).alias(chdr.charge_capacity_loss),
         (dc.shift(1) - dc).alias(chdr.discharge_capacity_loss),
     )
@@ -434,16 +460,16 @@ def make_summary(
     return data
 
 
-# TODO(#13): NOT polars — pandas (summary[col] assignment). Still used by the
-#  `add_scaled_summary_columns` bridge; port to polars-native (native schema).
 def generate_specific_summary_columns(
     data: Data,
     mode: str,
     specific_columns: Sequence,
     specific_converter: float,
 ) -> Data:
-    """
-    Generate specific summary columns.
+    """Generate specific (per mass / area / volume) summary columns.
+
+    Polars-native: for each source column ``col`` present in the summary, add a
+    ``{col}_{mode}`` column equal to ``specific_converter * col``.
 
     The unit conversion is handled by value: the caller computes the conversion
     factor (e.g. via the consumer's own pint-based machinery) and passes it in,
@@ -451,41 +477,48 @@ def generate_specific_summary_columns(
 
     Args:
         data (Data): The data object.
-        mode (str): The mode of the data (gravimetric, areal or absolute).
-        specific_columns (Sequence): The columns to generate specific summary columns for.
+        mode (str): The mode of the data (``"gravimetric"``, ``"areal"`` or
+            ``"absolute"``).
+        specific_columns (Sequence): The columns to generate specific summary
+            columns for. Columns missing from the summary are skipped.
         specific_converter (float): The precomputed conversion factor to multiply
             the absolute columns by to obtain the specific (per mode) values.
 
     Returns:
         Data: The data object with the specific summary columns added to the summary.
     """
+    # The engine is polars-native; accept a pandas frame for convenience.
     summary = data.summary
-    for col in specific_columns:
-        logger.debug(f"generating specific column {col}_{mode}")
-        summary[f"{col}_{mode}"] = specific_converter * summary[col]
-    data.summary = summary
+    if not isinstance(summary, pl.DataFrame):
+        summary = pl.from_pandas(summary)
+    exprs = [
+        (specific_converter * pl.col(col)).alias(f"{col}_{mode}")
+        for col in specific_columns
+        if col in summary.columns
+    ]
+    data.summary = summary.with_columns(exprs)
     return data
 
 
-# TODO(#13): NOT polars — pandas (.loc/.isin/.empty/.mean). Helper for
-#  `equivalent_cycles_to_summary` / `c_rates_to_summary`; port to polars-native.
 def _calculate_nominal_capacity_from_cycles(
     summary: DataFrame,
     schema: Schema,
     normalization_cycles: Union[Sequence, int],
     step_txt: str,
 ) -> float:
-    """
-    Calculate nominal capacity from specified normalization cycles.
+    """Calculate nominal capacity from specified normalization cycles.
+
+    Polars-native: averages ``step_txt`` over the rows whose cycle number is in
+    ``normalization_cycles``.
 
     Args:
-        summary: The summary DataFrame containing cycle data.
+        summary: The summary ``polars.DataFrame`` containing cycle data.
         schema: The column-header schema to use.
-        normalization_cycles: The cycles to use for normalization (can be int or sequence).
-        step_txt: The header string for the capacity column.
+        normalization_cycles: The cycles to use for normalization (``int`` or sequence).
+        step_txt: The header string for the capacity column to average.
 
     Returns:
-        float: The calculated nominal capacity.
+        float: The calculated nominal capacity (``1.0`` if no reference cycle matches).
     """
     logger.info(
         f"Using these cycles for finding the nominal capacity: {normalization_cycles}"
@@ -493,11 +526,10 @@ def _calculate_nominal_capacity_from_cycles(
     if not isinstance(normalization_cycles, (list, tuple)):
         normalization_cycles = [normalization_cycles]
 
-    cap_ref = summary.loc[
-        summary[schema.raw.cycle_index_txt].isin(normalization_cycles),
-        step_txt,
-    ]
-    if not cap_ref.empty:
+    cap_ref = summary.filter(
+        pl.col(schema.cycle.cycle_num).is_in(list(normalization_cycles))
+    )[step_txt]
+    if cap_ref.len() > 0:
         nom_cap = cap_ref.mean()
     else:
         logger.info("Empty reference cycle(s)")
@@ -506,8 +538,6 @@ def _calculate_nominal_capacity_from_cycles(
     return nom_cap
 
 
-# TODO(#13): NOT polars — pandas (.assign, summary[...]). Still used by the
-#  `add_scaled_summary_columns` bridge (normalized_cycle_index); port to polars-native.
 def equivalent_cycles_to_summary(
     data: Data,
     schema: Optional[Schema] = None,
@@ -515,45 +545,49 @@ def equivalent_cycles_to_summary(
     normalization_cycles: Union[Sequence, int, None] = None,
     step_txt: Optional[str] = None,
 ) -> Data:
-    """
-    Add equivalent cycles column to the summary.
+    """Add the ``normalized_cycle_index`` (equivalent cycles) column to the summary.
+
+    Polars-native: ``normalized_cycle_index = test_cumulated_charge_capacity / nom_cap``.
 
     Args:
         data (Data): The data object.
         schema: The column-header schema to use. Defaults to the native
             cellpy-core schema when not provided.
-        nom_cap (float): The nominal capacity (default: 1.0)
-        normalization_cycles (Union[Sequence, int, None]): The cycles for normalization (default: None)
-        step_txt (str): The header string for the charge or discharge capacity
-            (defaults to the raw charge-capacity header)
+        nom_cap (float): The nominal capacity (default: 1.0).
+        normalization_cycles (Union[Sequence, int, None]): The cycles for
+            normalization; when given, ``nom_cap`` is derived from them.
+        step_txt (str): The summary capacity column used to derive ``nom_cap``
+            from ``normalization_cycles`` (defaults to the native cycle
+            charge-capacity column).
+
+    Returns:
+        Data: The data object with ``normalized_cycle_index`` added to the summary.
     """
     if schema is None:
         schema = default_schema()
     headers_summary = schema.cycle
 
     if step_txt is None:
-        step_txt = schema.raw.charge_capacity_txt
+        step_txt = headers_summary.charge_capacity
 
+    # The engine is polars-native; accept a pandas frame for convenience.
     summary = data.summary
+    if not isinstance(summary, pl.DataFrame):
+        summary = pl.from_pandas(summary)
 
     if normalization_cycles is not None:
         nom_cap = _calculate_nominal_capacity_from_cycles(
             summary, schema, normalization_cycles, step_txt
         )
 
-    normalized_cycle_index_column = {
-        headers_summary.normalized_cycle_index: summary[
-            headers_summary.cumulated_charge_capacity
-        ]
-        / nom_cap
-    }
-    summary = summary.assign(**normalized_cycle_index_column)
-    data.summary = summary
+    data.summary = summary.with_columns(
+        (pl.col(headers_summary.test_cumulated_charge_capacity) / nom_cap).alias(
+            headers_summary.normalized_cycle_index
+        )
+    )
     return data
 
 
-# TODO(#13): NOT polars — pandas (.loc/.rename/.drop_duplicates/.merge/.drop). Still
-#  used by the legacy summary bridge (`_add_legacy_summary_extras`); port to polars-native.
 def c_rates_to_summary(
     data: Data,
     schema: Optional[Schema] = None,
@@ -562,8 +596,12 @@ def c_rates_to_summary(
     step_txt: Optional[str] = None,
     current_conversion_factor: float = 1.0,
 ) -> Data:
-    """
-    Add c-rates to the summary.
+    """Add per-cycle charge / discharge C-rates to the summary.
+
+    Polars-native: takes the first charge (resp. discharge) step's per-step
+    C-rate (``c_rate``) in each cycle, scales it by ``current_conversion_factor /
+    nom_cap``, and joins it onto the summary as ``charge_c_rate`` /
+    ``discharge_c_rate``.
 
     The current-unit conversion is handled by value: the caller computes the
     factor that converts the raw current unit to the desired output current unit
@@ -571,17 +609,20 @@ def c_rates_to_summary(
     unit handling itself.
 
     Args:
-        data (core.Data): The data object.
+        data (core.Data): The data object (needs ``summary`` and ``steps``).
         schema: The column-header schema to use. Defaults to the native
             cellpy-core schema when not provided.
-        nom_cap (float): The nominal capacity (default: 1.0)
-        normalization_cycles (Union[Sequence, int, None]): The cycles for normalization (default: None)
-        step_txt (str): The header string for the charge or discharge capacity
-            (defaults to the raw charge-capacity header)
+        nom_cap (float): The nominal capacity (default: 1.0).
+        normalization_cycles (Union[Sequence, int, None]): The cycles for
+            normalization; when given, ``nom_cap`` is derived from them.
+        step_txt (str): The summary capacity column used to derive ``nom_cap``
+            from ``normalization_cycles`` (defaults to the native cycle
+            charge-capacity column).
         current_conversion_factor (float): The precomputed factor to convert the
             raw current unit to the output current unit (default: 1.0).
+
     Returns:
-        core.Data: The data object with the c-rates added to the summary.
+        core.Data: The data object with the C-rates added to the summary.
     """
     if schema is None:
         schema = default_schema()
@@ -591,123 +632,138 @@ def c_rates_to_summary(
     logger.debug("Extracting C-rates")
 
     if step_txt is None:
-        step_txt = schema.raw.charge_capacity_txt
+        step_txt = headers_summary.charge_capacity
 
+    # The engine is polars-native; accept pandas frames for convenience.
     summary = data.summary
+    if not isinstance(summary, pl.DataFrame):
+        summary = pl.from_pandas(summary)
     steps = data.steps
+    if not isinstance(steps, pl.DataFrame):
+        steps = pl.from_pandas(steps)
 
     if normalization_cycles is not None:
         nom_cap = _calculate_nominal_capacity_from_cycles(
             summary, schema, normalization_cycles, step_txt
         )
 
-    def rate_to_cellpy_units(rate):
-        return rate * current_conversion_factor
+    def _first_rate(step_type: str, out_name: str) -> "pl.DataFrame":
+        # First step of the given type per cycle (mirrors legacy drop_duplicates
+        # keep="first" on the step-table row order).
+        return (
+            steps.filter(pl.col(headers_steps.step_type) == step_type)
+            .group_by(headers_steps.cycle_num, maintain_order=True)
+            .agg(pl.col(headers_steps.c_rate).first().alias(out_name))
+            .with_columns(
+                (pl.col(out_name) / nom_cap * current_conversion_factor).alias(out_name)
+            )
+        )
 
-    charge_steps = steps.loc[
-        steps[headers_steps.type] == "charge",
-        [headers_steps.cycle, headers_steps.rate_avr],
-    ].rename(columns={headers_steps.rate_avr: headers_summary.charge_c_rate})
+    charge = _first_rate("charge", headers_summary.charge_c_rate)
+    discharge = _first_rate("discharge", headers_summary.discharge_c_rate)
 
-    charge_steps = charge_steps.drop_duplicates(
-        subset=[headers_steps.cycle], keep="first"
-    )
-    charge_steps[headers_summary.charge_c_rate] = rate_to_cellpy_units(
-        charge_steps[headers_summary.charge_c_rate] / nom_cap
-    )
-
-    summary = summary.merge(
-        charge_steps,
-        left_on=headers_summary.cycle_index,
-        right_on=headers_steps.cycle,
+    summary = summary.join(
+        charge,
+        left_on=headers_summary.cycle_num,
+        right_on=headers_steps.cycle_num,
         how="left",
-    ).drop(columns=headers_steps.cycle)
-
-    discharge_steps = steps.loc[
-        steps[headers_steps.type] == "discharge",
-        [headers_steps.cycle, headers_steps.rate_avr],
-    ].rename(columns={headers_steps.rate_avr: headers_summary.discharge_c_rate})
-
-    discharge_steps = discharge_steps.drop_duplicates(
-        subset=[headers_steps.cycle], keep="first"
     )
-    discharge_steps[headers_summary.discharge_c_rate] = rate_to_cellpy_units(
-        discharge_steps[headers_summary.discharge_c_rate] / nom_cap
-    )
-    summary = summary.merge(
-        discharge_steps,
-        left_on=headers_summary.cycle_index,
-        right_on=headers_steps.cycle,
+    summary = summary.join(
+        discharge,
+        left_on=headers_summary.cycle_num,
+        right_on=headers_steps.cycle_num,
         how="left",
-    ).drop(columns=headers_steps.cycle)
+    )
     data.summary = summary
     return data
 
 
-# TODO(#13): NOT polars — pandas (.iloc/.loc/.insert/.index row loop). Still used by the
-#  legacy summary bridge (`_add_legacy_summary_extras`); port to polars-native. NOTE the
-#  pre-existing "DOES NOT WORK PROPERLY" bug below — preserve current behaviour (oracle-locked)
-#  when porting; fix correctness in its own issue.
 def ir_to_summary(data: Data, schema: Optional[Schema] = None) -> Data:
-    # should check:  test.charge_steps = None,
-    # test.discharge_steps = None
-    # THIS DOES NOT WORK PROPERLY!!!!
-    # Found a file where it writes IR for cycle n on cycle n+1
-    # This only picks out the data on the last IR step before
+    """Add per-cycle internal-resistance columns (``ir_charge`` / ``ir_discharge``).
+
+    Polars-native, **behaviour-preserving** port of the legacy helper: for each
+    cycle it takes the first charge (resp. discharge) step and reads the
+    internal-resistance value of that step's first raw datapoint. Cycles without a
+    matching step get ``0.0``.
+
+    Note:
+        This reproduces a known legacy correctness quirk (it reads IR from the
+        charge/discharge step itself rather than a dedicated IR step). The
+        behaviour is intentionally kept oracle-locked here; fixing the IR
+        semantics is tracked as its own issue.
+
+    Args:
+        data (Data): The data object (needs ``summary``, ``raw`` and ``steps``).
+        schema: The column-header schema to use. Defaults to the native
+            cellpy-core schema when not provided.
+
+    Returns:
+        Data: The data object with ``ir_charge`` / ``ir_discharge`` added.
+    """
     if schema is None:
         schema = default_schema()
     headers_raw = schema.raw
     headers_summary = schema.cycle
+    headers_steps = schema.step
 
+    # The engine is polars-native; accept pandas frames for convenience.
     summary = data.summary
+    if not isinstance(summary, pl.DataFrame):
+        summary = pl.from_pandas(summary)
     raw = data.raw
+    if not isinstance(raw, pl.DataFrame):
+        raw = pl.from_pandas(raw)
+    steps = data.steps
+    if not isinstance(steps, pl.DataFrame):
+        steps = pl.from_pandas(steps)
 
     logger.debug("finding ir")
-    only_zeros = summary[headers_raw.discharge_capacity_txt] * 0.0
-    discharge_steps = selectors.get_step_numbers(
-        data,
-        schema,
-        steptype="discharge",
-        allctypes=False,
+
+    # internal resistance at the first raw datapoint of each (cycle, step).
+    # maintain_order (no sort) mirrors the legacy ``.values[0]`` taking the first
+    # matching raw row in the frame's natural order.
+    raw_ir = (
+        raw.group_by(
+            [headers_raw.cycle_num, headers_raw.step_num], maintain_order=True
+        ).agg(pl.col(headers_raw.internal_resistance).first().alias("__ir"))
     )
-    charge_steps = selectors.get_step_numbers(
-        data,
-        schema,
-        steptype="charge",
-        allctypes=False,
+
+    def _ir_for(step_type: str, out_name: str) -> "pl.DataFrame":
+        first_step = (
+            steps.filter(pl.col(headers_steps.step_type) == step_type)
+            .group_by(headers_steps.cycle_num, maintain_order=True)
+            .agg(pl.col(headers_steps.step_num).first().alias("__step"))
+        )
+        joined = first_step.join(
+            raw_ir,
+            left_on=[headers_steps.cycle_num, "__step"],
+            right_on=[headers_raw.cycle_num, headers_raw.step_num],
+            how="left",
+        )
+        return joined.select(
+            pl.col(headers_steps.cycle_num),
+            pl.col("__ir").alias(out_name),
+        )
+
+    ir_discharge = _ir_for("discharge", headers_summary.ir_discharge)
+    ir_charge = _ir_for("charge", headers_summary.ir_charge)
+
+    summary = summary.join(
+        ir_discharge,
+        left_on=headers_summary.cycle_num,
+        right_on=headers_steps.cycle_num,
+        how="left",
     )
-    ir_indexes = []
-    ir_values = []
-    ir_values2 = []
-    for i in summary.index:
-        # selecting the appropriate cycle
-        cycle = summary.iloc[i][headers_raw.cycle_index_txt]
-        step = discharge_steps[cycle]
-        if step[0]:
-            ir = raw.loc[
-                (raw[headers_raw.cycle_index_txt] == cycle)
-                & (data.raw[headers_raw.step_index_txt] == step[0]),
-                headers_raw.internal_resistance_txt,
-            ]
-            # This will not work if there are more than one item in step
-            ir = ir.values[0]
-        else:
-            ir = 0
-        step2 = charge_steps[cycle]
-        if step2[0]:
-            ir2 = raw[
-                (raw[headers_raw.cycle_index_txt] == cycle)
-                & (data.raw[headers_raw.step_index_txt] == step2[0])
-            ][headers_raw.internal_resistance_txt].values[0]
-        else:
-            ir2 = 0
-        ir_indexes.append(i)
-        ir_values.append(ir)
-        ir_values2.append(ir2)
-    ir_frame = only_zeros + ir_values
-    ir_frame2 = only_zeros + ir_values2
-    summary.insert(0, column=headers_summary.ir_discharge, value=ir_frame)
-    summary.insert(0, column=headers_summary.ir_charge, value=ir_frame2)
+    summary = summary.join(
+        ir_charge,
+        left_on=headers_summary.cycle_num,
+        right_on=headers_steps.cycle_num,
+        how="left",
+    )
+    summary = summary.with_columns(
+        pl.col(headers_summary.ir_discharge).fill_null(0.0),
+        pl.col(headers_summary.ir_charge).fill_null(0.0),
+    )
     data.summary = summary
     return data
 

--- a/tests/test_config_columns.py
+++ b/tests/test_config_columns.py
@@ -76,6 +76,8 @@ CYCLE_EXPECTED = [
     "open_circuit_potential_discharge", "cv_share", "cv_charge_capacity",
     "cv_charge_energy", "cv_charge_time", "cc_charge_capacity", "cc_charge_energy",
     "cc_charge_time",
+    "normalized_cycle_index", "charge_c_rate", "discharge_c_rate",
+    "ir_charge", "ir_discharge",
 ]
 
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -12,6 +12,7 @@ import pytest
 
 from cellpycore import selectors, summarizers
 from cellpycore.cell_core import CellpyCellCore, OldCellpyCellCore, Data
+from cellpycore import config
 from cellpycore.config import RawCols, CycleCols, StepCols, Schema, default_schema
 from cellpycore.legacy import HeadersNormal
 
@@ -47,6 +48,39 @@ def _build_raw(nhdr: RawCols) -> pd.DataFrame:
                     }
                 )
                 dp += 1
+    return pd.DataFrame(records)
+
+
+def _build_cumulative_raw(nhdr: RawCols) -> pd.DataFrame:
+    """2 cycles, each charge then discharge, with cycle-cumulative capacities held.
+
+    Unlike ``_build_raw`` (which ends each cycle on a zero-capacity rest step), the
+    cycle-end datapoint here has non-zero charge/discharge capacities (cc=0.5,
+    dc=0.4), so the per-cycle summary capacities and efficiencies are meaningful.
+    """
+    records = []
+    dp = 0
+    for cyc in (1, 2):
+        for k in range(5):  # charge: cc 0.1..0.5, dc 0
+            records.append({
+                nhdr.datapoint_num: dp, nhdr.test_time: float(dp),
+                nhdr.step_time: float(k), nhdr.step_num: 1, nhdr.cycle_num: cyc,
+                nhdr.current: 1.0, nhdr.potential: 3.5 + 0.01 * k,
+                nhdr.cumulative_charge_capacity: 0.1 * (k + 1),
+                nhdr.cumulative_discharge_capacity: 0.0,
+                nhdr.internal_resistance: 0.0,
+            })
+            dp += 1
+        for k in range(5):  # discharge: cc held 0.5, dc 0.08..0.4
+            records.append({
+                nhdr.datapoint_num: dp, nhdr.test_time: float(dp),
+                nhdr.step_time: float(k), nhdr.step_num: 2, nhdr.cycle_num: cyc,
+                nhdr.current: -1.0, nhdr.potential: 3.9 - 0.01 * k,
+                nhdr.cumulative_charge_capacity: 0.5,
+                nhdr.cumulative_discharge_capacity: 0.08 * (k + 1),
+                nhdr.internal_resistance: 0.0,
+            })
+            dp += 1
     return pd.DataFrame(records)
 
 
@@ -198,9 +232,103 @@ def test_make_summary_native_schema():
 def test_generate_specific_columns_takes_factor_by_value():
     """generate_specific_summary_columns multiplies by the given factor (no pint)."""
     data = Data()
-    data.summary = pd.DataFrame({"charge_capacity": [1.0, 2.0, 4.0]})
+    data.summary = pl.DataFrame({"charge_capacity": [1.0, 2.0, 4.0]})
     data = summarizers.generate_specific_summary_columns(
         data, mode="gravimetric", specific_columns=["charge_capacity"],
         specific_converter=10.0,
     )
-    assert list(data.summary["charge_capacity_gravimetric"]) == [10.0, 20.0, 40.0]
+    assert data.summary["charge_capacity_gravimetric"].to_list() == [10.0, 20.0, 40.0]
+
+
+def test_make_summary_anode_flips_coulombic_columns():
+    """TestMode.INVERTED (anode) flips CE and coulombic_difference references."""
+    nhdr = RawCols()
+    schema = _native_schema()
+    chdr = schema.cycle
+
+    def _summ(test_mode):
+        data = Data()
+        data.raw = _build_cumulative_raw(nhdr)
+        summarizers.make_step_table(data, schema=schema, nom_cap=1.0)
+        summarizers.make_summary(data, schema=schema, test_mode=test_mode)
+        return data.summary
+
+    s_n = _summ(config.TestMode.NORMAL)
+    s_a = _summ(config.TestMode.INVERTED)
+
+    cc = s_n[chdr.charge_capacity].to_list()
+    dc = s_n[chdr.discharge_capacity].to_list()
+    ce_normal = s_n[chdr.coulombic_efficiency].to_list()
+    ce_anode = s_a[chdr.coulombic_efficiency].to_list()
+    cd_normal = s_n[chdr.coulombic_difference].to_list()
+    cd_anode = s_a[chdr.coulombic_difference].to_list()
+
+    assert cc == pytest.approx([0.5, 0.5])
+    assert dc == pytest.approx([0.4, 0.4])
+    for i in range(len(cc)):
+        assert ce_normal[i] == pytest.approx(100.0 * dc[i] / cc[i])
+        assert ce_anode[i] == pytest.approx(100.0 * cc[i] / dc[i])
+        assert cd_normal[i] == pytest.approx(cc[i] - dc[i])
+        assert cd_anode[i] == pytest.approx(dc[i] - cc[i])
+
+
+def test_c_rates_to_summary_native():
+    """c_rates_to_summary joins per-cycle first charge/discharge C-rates (native)."""
+    nhdr = RawCols()
+    schema = _native_schema()
+    chdr = schema.cycle
+
+    data = _data_with_raw(nhdr)
+    summarizers.make_step_table(data, schema=schema, nom_cap=2.0)
+    summarizers.make_summary(data, schema=schema)
+    summarizers.c_rates_to_summary(data, schema, nom_cap=1.0)
+
+    assert chdr.charge_c_rate in data.summary.columns
+    assert chdr.discharge_c_rate in data.summary.columns
+    # both directions present in every cycle of the fixture -> no nulls
+    assert data.summary[chdr.charge_c_rate].null_count() == 0
+    assert data.summary[chdr.discharge_c_rate].null_count() == 0
+
+
+def test_ir_to_summary_native():
+    """ir_to_summary adds ir_charge/ir_discharge filling 0.0 where absent (native)."""
+    nhdr = RawCols()
+    schema = _native_schema()
+    chdr = schema.cycle
+
+    data = _data_with_raw(nhdr)
+    summarizers.make_step_table(data, schema=schema, nom_cap=1.0)
+    summarizers.make_summary(data, schema=schema)
+    summarizers.ir_to_summary(data, schema)
+
+    assert chdr.ir_charge in data.summary.columns
+    assert chdr.ir_discharge in data.summary.columns
+    # the fixture has a zero internal_resistance column -> all zeros, no nulls
+    assert data.summary[chdr.ir_charge].null_count() == 0
+    assert set(data.summary[chdr.ir_charge].to_list()) == {0.0}
+
+
+def test_native_add_scaled_summary_columns_end_to_end():
+    """The native CellpyCellCore add_scaled path runs on the polars summary."""
+    cell = CellpyCellCore(initialize=False)
+    nhdr = cell.schema.raw
+    chdr = cell.schema.cycle
+
+    data = _data_with_raw(nhdr)
+    cell.make_core_step_table(data, nom_cap=1.0)
+    cell.make_core_summary(data)
+    cell.add_scaled_summary_columns(
+        data,
+        nom_cap_abs=1.0,
+        normalization_cycles=None,
+        specific_converters={"gravimetric": 10.0, "areal": 2.0, "absolute": 1.0},
+    )
+
+    assert chdr.normalized_cycle_index in data.summary.columns
+    assert f"{chdr.charge_capacity}_gravimetric" in data.summary.columns
+    assert f"{chdr.charge_capacity}_areal" in data.summary.columns
+    # gravimetric variant is 10x the absolute charge_capacity
+    base = data.summary[chdr.charge_capacity].to_list()
+    grav = data.summary[f"{chdr.charge_capacity}_gravimetric"].to_list()
+    for b, g in zip(base, grav):
+        assert g == pytest.approx(10.0 * b)


### PR DESCRIPTION
## Summary

Finishes the polars-native summary migration (follow-up to #13) so the native `CellpyCellCore` summary path stands on its own, while keeping the `tests/test_golden.py` summary oracle byte-green through the legacy bridge.

- **Ported the 5 remaining pandas summary helpers to polars-native** on the native schema: `c_rates_to_summary`, `ir_to_summary`, `equivalent_cycles_to_summary`, `generate_specific_summary_columns`, `_calculate_nominal_capacity_from_cycles`. `ir_to_summary` is behaviour-preserving (legacy off-by-one kept oracle-locked) and no longer depends on the pandas `selectors.get_step_numbers`.
- **Anode (discharge-first) mode** added to `make_summary` via the `config.TestMode` enum (`NORMAL`/`INVERTED`), flipping only `coulombic_efficiency` and `coulombic_difference`. `make_core_summary` derives it from `cycle_mode == "anode"`.
- **Native `add_scaled_summary_columns`** now works on the polars summary; native `make_core_summary` adds C-rate/IR columns natively.
- **Extended native `CycleCols`** (Option A — revises the Phase 3b bridge-only decision): added `normalized_cycle_index`, `charge_c_rate`, `discharge_c_rate`, `ir_charge`, `ir_discharge`, and a `specific_columns` accessor; synced `cycle_table.md` and `CYCLE_EXPECTED`.
- **Bridge restructured**: `OldCellpyCellCore.make_core_summary` runs the native polars C-rate/IR helpers before the native→legacy rename (only genuine legacy cruft stays pandas); an `add_scaled_summary_columns` override bridges pandas↔polars + legacy↔native so the external cellpy call keeps working.

Design decision recorded in `.issueflows/04-designs-and-guides/step-table-polars-migration.md`.

## Test plan

- [x] `uv run pytest` — 34 passed
- [x] `tests/test_golden.py` summary oracle stays byte-green through the bridge
- [x] New native-schema tests: anode CE/coulombic-difference flip, native `c_rates_to_summary`, native `ir_to_summary`, native `add_scaled_summary_columns` end-to-end
- [x] `tests/test_config_columns.py` cycle-cols spec parity

## Follow-ups (out of scope)

- `ir_to_summary` correctness bug (writes IR for cycle n on n+1) — preserved here; fix in its own issue.
- Cross-repo (cellpy) byte-parity for the bridge `add_scaled` path — applies when cellpy bumps its pinned core (cellpy#377/#378).

Closes #21

Made with [Cursor](https://cursor.com)