### PR TITLE
STEP-09: Finalize config.Cols <-> legacy Headers* mapping (#34)

### DIFF
--- a/.issueflows/03-solved-issues/issue34_original.md
+++ b/.issueflows/03-solved-issues/issue34_original.md
@@ -1,0 +1,60 @@
+# Issue #34: STEP-09: Finalize config.Cols <-> legacy Headers* mapping (lossless/total round-trip + test)
+
+Source: https://github.com/cellpy/cellpy-core/issues/34
+
+## Original issue text
+
+## Context
+
+Roadmap **STEP-09 (Harmonize column headers)** — see
+`.issueflows/04-designs-and-guides/cellpy-core-integration-roadmap.md`.
+
+The integration delegates `cellpy`'s core processing to `cellpy-core` while keeping
+legacy behaviour. Native column names live in `config.Cols`
+(`RawCols` / `StepCols` / `CycleCols`); the legacy-named headers cellpy still expects
+live in `cellpycore.legacy` (`HeadersNormal` / `HeadersSummary` / `HeadersStepTable`).
+
+## Current state
+
+- `config.Cols` and `legacy.Headers*` both exist, each with spec-conformance tests
+  (`tests/test_config_columns.py`).
+- The `OldCellpyCellCore` bridge in `src/cellpycore/cell_core.py` already translates
+  native <-> legacy column names, but **ad hoc**: e.g. `_NATIVE_STAT_TO_LEGACY` and the
+  inline native->legacy rename map in the summary bridge.
+- There is **no single, declared, tested** `config.Cols` <-> legacy `Headers*` mapping,
+  and no round-trip test proving the translation is lossless and total.
+
+## Goal
+
+Settle the column-header story: provide one authoritative `config.Cols` <-> legacy
+`Headers*` mapping and prove (by test) that the translation is **lossless and total** —
+every legacy header maps to a native column and back, with no silent rename drift.
+
+## Scope / tasks
+
+- Define the authoritative mapping in one place (native <-> legacy), replacing or backing
+  the ad-hoc rename dicts currently scattered in `cell_core.py`.
+- Document any legacy headers that intentionally have **no** native counterpart (legacy-only
+  "extras" such as `shifted_*`, RIC, cumulated-CE) and any native columns with no legacy
+  counterpart, so "lossless/total" is well-defined rather than aspirational.
+- Add a round-trip / mapping test (e.g. `tests/test_header_mapping.py`).
+
+## Success criteria (from roadmap STEP-09)
+
+- Spec-conformance tests continue to pin `RawCols` / `StepCols` / `CycleCols` to the
+  authoritative spec tables (`tests/test_config_columns.py` — exists).
+- A round-trip / mapping test proves `config.Cols` <-> legacy `Headers*` translation is
+  lossless and total (every legacy header maps and back, documented exceptions aside).
+- The STEP-05 contract tests (in `cellpy`) and STEP-06 goldens (`tests/test_golden.py`)
+  still pass — no silent rename drift.
+
+## Out of scope
+
+- Porting further engine behaviour (STEP-08 cleanup, STEP-10/11/12) — tracked separately.
+- Changing the harmonized raw spec itself.
+
+## References
+
+- `.issueflows/04-designs-and-guides/cellpy-core-integration-roadmap.md` (STEP-09)
+- `src/cellpycore/config.py`, `src/cellpycore/legacy.py`, `src/cellpycore/cell_core.py`
+- `tests/test_config_columns.py`, `tests/test_golden.py`

--- a/.issueflows/03-solved-issues/issue34_plan.md
+++ b/.issueflows/03-solved-issues/issue34_plan.md
@@ -1,0 +1,58 @@
+# Plan for issue #34: Finalize config.Cols <-> legacy Headers* mapping
+
+## Goal
+Replace the four scattered, hand-maintained rename dicts in `OldCellpyCellCore` with a single declared `config.Cols` <-> legacy `Headers*` mapping (a new module), and prove by test that the translation is **lossless and total** over the declared header classes, modulo explicitly listed exception sets (legacy-only / native-only columns). Behavior must stay identical (goldens green).
+
+## Constraints
+- Behavior-preserving: `tests/test_golden.py`, `tests/test_schema.py`, `tests/test_config_columns.py` must stay green; the STEP-05 contract tests live in the `cellpy` repo and rely on the legacy frame layout being byte-identical, so no observable rename change.
+- KISS: one new module + one new test + a focused refactor; no new deps.
+- Mapping is defined over **column-name strings** (the dataclass field *values*), not attribute names, because that is what DataFrame renames act on and because legacy `HeadersSummary` has duplicate values (e.g. `discharge_capacity` and `discharge_capacity_raw`).
+- The mapping must distinguish **renamed pairs** (native string != legacy string) from **identity pass-through** (native == legacy, intentionally unrenamed, e.g. summary `ir_charge`, `charge_c_rate`, `normalized_cycle_index`). A correct totality claim depends on capturing identity pass-throughs.
+
+### Prior art
+- `OldCellpyCellCore._NATIVE_STAT_TO_LEGACY`, `_legacy_to_native_raw_rename`, `_native_to_legacy_step_rename`, `_native_to_legacy_summary_rename` (`cellpycore.cell_core`) — the current ad-hoc maps; convention: per-family dicts, step uses base-signal + stat-suffix expansion + scalar columns. New work: **migrate** these to derive from the new module (single source of truth), preserving exact output.
+- `tests/test_config_columns.py` — convention: transcribe spec tables to expected lists, assert `list(declared) == EXPECTED` and value==name. New work: **mirror** this style for the mapping/round-trip test.
+- `config.CycleCols.specific_columns` / `legacy.HeadersSummary.specific_columns` — convention: native list deliberately drops legacy-only `shifted_*`. New work: reuse this as the canonical example of a documented native-vs-legacy gap.
+- `.issueflows/04-designs-and-guides/column-headers-review.md` — durable header-decision memory; new work appends an issue-#34 decision section.
+
+## Approach
+1. **New module `src/cellpycore/header_mapping.py`** — the single authoritative declaration:
+   - `STAT_SUFFIXES`: native->legacy stat map (`mean->avr`, `std`, `min`, `max`, `first`, `last`, `delta`) (moved from `_NATIVE_STAT_TO_LEGACY`).
+   - `RAW_PAIRS`: list of `(native, legacy)` tuples for the raw frame (the 10 current pairs, e.g. `("cumulative_charge_capacity", "charge_capacity")`).
+   - `STEP_BASE_PAIRS` (base signals: `step_time`/`current`/`potential`<->`voltage`/`charge_capacity`<->`charge`/`discharge_capacity`<->`discharge`/`internal_resistance`<->`ir`/`datapoint_num`<->`point`/`test_time`) + `STEP_SCALAR_PAIRS` (`cycle_num`<->`cycle`, `step_num`<->`step`, `sub_step_num`<->`sub_step`, `step_type`<->`type`, `sub_step_type`<->`sub_type`, `c_rate`<->`rate_avr`).
+   - `CYCLE_PAIRS`: the 16 current summary pairs **plus** the identity pass-throughs (`ir_charge`, `ir_discharge`, `charge_c_rate`, `discharge_c_rate`, `normalized_cycle_index`) so totality holds.
+   - Documented exception constants per family: `LEGACY_ONLY_RAW/STEP/CYCLE` and `NATIVE_ONLY_RAW/STEP/CYCLE` (sets of column-name strings with short comments explaining why they have no counterpart, e.g. raw `aci_phase_angle`, summary `shifted_*` / `cumulated_ric*` / `cumulated_coulombic_efficiency` / `ocv_*`, native `aux_*` / `cumulative_*_energy`).
+   - Small derivation helpers used by the bridge: `legacy_to_native_raw()`, `native_to_legacy_step()`, `native_to_legacy_summary()` (build the dicts the bridge needs, incl. step base x stat expansion), and their inverses where needed.
+2. **Refactor `OldCellpyCellCore`** so the four helpers delegate to `header_mapping` (no literal dicts left in `cell_core.py`); keep method names/signatures so the rest of the class is untouched. Output frames must be identical.
+3. **Document exceptions** as the module-level constants above (single source) + a concise decision section appended to `column-headers-review.md`.
+
+## Files to touch
+- `src/cellpycore/header_mapping.py` (new) — authoritative pairs, stat map, exception sets, derivation helpers.
+- `src/cellpycore/cell_core.py` — back the 4 rename helpers with `header_mapping`; drop the inline literals.
+- `tests/test_header_mapping.py` (new) — round-trip + totality + no-drift tests.
+- `.issueflows/04-designs-and-guides/column-headers-review.md` — append "Issue #34 — authoritative header mapping" decision note.
+- `.issueflows/01-current-issues/issue34_plan.md` — write this plan (first step of /iflow-start).
+
+## Test strategy
+`tests/test_header_mapping.py` (run with `uv run pytest`), per family (raw / step / cycle):
+- **Round-trip / bijection:** mapping is injective both ways; native->legacy->native is identity on the declared domain; `STAT_SUFFIXES` is bijective.
+- **Native totality:** every declared `config.Cols` column value is either in the mapping (directly, or via base x stat expansion for step) or in `NATIVE_ONLY_*`; the two are disjoint and cover the class exactly.
+- **Legacy totality:** every declared `Headers*` column value is either mapped or in `LEGACY_ONLY_*`; disjoint and exact cover.
+- **No stale drift:** every name in the exception sets and pairs actually exists on the relevant class.
+- **Bridge parity:** assert `OldCellpyCellCore`'s helper outputs equal the `header_mapping`-derived dicts (guards the refactor).
+- Document the known step quirk: `datapoint_num`/`test_time` base signals yield runtime stat columns beyond the `*_first`/`*_last` declared in `StepCols`; the step totality check is asserted at base-signal granularity with this noted.
+- Re-run full suite: `uv run pytest` (esp. `test_golden.py`, `test_schema.py`, `test_config_columns.py`).
+
+## Open questions
+- `RawCols.test_id` and legacy `HeadersNormal.test_id_txt` are both `"test_id"` but the raw bridge does **not** translate `test_id` today. Plan: document it as an exception on both sides (behavior-preserving) rather than adding it to `RAW_PAIRS`. Flag if you'd prefer it added to the mapping instead.
+- STEP-05 contract tests live in `cellpy` (sibling repo); they are not run from `cellpy-core` CI. Plan treats "no observable rename change" as the guarantee; a manual cross-repo `pytest` run in `cellpy` can confirm if desired.
+
+## Status
+- [x] Done
+
+Implemented: `src/cellpycore/header_mapping.py` (authoritative pairs + exception
+sets + derivation helpers), refactored `OldCellpyCellCore` to derive its four
+rename dicts from it, added `tests/test_header_mapping.py` (12 tests), and
+recorded the decisions in `column-headers-review.md`. Full suite green (50
+passed), including `test_golden.py` / `test_schema.py` / `test_config_columns.py`
+— no rename drift.

--- a/.issueflows/04-designs-and-guides/cellpy-core-integration-into-cellpy.md
+++ b/.issueflows/04-designs-and-guides/cellpy-core-integration-into-cellpy.md
@@ -72,6 +72,25 @@ package):
 6. Port `tests/test_slim.py` (from 334) as the seam's acceptance test; keep the full
    suite green.
 
+## Regularly run the essential parity smoke tests (cellpy repo)
+
+The integration seam is only as safe as the tests that guard it. In the **`cellpy`**
+repo, run the curated smoke set regularly (after any change to `cellpy-core`, the
+bridge, headers/units, or the summary/step path):
+
+```bash
+uv run pytest -m essential   # ~15 tests, ~12 s
+```
+
+These are tagged with the `essential` pytest marker (registered in
+`cellpy/pyproject.toml`) and cover the read -> step-table -> summary pipeline plus
+the `cellpy` <-> `cellpy-core` header/unit parity contract
+(`tests/test_core_settings_parity.py`). Run them via **uv**, not the conda env:
+the `cellpycore` editable dependency is wired through `[tool.uv.sources]`, which
+conda/pip do not honor, and the conda `cellpy_dev_31x` env may be below the 3.13
+floor both repos require. The full suite is still the source of truth before a
+release/PR; `-m essential` is the fast inner-loop check.
+
 ## Open decisions (resolve early — cheap, unblocking)
 
 - **Python floor.** `cellpy-core` requires `>=3.13`; `cellpy` supports 3.10–3.13.

--- a/.issueflows/04-designs-and-guides/column-headers-review.md
+++ b/.issueflows/04-designs-and-guides/column-headers-review.md
@@ -107,3 +107,42 @@ Deliberately **out of scope** for this pass (deferred): metadata-level enums
 (`TestFamily`/`TestType`, `SourceKind`) and cross-cutting descriptors (capacity
 specifics `gravimetric`/`areal`/`absolute`; batbase-aligned `CellConfiguration`
 / `FormFactor`).
+
+## Issue #34 — authoritative header mapping (STEP-09)
+
+Settled the `config.Cols` <-> legacy `Headers*` story. Decisions:
+
+1. **One source of truth.** The native <-> legacy correspondence now lives in
+   `src/cellpycore/header_mapping.py` (per-family `RAW_PAIRS`, `STEP_BASE_PAIRS`
+   + `STEP_SCALAR_PAIRS` + `STAT_SUFFIXES`, `CYCLE_PAIRS`). The four rename dicts
+   that used to be hand-maintained inside `OldCellpyCellCore` (`cell_core.py`)
+   now derive from it; the bridge keeps no literal column maps. Behaviour is
+   byte-identical (golden + schema tests unchanged).
+2. **Mapping is over column-name strings**, not attribute names — that is what
+   DataFrame renames act on, and legacy `HeadersSummary` has two attributes that
+   share a value (`discharge_capacity` / `discharge_capacity_raw`).
+3. **Identity pass-throughs are declared.** Summary `ir_charge`, `ir_discharge`,
+   `charge_c_rate`, `discharge_c_rate`, `normalized_cycle_index` already share a
+   name across native/legacy; they are listed as (identity) pairs so the totality
+   claim holds. As bridge renames they are harmless no-ops.
+4. **"Lossless/total" is modulo documented exceptions.** Each side declares
+   explicit exception sets (`LEGACY_ONLY_*` / `NATIVE_ONLY_*`) for columns with
+   no counterpart — legacy-only cruft (`shifted_*`, `cumulated_ric*`,
+   `cumulated_coulombic_efficiency`, `ocv_*`, temperatures, `aux_` prefix, the
+   step-table `info` / `ustep` / `ir_pct_change` / `test`) and native-only
+   columns (raw `aux_*` / `cumulative_*_energy` / identity & source fields, the
+   step `power_*` / `*_energy` statistics and `mask`, and the rich native cycle
+   statistics). `tests/test_header_mapping.py` asserts, per family, that declared
+   columns == mapped ∪ exceptions (disjoint), so adding a column on either side
+   fails the test until it is deliberately categorised — no silent rename drift.
+5. **`test_id` is intentionally not bridged.** `RawCols.test_id` and
+   `HeadersNormal.test_id_txt` are both `"test_id"`, but the raw bridge does not
+   translate it today; it is recorded as an exception on both sides rather than
+   added to `RAW_PAIRS` (behaviour-preserving). Revisit if/when the bridge needs
+   to carry `test_id` through.
+6. **Step granularity.** The native/legacy step correspondence is declared at
+   *base-signal* level and expanded with `STAT_SUFFIXES` (`mean` -> `avr`, the
+   rest identical). `datapoint_num` / `test_time` participate as base signals but
+   `StepCols` only declares their `_first` / `_last` variants (the engine emits
+   just those two stats), so the step totality test compares at base-signal
+   granularity.

--- a/src/cellpycore/cell_core.py
+++ b/src/cellpycore/cell_core.py
@@ -11,6 +11,7 @@ from typing import Callable, Iterable, Union, Sequence, Optional, List, TypeVar
 
 
 from cellpycore import config
+from cellpycore import header_mapping
 
 from cellpycore.legacy import NoDataFound
 from cellpycore.legacy import Meta, MockMetaTestDependent
@@ -373,56 +374,16 @@ class OldCellpyCellCore(CellpyCellCore):
     # translate at this seam: legacy pandas raw -> native polars raw -> engine ->
     # native polars steps -> legacy pandas steps. The output frame reproduces the
     # legacy ``HeadersStepTable`` layout byte-for-byte (the golden oracle).
-
-    _NATIVE_STAT_TO_LEGACY = {
-        "mean": "avr",
-        "std": "std",
-        "min": "min",
-        "max": "max",
-        "first": "first",
-        "last": "last",
-        "delta": "delta",
-    }
+    #
+    # The native <-> legacy correspondence is declared once in
+    # ``cellpycore.header_mapping``; the methods below just adapt it to the
+    # DataFrame renames this bridge needs (see tests/test_header_mapping.py).
 
     def _legacy_to_native_raw_rename(self, columns) -> dict:
-        leg, nat = self.raw_cols, config.RawCols()
-        mapping = {
-            leg.data_point_txt: nat.datapoint_num,
-            leg.test_time_txt: nat.test_time,
-            leg.step_time_txt: nat.step_time,
-            leg.cycle_index_txt: nat.cycle_num,
-            leg.step_index_txt: nat.step_num,
-            leg.current_txt: nat.current,
-            leg.voltage_txt: nat.potential,
-            leg.charge_capacity_txt: nat.cumulative_charge_capacity,
-            leg.discharge_capacity_txt: nat.cumulative_discharge_capacity,
-            leg.internal_resistance_txt: nat.internal_resistance,
-        }
-        return {k: v for k, v in mapping.items() if k in columns}
+        return header_mapping.legacy_to_native_raw(columns)
 
     def _native_to_legacy_step_rename(self) -> dict:
-        leg, nat = self.step_cols, config.StepCols()
-        base_map = {
-            "datapoint_num": leg.point,
-            "test_time": leg.test_time,
-            "step_time": leg.step_time,
-            "current": leg.current,
-            "potential": leg.voltage,
-            "charge_capacity": leg.charge,
-            "discharge_capacity": leg.discharge,
-            "internal_resistance": leg.internal_resistance,
-        }
-        rename = {}
-        for nbase, lbase in base_map.items():
-            for nstat, lstat in self._NATIVE_STAT_TO_LEGACY.items():
-                rename[f"{nbase}_{nstat}"] = f"{lbase}_{lstat}"
-        rename[nat.cycle_num] = leg.cycle
-        rename[nat.step_num] = leg.step
-        rename[nat.sub_step_num] = leg.sub_step
-        rename[nat.step_type] = leg.type
-        rename[nat.sub_step_type] = leg.sub_type
-        rename[nat.c_rate] = leg.rate_avr
-        return rename
+        return header_mapping.native_to_legacy_step()
 
     def _legacy_step_column_order(self) -> list:
         leg = self.step_cols
@@ -435,7 +396,7 @@ class OldCellpyCellCore(CellpyCellCore):
             leg.charge, leg.discharge, leg.internal_resistance,
         ]
         for base in bases:
-            order += [f"{base}_{stat}" for stat in self._NATIVE_STAT_TO_LEGACY.values()]
+            order += [f"{base}_{stat}" for stat in header_mapping.STAT_SUFFIXES.values()]
         order += [leg.rate_avr, leg.type, leg.sub_type, leg.info]
         return order
 
@@ -552,31 +513,13 @@ class OldCellpyCellCore(CellpyCellCore):
     # pandas helpers, which is appropriate: they are legacy cruft.
 
     def _legacy_to_native_step_rename(self) -> dict:
-        return {v: k for k, v in self._native_to_legacy_step_rename().items()}
+        return header_mapping.legacy_to_native_step()
 
     def _native_to_legacy_summary_rename(self) -> dict:
-        leg, nat = self.cycle_cols, config.CycleCols()
-        return {
-            nat.cycle_num: leg.cycle_index,
-            nat.datapoint_num_last: leg.data_point,
-            nat.last_test_time: leg.test_time,
-            nat.charge_capacity: leg.charge_capacity,
-            nat.discharge_capacity: leg.discharge_capacity,
-            nat.coulombic_efficiency: leg.coulombic_efficiency,
-            nat.coulombic_difference: leg.coulombic_difference,
-            nat.charge_capacity_loss: leg.charge_capacity_loss,
-            nat.discharge_capacity_loss: leg.discharge_capacity_loss,
-            nat.test_cumulated_charge_capacity: leg.cumulated_charge_capacity,
-            nat.test_cumulated_discharge_capacity: leg.cumulated_discharge_capacity,
-            nat.test_cumulated_coulombic_difference: leg.cumulated_coulombic_difference,
-            nat.test_cumulated_charge_capacity_loss: leg.cumulated_charge_capacity_loss,
-            nat.test_cumulated_discharge_capacity_loss: leg.cumulated_discharge_capacity_loss,
-            nat.potential_end_charge: leg.end_voltage_charge,
-            nat.potential_end_discharge: leg.end_voltage_discharge,
-        }
+        return header_mapping.native_to_legacy_summary()
 
     def _legacy_to_native_summary_rename(self) -> dict:
-        return {v: k for k, v in self._native_to_legacy_summary_rename().items()}
+        return header_mapping.legacy_to_native_summary()
 
     def _legacy_summary_column_order(self, find_end_voltage: bool) -> list:
         leg = self.cycle_cols

--- a/src/cellpycore/header_mapping.py
+++ b/src/cellpycore/header_mapping.py
@@ -1,0 +1,252 @@
+"""Authoritative ``config.Cols`` <-> legacy ``Headers*`` column-name mapping.
+
+This module is the single source of truth for how the native cellpy-core column
+names (``config.RawCols`` / ``config.StepCols`` / ``config.CycleCols``) translate
+to and from the legacy cellpy names (``legacy.HeadersNormal`` /
+``legacy.HeadersStepTable`` / ``legacy.HeadersSummary``).
+
+The legacy bridge (``cell_core.OldCellpyCellCore``) builds all of its native
+<-> legacy rename dictionaries from the declarations here, so the translation
+lives in exactly one place and is covered by ``tests/test_header_mapping.py``
+(round-trip, totality, and bridge-parity tests).
+
+Design notes:
+
+- The mapping is defined over **column-name strings** (the values of the
+  dataclass fields), not over attribute names. This is what DataFrame renames
+  act on, and it side-steps the fact that legacy ``HeadersSummary`` has two
+  attributes that share a value (``discharge_capacity`` /
+  ``discharge_capacity_raw``).
+- Pairs include **identity pass-throughs** (native string == legacy string,
+  e.g. summary ``ir_charge`` / ``charge_c_rate`` / ``normalized_cycle_index``).
+  These columns are intentionally not renamed by the bridge (they already share
+  a name), but they are real, mapped columns and must be declared so the
+  "total" claim holds.
+- "Lossless and total" is defined **modulo the documented exception sets**
+  below: every native column is either mapped or listed in a ``NATIVE_ONLY_*``
+  set, and every legacy column is either mapped or listed in a ``LEGACY_ONLY_*``
+  set. The exception sets are explicit (not derived) so that adding a new column
+  on either side fails the totality test until it is deliberately categorised.
+
+Step-table granularity: the step engine produces per-signal statistic columns
+(``<signal>_<stat>``). The native/legacy *base-signal* correspondence is declared
+in :data:`STEP_BASE_PAIRS` and expanded with :data:`STAT_SUFFIXES`; scalar
+(non-statistic) step columns are in :data:`STEP_SCALAR_PAIRS`. Note that the
+``datapoint_num`` and ``test_time`` step signals are declared in ``StepCols`` only
+with ``_first`` / ``_last`` variants (the engine emits just those two stats for
+them), even though they participate in the base-signal mapping.
+"""
+
+# --- statistic suffixes (native -> legacy) ----------------------------------
+# The per-step engine names statistics ``<signal>_<native_stat>``; legacy cellpy
+# uses ``<signal>_<legacy_stat>`` (only ``mean`` -> ``avr`` actually differs).
+STAT_SUFFIXES = {
+    "mean": "avr",
+    "std": "std",
+    "min": "min",
+    "max": "max",
+    "first": "first",
+    "last": "last",
+    "delta": "delta",
+}
+
+# --- raw frame (native RawCols <-> legacy HeadersNormal) ---------------------
+# Each entry is ``(native, legacy)``. Only these raw columns cross the bridge;
+# everything else is a documented exception below.
+RAW_PAIRS = [
+    ("datapoint_num", "data_point"),
+    ("test_time", "test_time"),
+    ("step_time", "step_time"),
+    ("cycle_num", "cycle_index"),
+    ("step_num", "step_index"),
+    ("current", "current"),
+    ("potential", "voltage"),
+    ("cumulative_charge_capacity", "charge_capacity"),
+    ("cumulative_discharge_capacity", "discharge_capacity"),
+    ("internal_resistance", "internal_resistance"),
+]
+
+# --- step table (native StepCols <-> legacy HeadersStepTable) ----------------
+# Base signals carry the seven ``STAT_SUFFIXES`` variants; ``(native, legacy)``.
+STEP_BASE_PAIRS = [
+    ("datapoint_num", "point"),
+    ("test_time", "test_time"),
+    ("step_time", "step_time"),
+    ("current", "current"),
+    ("potential", "voltage"),
+    ("charge_capacity", "charge"),
+    ("discharge_capacity", "discharge"),
+    ("internal_resistance", "ir"),
+]
+
+# Scalar (non-statistic) step columns; ``(native, legacy)``.
+STEP_SCALAR_PAIRS = [
+    ("cycle_num", "cycle"),
+    ("step_num", "step"),
+    ("sub_step_num", "sub_step"),
+    ("step_type", "type"),
+    ("sub_step_type", "sub_type"),
+    ("c_rate", "rate_avr"),
+]
+
+# --- cycle / summary (native CycleCols <-> legacy HeadersSummary) ------------
+# ``(native, legacy)``. Includes identity pass-throughs (last block) so the
+# totality claim holds; the bridge treats those as no-op renames.
+CYCLE_PAIRS = [
+    ("cycle_num", "cycle_index"),
+    ("datapoint_num_last", "data_point"),
+    ("last_test_time", "test_time"),
+    ("charge_capacity", "charge_capacity"),
+    ("discharge_capacity", "discharge_capacity"),
+    ("coulombic_efficiency", "coulombic_efficiency"),
+    ("coulombic_difference", "coulombic_difference"),
+    ("charge_capacity_loss", "charge_capacity_loss"),
+    ("discharge_capacity_loss", "discharge_capacity_loss"),
+    ("test_cumulated_charge_capacity", "cumulated_charge_capacity"),
+    ("test_cumulated_discharge_capacity", "cumulated_discharge_capacity"),
+    ("test_cumulated_coulombic_difference", "cumulated_coulombic_difference"),
+    ("test_cumulated_charge_capacity_loss", "cumulated_charge_capacity_loss"),
+    ("test_cumulated_discharge_capacity_loss", "cumulated_discharge_capacity_loss"),
+    ("potential_end_charge", "end_voltage_charge"),
+    ("potential_end_discharge", "end_voltage_discharge"),
+    # Identity pass-throughs (native name already equals the legacy name).
+    ("ir_charge", "ir_charge"),
+    ("ir_discharge", "ir_discharge"),
+    ("charge_c_rate", "charge_c_rate"),
+    ("discharge_c_rate", "discharge_c_rate"),
+    ("normalized_cycle_index", "normalized_cycle_index"),
+]
+
+# -----------------------------------------------------------------------------
+#   Documented exceptions (columns with no counterpart on the other side).
+#   These make "lossless/total" well-defined; the totality test asserts that the
+#   declared columns of each class equal (mapped columns) ∪ (its exception set).
+# -----------------------------------------------------------------------------
+
+# Legacy HeadersNormal column values with no native RawCols counterpart.
+# (``test_id`` exists on both sides with the same name but is intentionally not
+# translated by the raw bridge, so it is listed as an exception on both sides.)
+LEGACY_ONLY_RAW = frozenset({
+    "aci_phase_angle", "ref_aci_phase_angle", "ac_impedance", "ref_ac_impedance",
+    "charge_energy", "date_time", "discharge_energy", "power", "is_fc_data",
+    "sub_step_index", "sub_step_time", "test_id", "reference_voltage", "dv_dt",
+    "frequency", "amplitude", "channel_id", "data_flag", "test_name",
+})
+
+# Native RawCols column values with no legacy HeadersNormal counterpart.
+NATIVE_ONLY_RAW = frozenset({
+    "source_datapoint_num", "mask", "epoch_time_utc", "source_type",
+    "source_uuid", "test_id", "source_step_num", "step_type", "step_type_detail",
+    "step_mode", "cycle_type", "cumulative_charge_energy",
+    "cumulative_discharge_energy", "step_charge_power", "step_discharge_power",
+    "aux_temperature_cell", "aux_temperature_chamber", "aux_pressure_cell",
+})
+
+# Legacy HeadersStepTable column values with no native StepCols counterpart.
+# (``ustep`` is emitted by the engine as a literal "ustep" column only when
+# ``usteps=True``; it has no declared StepCols field.)
+LEGACY_ONLY_STEP = frozenset({"test", "ustep", "info", "ir_pct_change"})
+
+# Native StepCols *signals* with no legacy counterpart (power / energy
+# statistics, and the boolean ``mask``). Compared at base-signal granularity,
+# i.e. after stripping the ``STAT_SUFFIXES`` from statistic columns.
+NATIVE_ONLY_STEP = frozenset({"power", "charge_energy", "discharge_energy", "mask"})
+
+# Legacy HeadersSummary column values with no native CycleCols counterpart
+# (legacy-only cruft: cumulated CE, shifted / RIC capacities, OCV mins/maxes,
+# normalized capacities, temperatures, levels, passthrough identity columns).
+LEGACY_ONLY_CYCLE = frozenset({
+    "date_time", "test_name", "data_flag", "channel_id",
+    "cumulated_coulombic_efficiency", "normalized_charge_capacity",
+    "normalized_discharge_capacity", "shifted_charge_capacity",
+    "shifted_discharge_capacity", "ocv_first_min", "ocv_second_min",
+    "ocv_first_max", "ocv_second_max", "cumulated_ric_disconnect",
+    "cumulated_ric_sei", "cumulated_ric", "low_level", "high_level",
+    "temperature_last", "temperature_mean", "aux_",
+})
+
+# Native CycleCols column values with no legacy HeadersSummary counterpart.
+NATIVE_ONLY_CYCLE = frozenset({
+    "mask", "datapoint_num_first", "first_epoch_time_utc", "last_epoch_time_utc",
+    "first_test_time", "cycle_duration", "charge_duration", "discharge_duration",
+    "rest_duration", "test_net_capacity", "charge_energy", "discharge_energy",
+    "cycle_net_energy", "energy_efficiency", "test_cumulated_charge_energy",
+    "test_cumulated_discharge_energy", "test_net_energy",
+    "current_charge_mean", "current_charge_mean_tw", "current_charge_mean_cw",
+    "current_charge_max", "current_charge_min", "current_discharge_mean",
+    "current_discharge_mean_tw", "current_discharge_mean_cw",
+    "current_discharge_max", "current_discharge_min",
+    "potential_charge_mean", "potential_charge_mean_tw", "potential_charge_mean_cw",
+    "potential_charge_max", "potential_charge_min", "potential_discharge_mean",
+    "potential_discharge_mean_tw", "potential_discharge_mean_cw",
+    "potential_discharge_max", "potential_discharge_min",
+    "potential_start_charge", "potential_start_discharge", "voltage_efficiency",
+    "power_charge_mean", "power_charge_mean_tw", "power_charge_mean_cw",
+    "power_charge_max", "power_charge_min", "power_discharge_mean",
+    "power_discharge_mean_tw", "power_discharge_mean_cw", "power_discharge_max",
+    "power_discharge_min", "ir_start_charge", "ir_end_charge", "ir_start_discharge",
+    "ir_end_discharge", "relaxation_potential_charge",
+    "relaxation_potential_discharge", "open_circuit_potential_charge",
+    "open_circuit_potential_discharge", "cv_share", "cv_charge_capacity",
+    "cv_charge_energy", "cv_charge_time", "cc_charge_capacity", "cc_charge_energy",
+    "cc_charge_time",
+})
+
+
+# -----------------------------------------------------------------------------
+#   Derivation helpers (the bridge builds its rename dicts from these).
+# -----------------------------------------------------------------------------
+def legacy_to_native_raw(columns=None) -> dict:
+    """Return the legacy -> native rename dict for the raw frame.
+
+    Args:
+        columns: Optional iterable of column names actually present. When given,
+            the result is filtered to keys in ``columns`` (so the dict is safe to
+            pass straight to ``DataFrame.rename``).
+
+    Returns:
+        dict: Mapping ``legacy_name -> native_name``.
+    """
+    mapping = {legacy: native for native, legacy in RAW_PAIRS}
+    if columns is not None:
+        cols = set(columns)
+        mapping = {k: v for k, v in mapping.items() if k in cols}
+    return mapping
+
+
+def native_to_legacy_step() -> dict:
+    """Return the native -> legacy rename dict for the step table.
+
+    Expands :data:`STEP_BASE_PAIRS` with every :data:`STAT_SUFFIXES` variant and
+    appends the scalar :data:`STEP_SCALAR_PAIRS`.
+
+    Returns:
+        dict: Mapping ``native_name -> legacy_name``.
+    """
+    rename = {}
+    for native_base, legacy_base in STEP_BASE_PAIRS:
+        for native_stat, legacy_stat in STAT_SUFFIXES.items():
+            rename[f"{native_base}_{native_stat}"] = f"{legacy_base}_{legacy_stat}"
+    for native, legacy in STEP_SCALAR_PAIRS:
+        rename[native] = legacy
+    return rename
+
+
+def legacy_to_native_step() -> dict:
+    """Return the inverse of :func:`native_to_legacy_step` (legacy -> native)."""
+    return {v: k for k, v in native_to_legacy_step().items()}
+
+
+def native_to_legacy_summary() -> dict:
+    """Return the native -> legacy rename dict for the per-cycle summary.
+
+    Returns:
+        dict: Mapping ``native_name -> legacy_name`` (identity pass-throughs
+        included; harmless no-op renames for the bridge).
+    """
+    return {native: legacy for native, legacy in CYCLE_PAIRS}
+
+
+def legacy_to_native_summary() -> dict:
+    """Return the inverse of :func:`native_to_legacy_summary` (legacy -> native)."""
+    return {v: k for k, v in native_to_legacy_summary().items()}

--- a/tests/test_header_mapping.py
+++ b/tests/test_header_mapping.py
@@ -1,0 +1,181 @@
+"""Round-trip / totality tests for the authoritative header mapping.
+
+These lock the native ``config.Cols`` <-> legacy ``Headers*`` mapping declared in
+``cellpycore.header_mapping`` so the translation is provably **lossless and total**
+(every column on each side either maps to the other side or is listed in a
+documented exception set) and so the legacy bridge cannot silently drift away
+from it.
+
+Granularity note: the mapping is compared over column-name *strings* (the field
+values). The step table is compared at *base-signal* granularity (statistic
+columns ``<signal>_<stat>`` are reduced to ``<signal>``), because the engine emits
+per-signal statistics that share one declared base correspondence.
+"""
+
+import dataclasses
+
+from cellpycore import config, header_mapping
+from cellpycore.cell_core import OldCellpyCellCore
+from cellpycore.legacy import HeadersNormal, HeadersStepTable, HeadersSummary
+
+
+# --- helpers ----------------------------------------------------------------
+def _native_values(cols_cls) -> set:
+    """Distinct column-name strings declared on a native ``config.Cols`` class."""
+    return {getattr(cols_cls, name) for name in cols_cls.__annotations__}
+
+
+def _legacy_values(headers_cls) -> set:
+    """Distinct column-name strings declared on a legacy ``Headers*`` dataclass."""
+    return {f.default for f in dataclasses.fields(headers_cls)}
+
+
+_STAT_NATIVE = set(header_mapping.STAT_SUFFIXES)
+
+
+def _step_signal(value: str) -> str:
+    """Reduce a step column ``<signal>_<stat>`` to its base ``<signal>``."""
+    head, _, tail = value.rpartition("_")
+    if head and tail in _STAT_NATIVE:
+        return head
+    return value
+
+
+# --- bijection / round-trip -------------------------------------------------
+def test_stat_suffixes_bijective():
+    legacy_stats = list(header_mapping.STAT_SUFFIXES.values())
+    assert len(legacy_stats) == len(set(legacy_stats))
+
+
+def _assert_pairs_bijective(pairs):
+    natives = [n for n, _ in pairs]
+    legacies = [legacy for _, legacy in pairs]
+    assert len(natives) == len(set(natives)), "native names not unique"
+    assert len(legacies) == len(set(legacies)), "legacy names not unique"
+
+
+def test_pair_lists_are_bijective():
+    _assert_pairs_bijective(header_mapping.RAW_PAIRS)
+    _assert_pairs_bijective(header_mapping.STEP_BASE_PAIRS)
+    _assert_pairs_bijective(header_mapping.STEP_SCALAR_PAIRS)
+    _assert_pairs_bijective(header_mapping.CYCLE_PAIRS)
+
+
+def test_step_round_trip_identity():
+    n2l = header_mapping.native_to_legacy_step()
+    l2n = header_mapping.legacy_to_native_step()
+    assert n2l, "expected a non-empty step rename"
+    for native, legacy in n2l.items():
+        assert l2n[legacy] == native
+
+
+def test_summary_round_trip_identity():
+    n2l = header_mapping.native_to_legacy_summary()
+    l2n = header_mapping.legacy_to_native_summary()
+    assert n2l
+    for native, legacy in n2l.items():
+        assert l2n[legacy] == native
+
+
+# --- raw totality -----------------------------------------------------------
+def test_raw_native_totality():
+    native_vals = _native_values(config.RawCols)
+    mapped = {n for n, _ in header_mapping.RAW_PAIRS}
+    assert mapped <= native_vals
+    assert mapped.isdisjoint(header_mapping.NATIVE_ONLY_RAW)
+    assert mapped | header_mapping.NATIVE_ONLY_RAW == native_vals
+
+
+def test_raw_legacy_totality():
+    legacy_vals = _legacy_values(HeadersNormal)
+    mapped = {legacy for _, legacy in header_mapping.RAW_PAIRS}
+    assert mapped <= legacy_vals
+    assert mapped.isdisjoint(header_mapping.LEGACY_ONLY_RAW)
+    assert mapped | header_mapping.LEGACY_ONLY_RAW == legacy_vals
+
+
+# --- step totality (base-signal granularity) --------------------------------
+def test_step_native_totality():
+    native_signals = {_step_signal(v) for v in _native_values(config.StepCols)}
+    mapped = {n for n, _ in header_mapping.STEP_BASE_PAIRS} | {
+        n for n, _ in header_mapping.STEP_SCALAR_PAIRS
+    }
+    assert mapped <= native_signals
+    assert mapped.isdisjoint(header_mapping.NATIVE_ONLY_STEP)
+    assert mapped | header_mapping.NATIVE_ONLY_STEP == native_signals
+
+
+def test_step_legacy_totality():
+    legacy_vals = _legacy_values(HeadersStepTable)
+    mapped = {legacy for _, legacy in header_mapping.STEP_BASE_PAIRS} | {
+        legacy for _, legacy in header_mapping.STEP_SCALAR_PAIRS
+    }
+    assert mapped <= legacy_vals
+    assert mapped.isdisjoint(header_mapping.LEGACY_ONLY_STEP)
+    assert mapped | header_mapping.LEGACY_ONLY_STEP == legacy_vals
+
+
+# --- cycle / summary totality ----------------------------------------------
+def test_cycle_native_totality():
+    native_vals = _native_values(config.CycleCols)
+    mapped = {n for n, _ in header_mapping.CYCLE_PAIRS}
+    assert mapped <= native_vals
+    assert mapped.isdisjoint(header_mapping.NATIVE_ONLY_CYCLE)
+    assert mapped | header_mapping.NATIVE_ONLY_CYCLE == native_vals
+
+
+def test_cycle_legacy_totality():
+    legacy_vals = _legacy_values(HeadersSummary)
+    mapped = {legacy for _, legacy in header_mapping.CYCLE_PAIRS}
+    assert mapped <= legacy_vals
+    assert mapped.isdisjoint(header_mapping.LEGACY_ONLY_CYCLE)
+    assert mapped | header_mapping.LEGACY_ONLY_CYCLE == legacy_vals
+
+
+# --- spot-checks (guard against accidental pair edits) ----------------------
+def test_known_translations():
+    assert header_mapping.legacy_to_native_raw() == {
+        "data_point": "datapoint_num",
+        "test_time": "test_time",
+        "step_time": "step_time",
+        "cycle_index": "cycle_num",
+        "step_index": "step_num",
+        "current": "current",
+        "voltage": "potential",
+        "charge_capacity": "cumulative_charge_capacity",
+        "discharge_capacity": "cumulative_discharge_capacity",
+        "internal_resistance": "internal_resistance",
+    }
+    step = header_mapping.native_to_legacy_step()
+    assert step["current_mean"] == "current_avr"
+    assert step["potential_first"] == "voltage_first"
+    assert step["c_rate"] == "rate_avr"
+    summary = header_mapping.native_to_legacy_summary()
+    assert summary["cycle_num"] == "cycle_index"
+    assert summary["potential_end_charge"] == "end_voltage_charge"
+    assert summary["ir_charge"] == "ir_charge"  # identity pass-through
+
+
+# --- bridge parity (the bridge must use the authoritative mapping) ----------
+def test_bridge_uses_header_mapping():
+    core = OldCellpyCellCore(initialize=False)
+    legacy_raw_cols = list(_legacy_values(HeadersNormal))
+    assert core._legacy_to_native_raw_rename(
+        legacy_raw_cols
+    ) == header_mapping.legacy_to_native_raw(legacy_raw_cols)
+    assert (
+        core._native_to_legacy_step_rename()
+        == header_mapping.native_to_legacy_step()
+    )
+    assert (
+        core._legacy_to_native_step_rename()
+        == header_mapping.legacy_to_native_step()
+    )
+    assert (
+        core._native_to_legacy_summary_rename()
+        == header_mapping.native_to_legacy_summary()
+    )
+    assert (
+        core._legacy_to_native_summary_rename()
+        == header_mapping.legacy_to_native_summary()
+    )


### PR DESCRIPTION
## Summary
- Centralizes the native `config.Cols` <-> legacy `Headers*` translation into a single authoritative module, `cellpycore.header_mapping` (`RAW_PAIRS`, `STEP_BASE_PAIRS`/`STEP_SCALAR_PAIRS` + `STAT_SUFFIXES`, `CYCLE_PAIRS` incl. identity pass-throughs), with explicit per-family exception sets (`LEGACY_ONLY_*` / `NATIVE_ONLY_*`).
- Refactors `OldCellpyCellCore`'s four ad-hoc rename dicts to derive from that single source, so the bridge can no longer silently drift. Behaviour is unchanged.
- Adds `tests/test_header_mapping.py` proving the mapping is lossless and total (round-trip/bijection + per-family totality against the declared header classes, modulo documented exceptions) and that the bridge actually uses the mapping.
- Documents the decisions in `column-headers-review.md`; notes the cellpy `-m essential` smoke set in `cellpy-core-integration-into-cellpy.md`.

Implements STEP-09 of the integration roadmap.

## Test plan
- [x] `uv run pytest` — full suite green (50 passed), incl. `test_golden.py`, `test_schema.py`, `test_config_columns.py` (no rename drift)
- [x] New `tests/test_header_mapping.py` (12 tests) passes
- [x] Optional: run cellpy's `uv run pytest -m essential` against this branch (STEP-05 contract tests)

Closes #34

Made with [Cursor](https://cursor.com)