### PR TITLE
feat: add cellpycore.metadata scaffolding for test/cell metadata

### DIFF
--- a/.issueflows/03-solved-issues/issue30_original.md
+++ b/.issueflows/03-solved-issues/issue30_original.md
@@ -1,0 +1,13 @@
+# Issue #30: module for handling meta data
+
+Source: https://github.com/cellpy/cellpy-core/issues/30
+
+## Original issue text
+
+add a new module with scaffolding for handling meta-data. It is best to make it into a separate package (i.e. a folder with a __init__.py file inside).
+
+we need to carefully analyse how old cellpy carries meta-data, as well as the available documents within cellpy core and suggest how we should add the key elements into cellpy core. In step one, defining the data structures (enums, dataclasses, etc) would be the goal. In step two, creating some dummy functions that the full future cellpy suite can use, is the goal. We are not yet sure what we need. We need to be able to communicate with a db (through an API / JSONLD most likely). We also need to load cellpy archive files (I think they will be hdf5 as before). And save.
+
+notice that there are (at least) two levels of metadata, cell dependent (those that does not change between tests, for example material specific values and masses) and test-dependent (for example test type, test instrument, uuids, connection/file information)
+
+The overall goal is not to implement a final solution, but to work on the design and scaffolding.

--- a/.issueflows/03-solved-issues/issue30_plan.md
+++ b/.issueflows/03-solved-issues/issue30_plan.md
@@ -1,0 +1,124 @@
+# Plan for issue #30: module for handling meta data
+
+## Goal
+
+Add a new `cellpycore.metadata` sub-package that provides the **scaffolding** for
+test-/cell-level metadata: typed data structures (Step 1) plus dummy/stub functions for
+(de)serialization, archive load/save, and DB/API exchange (Step 2). This is design +
+scaffolding only — **not** a final implementation, and it must not change how the core
+engine runs today.
+
+## Constraints
+
+- **Honour the metadata boundary** (`.issueflows/04-designs-and-guides/cellpy-core-migration.md`
+  §4): core owns the *shape and the tools* (schemas, dataclasses, (de)serialization, merge
+  helpers, `test_id` plumbing). Core must **not require populated metadata** on `Data`, and
+  must keep working when metadata is absent. Attaching real metadata to `Data` stays a v2.0
+  / upstream opt-in.
+- **Non-breaking.** Leave `Data.meta_test_dependent` (the `legacy.MockMetaTestDependent`
+  scalar) and the `CellpyCellCore.cycle_mode` property untouched. The new package is
+  standalone scaffolding; the scalar→keyed move on `Data` is explicitly a later (v2.0)
+  concern (`cell_core.py:113-141`, `test-metadata-and-merging.md`). No edits to
+  `cell_core.py` / `summarizers.py` in this issue.
+- **Stay lean / loader-free.** No new runtime dependencies. HDF5 archive and DB/API
+  (JSON-LD) functions are **stubs** (raise `NotImplementedError` with a clear message);
+  only stdlib `json` is used for the dict/JSON round-trip. Pulling in `h5py`/`pytables`/an
+  RDF lib is deferred to whoever implements real persistence.
+- Follow project conventions: Google-style docstrings, `StrEnum` + `@dataclass` mirroring
+  `config.py`, thread-safe (pure data + pure functions, no shared mutable module state).
+- Align field names with the existing **TestMeta spec** in
+  `docs/data_format_specifications/harmonized_raw.md` (the authoritative field list).
+
+### Prior art
+
+- `legacy.Meta` / `legacy.MockMetaTestDependent` (`src/cellpycore/legacy.py:236-242`) —
+  convention: the current placeholder scalar hung off `Data.meta_test_dependent`. New work:
+  **coexist** (leave it as-is; the new package does not replace it this issue).
+- `config.RawCols.test_id` (`src/cellpycore/config.py:514`) — convention: compact per-row
+  grouping key, `0` for a single unmerged test. New work: `TestMeta.test_id` **mirrors** it
+  (one `TestMeta` record per `test_id`); a `TestMetaCollection` is keyed by it.
+- TestMeta spec table (`docs/data_format_specifications/harmonized_raw.md:91-131`) —
+  convention: authoritative field set + types/units. New work: `TestMeta` dataclass mirrors
+  these fields field-for-field.
+- Old cellpy `CellpyMetaCommon` (cell/material/geometry) + `CellpyMetaIndividualTest`
+  (`cellpy/cellpy/parameters/internal_settings.py:136-222`) — convention: existing
+  cell-vs-test metadata split with `update`/`digest`/`to_frame` helpers. New work: **mine**
+  field names for `CellMeta` (cell-dependent) and `TestMeta` (test-dependent); reimplement
+  clean dataclasses in core rather than importing cellpy (core must not depend on cellpy).
+- `config.StepType` / `CycleType` / `StepMode` `StrEnum`s (`config.py:78-196`) — convention:
+  non-validating reference vocabularies. New work: `SourceKind` (`file`/`db`/`api`) and a
+  `MetaLevel` enum **mirror** that style.
+
+## Approach
+
+Two metadata levels, two dataclasses, keyed collection, stub I/O:
+
+1. **Data structures (Step 1)** — `metadata/models.py`:
+   - `MetaLevel(StrEnum)` = `CELL` / `TEST`; `SourceKind(StrEnum)` = `FILE` / `DB` / `API`.
+   - `@dataclass CellMeta` — **cell-dependent** (constant across tests on the same cell):
+     mass, tot_mass, nom_cap, nom_cap_specifics, material, active-electrode area/loading/
+     thickness, electrolyte/electrode/separator types, cell_type, experiment_type, ...
+     (mined from `CellpyMetaCommon`). All fields `Optional`, default `None`.
+   - `@dataclass TestMeta` — **test-dependent** (one per `test_id`): the spec fields
+     (`test_id`, `uuid`, `cell_name`, `test_family`, `test_type`, `cycle_mode`,
+     `source_kind`, `source_type`, `source_uri`, `source_uuid`, `raw_file_names`,
+     `schedule_file_name`, `creator`, `channel`, `tester_id`, `start_datetime`, `time_zone`,
+     `loaded_datetime`, `comment`) + an optional `cell: Optional[CellMeta]` reference so the
+     cell/test split is captured without forcing a separate table. `test_id: int = 0`.
+   - `@dataclass TestMetaCollection` — a thin keyed container (`dict[int, TestMeta]`) for the
+     "many merged test files" case: `add`, `get`, `__iter__`, `__len__`, `test_ids`.
+2. **Dummy functions (Step 2)** — `metadata/io.py`:
+   - `to_dict(meta)` / `from_dict(cls, d)` — working stdlib round-trip (`dataclasses.asdict`
+     + reconstruction); used by everything else.
+   - `to_json(meta)` / `from_json(cls, s)` — working stdlib `json` round-trip.
+   - `merge_test_meta(collection, others, *, renumber=True)` — combine collections keyed by
+     `test_id`, reassigning ids on collision (the merging story from
+     `test-metadata-and-merging.md`).
+   - `load_archive(path)` / `save_archive(meta, path)` — **stubs** (HDF5 cellpy archive):
+     `raise NotImplementedError("HDF5 metadata archive I/O is scaffolding ...")`.
+   - `fetch_from_db(locator)` / `push_to_db(meta, locator)` — **stubs** (DB/API, JSON-LD):
+     `raise NotImplementedError("DB/API (JSON-LD) metadata exchange is scaffolding ...")`,
+     with a docstring sketch of the intended JSON-LD shape.
+3. **Public surface** — `metadata/__init__.py` re-exports the dataclasses, enums, and the
+   serialization/merge/stub functions so consumers do `from cellpycore.metadata import
+   TestMeta, CellMeta, ...`.
+
+## Files to touch
+
+- `src/cellpycore/metadata/__init__.py` — new; public exports + module docstring.
+- `src/cellpycore/metadata/models.py` — new; enums + `CellMeta` / `TestMeta` /
+  `TestMetaCollection`.
+- `src/cellpycore/metadata/io.py` — new; serialize/deserialize + merge helpers + HDF5 and
+  DB/API stubs.
+- `tests/test_metadata.py` — new; round-trip, merge, and stub-raises tests.
+- `.issueflows/04-designs-and-guides/metadata-scaffolding.md` — new; short durable design
+  note (two-level model, boundary decision, what is real vs stub, deferred questions). Links
+  back to `test-metadata-and-merging.md` and this issue.
+- `docs/data_format_specifications/harmonized_raw.md` — small note that `TestMeta`/`CellMeta`
+  now have a code home in `cellpycore.metadata` (spec stays authoritative for fields).
+
+## Test strategy
+
+- New `tests/test_metadata.py` (run with `uv run pytest` or `pytest` in the activated env):
+  - `TestMeta` / `CellMeta` construct with all-default (no required population) — the
+    "degrade gracefully" guard.
+  - `to_dict`/`from_dict` and `to_json`/`from_json` round-trip preserves values (incl. the
+    nested `cell`).
+  - `TestMetaCollection` keying + `merge_test_meta` renumbers colliding `test_id`s.
+  - `load_archive` / `save_archive` / `fetch_from_db` / `push_to_db` raise
+    `NotImplementedError`.
+- Re-run the full suite to confirm nothing else moved (the package is additive).
+
+## Open questions
+
+1. **CellMeta split.** The spec defers whether cell/material fields live in `TestMeta` or a
+   sibling `CellMeta` (`harmonized_raw.md:124-131`). Plan proposes **both** dataclasses with
+   `TestMeta.cell` as an optional link. OK, or fold everything into `TestMeta` for now?
+2. **Stub depth for HDF5 / DB.** Plan keeps these as `NotImplementedError` stubs (no new
+   deps). Acceptable, or do you want a minimal working JSON-file `save_archive`/`load_archive`
+   (no HDF5) so there is *some* real persistence to exercise?
+3. **Controlled vocabularies.** `test_family` / `test_type` / `source_type` kept as free-text
+   `str` for now (consistent with the deferred-vocabulary decisions in the spec). Agree?
+4. **Module split granularity.** 3 modules (`models` / `io` / `__init__`). Fine, or prefer a
+   flatter single `metadata.py`? (Issue explicitly asks for a *package* folder, so a folder
+   it is; this is just about how many files inside.)

--- a/.issueflows/03-solved-issues/issue30_status.md
+++ b/.issueflows/03-solved-issues/issue30_status.md
@@ -1,0 +1,52 @@
+# Issue 30 — Status
+
+Add a `cellpycore.metadata` sub-package with scaffolding for test-/cell-level
+metadata (typed structures + dummy/stub I/O). Design + scaffolding only; no change
+to how the core engine runs today.
+
+- [x] Done
+
+## What landed (2026-06-25)
+
+Implemented per the confirmed `issue30_plan.md`:
+
+- **`src/cellpycore/metadata/models.py`** — `MetaLevel` / `SourceKind` (`StrEnum`),
+  `CellMeta` (cell-dependent, mined from legacy `CellpyMetaCommon`), `TestMeta`
+  (test-dependent, mirrors the `TestMeta` spec table + `CellpyMetaIndividualTest`,
+  keyed by `test_id`, optional `cell` link), and `TestMetaCollection` (keyed
+  container with `add`/`get`/`test_ids`/`next_free_id`). `TestMeta` /
+  `TestMetaCollection` carry `__test__ = False` to avoid pytest collection.
+- **`src/cellpycore/metadata/io.py`** — real stdlib `to_dict`/`from_dict`,
+  `to_json`/`from_json`, `merge_test_meta` (renumbers colliding `test_id`s); stubs
+  `load_archive`/`save_archive` (HDF5) and `fetch_from_db`/`push_to_db` (DB/API
+  JSON-LD) raising `NotImplementedError`.
+- **`src/cellpycore/metadata/__init__.py`** — public re-exports.
+- **`tests/test_metadata.py`** — 12 tests (bare-record validity, list-default
+  isolation, dict/JSON round-trips, unknown-key tolerance, collection keying +
+  duplicate guard, merge renumber / no-renumber, stub `NotImplementedError`).
+- **`.issueflows/04-designs-and-guides/metadata-scaffolding.md`** — durable design
+  note.
+- **`docs/data_format_specifications/harmonized_raw.md`** — pointer noting the
+  `TestMeta`/`CellMeta` code home (spec stays authoritative for fields).
+
+## Guardrails honoured
+
+- Non-breaking: `Data.meta_test_dependent` scalar and `cycle_mode` untouched; no
+  edits to `cell_core.py` / `summarizers.py`. The package is additive.
+- No new runtime dependencies (HDF5 / JSON-LD are stubs; stdlib `json` only).
+- Degrades gracefully — every field optional; bare `TestMeta()` / `CellMeta()` valid.
+
+## Tests
+
+- `uv run pytest`: **62 passed** (50 prior + 12 new), no warnings.
+
+## Open questions confirmed (defaults accepted)
+
+Both `CellMeta` + `TestMeta`, `NotImplementedError` stubs for HDF5/DB, free-text
+vocabularies, 3 modules. All accepted as written in the plan.
+
+## Deferred (not part of this issue)
+
+- `CellMeta` as a separate normalized table vs the optional `TestMeta.cell` link.
+- Real HDF5 archive I/O and DB/API (JSON-LD) transport (consumer-owned, e.g. v2.0).
+- Wiring `TestMetaCollection` onto `Data` (replacing the scalar `meta_test_dependent`).

--- a/.issueflows/04-designs-and-guides/metadata-scaffolding.md
+++ b/.issueflows/04-designs-and-guides/metadata-scaffolding.md
@@ -1,0 +1,58 @@
+# Metadata scaffolding (`cellpycore.metadata`)
+
+Durable design note for the metadata sub-package added in issue
+[#30](https://github.com/cellpy/cellpy-core/issues/30). Companion to
+[`test-metadata-and-merging.md`](test-metadata-and-merging.md) (the merging model) and
+[`cellpy-core-migration.md`](cellpy-core-migration.md) §4 (the metadata boundary).
+
+## Context
+
+cellpy-core needed a home for test/cell metadata *structures and tooling* without taking on
+metadata *population* or heavy persistence dependencies. The boundary rule: **core owns the
+shape and the tools; the consumer (e.g. cellpy v2.0) owns the content and persistence.**
+
+## Decision
+
+A `cellpycore.metadata` sub-package with three modules:
+
+- `models.py` — typed data structures:
+  - `MetaLevel` / `SourceKind` (`StrEnum`, non-validating reference vocabularies).
+  - `CellMeta` — **cell-dependent** metadata (mined from legacy `CellpyMetaCommon`).
+  - `TestMeta` — **test-dependent** metadata, one record per `test_id`, mirroring the
+    `TestMeta` spec table in `docs/data_format_specifications/harmonized_raw.md`. Carries an
+    optional `cell: CellMeta` link.
+  - `TestMetaCollection` — keyed (`dict[int, TestMeta]`) container for a merged object.
+- `io.py` — Step-2 functions:
+  - **Real (stdlib only):** `to_dict`/`from_dict`, `to_json`/`from_json`, `merge_test_meta`.
+  - **Stubs (`NotImplementedError`):** `load_archive`/`save_archive` (HDF5),
+    `fetch_from_db`/`push_to_db` (DB/API, JSON-LD).
+- `__init__.py` — public re-exports.
+
+Guardrails honoured:
+
+- **Non-breaking / additive.** `Data.meta_test_dependent` (the `legacy.MockMetaTestDependent`
+  scalar) and `CellpyCellCore.cycle_mode` are untouched. The scalar→keyed move on `Data`
+  stays a v2.0 concern. Core does not import or require this package on the hot path.
+- **Lean / loader-free.** No new runtime dependencies; HDF5 + JSON-LD are stubbed.
+- **Degrades gracefully.** Every field is optional; a bare `TestMeta()` / `CellMeta()` is
+  valid.
+
+## Alternatives considered
+
+- **Fold cell fields into `TestMeta`** (no separate `CellMeta`). Rejected for now: the
+  cell-vs-test split is real (one cell, many tests) and matches legacy cellpy's
+  `CellpyMetaCommon` / `CellpyMetaIndividualTest`. Kept as an optional `TestMeta.cell` link
+  rather than a separate normalized table (that normalization is deferred).
+- **Real JSON-file persistence for `save/load_archive`.** Rejected: the archive format is
+  HDF5 and owned by the consumer; a half-real JSON path would be misleading. Stubs make the
+  "not yet implemented" boundary explicit.
+- **Denormalized per-row metadata columns.** Already rejected in
+  `test-metadata-and-merging.md`; this package is the normalized alternative.
+
+## Deferred / open
+
+- `CellMeta` as a separate normalized table vs the current optional `TestMeta.cell` link.
+- Controlled vocabularies for `test_family` / `test_type` / `source_type` (free text today).
+- Real HDF5 archive I/O and DB/API (JSON-LD) transport — owned by the consumer.
+- Wiring a `TestMetaCollection` onto `Data` (replacing the scalar `meta_test_dependent`) —
+  a v2.0 concern, tracked with the engine/merging work.

--- a/docs/data_format_specifications/harmonized_raw.md
+++ b/docs/data_format_specifications/harmonized_raw.md
@@ -99,6 +99,10 @@ merged, `TestMeta` holds one row per `test_id`.
 Test-level descriptors that are constant within a test (e.g. `test_family`, `test_type`,
 `cycle_mode`) belong here, **not** in the raw columns.
 
+This spec remains authoritative for the field set. The fields below now also have a code home
+as the `TestMeta` / `CellMeta` dataclasses in `cellpycore.metadata` (scaffolding; see
+`.issueflows/04-designs-and-guides/metadata-scaffolding.md`, issue #30).
+
 | Field | Data type | Unit | Sample data | Comment |
 | --- | --- | --- | --- | --- |
 | test_id | int | - | 0 | key; matches `raw.test_id` (the per-test grouping key) |

--- a/src/cellpycore/metadata/__init__.py
+++ b/src/cellpycore/metadata/__init__.py
@@ -1,0 +1,59 @@
+"""Metadata scaffolding for cellpy-core (issue #30).
+
+This sub-package provides the *shape and tools* for test-/cell-level metadata,
+without requiring that metadata be populated on the core ``Data`` object. See
+``.issueflows/04-designs-and-guides/metadata-scaffolding.md`` for the design and
+``docs/data_format_specifications/harmonized_raw.md`` for the authoritative field
+list.
+
+Two levels of metadata:
+
+- ``CellMeta`` — cell-dependent (constant for a physical cell across tests).
+- ``TestMeta`` — test-dependent (one record per test run, keyed by ``test_id``).
+
+``TestMetaCollection`` holds many ``TestMeta`` records for a merged object. The
+``io`` helpers give a working stdlib (de)serialization + merge surface; the HDF5
+archive and DB/API (JSON-LD) functions are deliberate stubs.
+
+Example:
+    >>> from cellpycore.metadata import TestMeta, to_json, from_json
+    >>> meta = TestMeta(test_id=0, cell_name="cell_001")
+    >>> from_json(TestMeta, to_json(meta)) == meta
+    True
+"""
+
+from cellpycore.metadata.models import (
+    CellMeta,
+    MetaLevel,
+    SourceKind,
+    TestMeta,
+    TestMetaCollection,
+)
+from cellpycore.metadata.io import (
+    fetch_from_db,
+    from_dict,
+    from_json,
+    load_archive,
+    merge_test_meta,
+    push_to_db,
+    save_archive,
+    to_dict,
+    to_json,
+)
+
+__all__ = [
+    "CellMeta",
+    "MetaLevel",
+    "SourceKind",
+    "TestMeta",
+    "TestMetaCollection",
+    "to_dict",
+    "from_dict",
+    "to_json",
+    "from_json",
+    "merge_test_meta",
+    "load_archive",
+    "save_archive",
+    "fetch_from_db",
+    "push_to_db",
+]

--- a/src/cellpycore/metadata/io.py
+++ b/src/cellpycore/metadata/io.py
@@ -1,0 +1,192 @@
+"""(De)serialization, merging, and persistence scaffolding for metadata.
+
+This is the **Step 2** scaffolding for issue #30. The serialization and merge
+helpers are real (stdlib only); the archive (HDF5) and DB/API (JSON-LD) functions
+are deliberate **stubs** that raise ``NotImplementedError``.
+
+Rationale (see ``.issueflows/04-designs-and-guides/cellpy-core-migration.md`` §4):
+core provides the *shape and the tools* and stays lean and loader-free. Real HDF5
+or RDF/JSON-LD persistence would pull in heavy dependencies and policy decisions
+that belong to the consumer (e.g. cellpy v2.0); they are stubbed here so the future
+suite has a stable surface to build against.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, fields
+from typing import Type, TypeVar, Union
+
+from cellpycore.metadata.models import (
+    CellMeta,
+    SourceKind,
+    TestMeta,
+    TestMetaCollection,
+)
+
+Meta = Union[CellMeta, TestMeta]
+M = TypeVar("M", CellMeta, TestMeta)
+
+
+def to_dict(meta: Meta) -> dict:
+    """Convert a metadata record to a plain ``dict``.
+
+    Nested ``CellMeta`` (on ``TestMeta.cell``) is converted recursively. Enum
+    values are stored as their plain string value so the result is trivially
+    JSON-serializable.
+
+    Args:
+        meta: A ``CellMeta`` or ``TestMeta`` instance.
+
+    Returns:
+        A plain ``dict`` representation.
+    """
+    return asdict(meta)
+
+
+def from_dict(cls: Type[M], data: dict) -> M:
+    """Reconstruct a metadata record from a ``dict``.
+
+    Unknown keys are ignored so the round-trip is tolerant of extra fields. The
+    nested ``cell`` mapping and the ``source_kind`` enum are coerced back to their
+    types.
+
+    Args:
+        cls: The target class (``CellMeta`` or ``TestMeta``).
+        data: A mapping as produced by ``to_dict``.
+
+    Returns:
+        An instance of ``cls``.
+    """
+    field_names = {f.name for f in fields(cls)}
+    kwargs = {k: v for k, v in data.items() if k in field_names}
+
+    if cls is TestMeta:
+        cell = kwargs.get("cell")
+        if isinstance(cell, dict):
+            kwargs["cell"] = from_dict(CellMeta, cell)
+        source_kind = kwargs.get("source_kind")
+        if source_kind is not None:
+            kwargs["source_kind"] = SourceKind(source_kind)
+
+    return cls(**kwargs)
+
+
+def to_json(meta: Meta, *, indent: Union[int, None] = 2) -> str:
+    """Serialize a metadata record to a JSON string (stdlib only)."""
+    return json.dumps(to_dict(meta), indent=indent)
+
+
+def from_json(cls: Type[M], text: str) -> M:
+    """Deserialize a metadata record from a JSON string produced by ``to_json``."""
+    return from_dict(cls, json.loads(text))
+
+
+def merge_test_meta(
+    *collections: TestMetaCollection, renumber: bool = True
+) -> TestMetaCollection:
+    """Merge several ``TestMetaCollection`` objects into a new one.
+
+    This is the "merge many test files" path: each input collection contributes
+    its records, and colliding ``test_id`` keys are resolved by assigning the next
+    free id (when ``renumber`` is True). The inputs are left untouched; the merged
+    records are shallow copies with their ``test_id`` updated as needed.
+
+    Args:
+        *collections: The collections to merge, in priority order (earlier ones
+            keep their ``test_id`` on collision; later ones get renumbered).
+        renumber: If True (default), reassign colliding ``test_id`` keys. If False,
+            raise on a collision.
+
+    Returns:
+        A new ``TestMetaCollection`` holding all records.
+
+    Raises:
+        KeyError: If ``renumber`` is False and two records share a ``test_id``.
+    """
+    import dataclasses
+
+    merged = TestMetaCollection()
+    for collection in collections:
+        for meta in collection:
+            if meta.test_id in merged:
+                if not renumber:
+                    raise KeyError(
+                        f"duplicate test_id {meta.test_id} while merging "
+                        f"(pass renumber=True to reassign)"
+                    )
+                meta = dataclasses.replace(meta, test_id=merged.next_free_id())
+            merged.add(meta)
+    return merged
+
+
+def load_archive(path) -> TestMetaCollection:
+    """Load metadata from a cellpy archive file (HDF5). **Stub.**
+
+    Intended to read the per-test metadata table from a cellpy ``.h5`` archive
+    (the format used by legacy cellpy). Not implemented here: HDF5 I/O and the
+    archive layout are the consumer's responsibility (e.g. cellpy v2.0), and core
+    stays loader-free.
+
+    Args:
+        path: Path to the cellpy archive file.
+
+    Raises:
+        NotImplementedError: Always; this is scaffolding.
+    """
+    raise NotImplementedError(
+        "HDF5 metadata archive loading is scaffolding for issue #30; the real "
+        "loader belongs to the consuming library (e.g. cellpy v2.0)."
+    )
+
+
+def save_archive(meta: Union[TestMeta, TestMetaCollection], path) -> None:
+    """Save metadata to a cellpy archive file (HDF5). **Stub.**
+
+    Args:
+        meta: The metadata to persist.
+        path: Destination archive path.
+
+    Raises:
+        NotImplementedError: Always; this is scaffolding.
+    """
+    raise NotImplementedError(
+        "HDF5 metadata archive saving is scaffolding for issue #30; the real "
+        "writer belongs to the consuming library (e.g. cellpy v2.0)."
+    )
+
+
+def fetch_from_db(locator: str) -> TestMeta:
+    """Fetch test metadata from a database / API. **Stub.**
+
+    Intended to retrieve a test record over a DB connection or an API, most likely
+    exchanging JSON-LD (e.g. a node like
+    ``{"@context": ..., "@type": "Test", "test_id": 0, ...}``). Not implemented
+    here: the transport, auth, and JSON-LD context belong to the consumer.
+
+    Args:
+        locator: A DB/API locator (e.g. ``"db://cellpydb/tests/123"``).
+
+    Raises:
+        NotImplementedError: Always; this is scaffolding.
+    """
+    raise NotImplementedError(
+        "DB/API (JSON-LD) metadata fetching is scaffolding for issue #30; the "
+        "real transport belongs to the consuming library."
+    )
+
+
+def push_to_db(meta: Union[TestMeta, TestMetaCollection], locator: str) -> None:
+    """Push test metadata to a database / API (JSON-LD). **Stub.**
+
+    Args:
+        meta: The metadata to send.
+        locator: A DB/API locator.
+
+    Raises:
+        NotImplementedError: Always; this is scaffolding.
+    """
+    raise NotImplementedError(
+        "DB/API (JSON-LD) metadata pushing is scaffolding for issue #30; the real "
+        "transport belongs to the consuming library."
+    )

--- a/src/cellpycore/metadata/models.py
+++ b/src/cellpycore/metadata/models.py
@@ -1,0 +1,238 @@
+"""Typed data structures for cellpy-core test/cell metadata (scaffolding).
+
+This module defines the *shape* of the metadata that cellpy-core understands. It
+follows the metadata-boundary decision in
+``.issueflows/04-designs-and-guides/cellpy-core-migration.md`` (§4): core owns the
+schema and tooling, but never *requires* that metadata be populated. Every field
+defaults to an empty / ``None`` value so a bare ``TestMeta()`` or ``CellMeta()`` is
+valid, and the core summary/step engine keeps working when no metadata is attached.
+
+There are two levels of metadata (see issue #30 and
+``.issueflows/04-designs-and-guides/test-metadata-and-merging.md``):
+
+- **cell-dependent** (`CellMeta`): constant for a physical cell across tests
+  (masses, nominal capacity, geometry, electrode / electrolyte types, ...).
+- **test-dependent** (`TestMeta`): one record per test run, keyed by ``test_id``
+  (the same compact key carried on every harmonized-raw row, see
+  ``cellpycore.config.RawCols.test_id``). A single (possibly merged) object holds
+  many tests via a ``TestMetaCollection`` keyed by ``test_id``.
+
+The authoritative field list lives in
+``docs/data_format_specifications/harmonized_raw.md`` ("Test metadata (TestMeta)");
+the dataclasses here mirror it. Field names are also mined from legacy cellpy's
+``cellpy.parameters.internal_settings.CellpyMetaCommon`` /
+``CellpyMetaIndividualTest`` so the two libraries stay aligned.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Optional
+
+
+class MetaLevel(StrEnum):
+    """The level a piece of metadata applies to.
+
+    Attributes:
+        CELL: Cell-dependent metadata (constant across tests on the same cell).
+        TEST: Test-dependent metadata (one record per test run).
+    """
+
+    CELL = "cell"
+    TEST = "test"
+
+
+class SourceKind(StrEnum):
+    """Where the test data was obtained from.
+
+    This is a non-validating reference vocabulary (mirroring the style of the
+    ``config`` enums): other values are still allowed by the free-text fields,
+    but these cover the expected sources.
+
+    Attributes:
+        FILE: Loaded from a raw data file on disk.
+        DB: Read from a database.
+        API: Fetched through an API (e.g. JSON-LD).
+    """
+
+    FILE = "file"
+    DB = "db"
+    API = "api"
+
+
+@dataclass
+class CellMeta:
+    """Cell-dependent metadata (constant for a physical cell across tests).
+
+    Mined from legacy ``cellpy.parameters.internal_settings.CellpyMetaCommon``
+    (cell / material / geometry fields). All fields are optional; an empty
+    ``CellMeta()`` is valid scaffolding and carries no obligation to be populated.
+
+    Attributes:
+        material: Active-material name / identifier.
+        mass: Active-material mass.
+        tot_mass: Total material mass.
+        nom_cap: Nominal capacity.
+        nom_cap_specifics: How ``nom_cap`` is specified (e.g. gravimetric).
+        active_electrode_area: Active-electrode area.
+        active_electrode_thickness: Active-electrode thickness.
+        active_electrode_loading: Active-electrode loading (e.g. mAh/cm2).
+        electrolyte_volume: Electrolyte volume.
+        electrolyte_type: Electrolyte type.
+        active_electrode_type: Active-electrode type.
+        counter_electrode_type: Counter-electrode type.
+        reference_electrode_type: Reference-electrode type.
+        separator_type: Separator type.
+        cell_type: Cell type / format.
+        experiment_type: Experiment type.
+        active_electrode_current_collector: Active-electrode current collector.
+        reference_electrode_current_collector: Reference-electrode current
+            collector.
+        comment: Free-text comment.
+    """
+
+    material: Optional[str] = None
+    mass: Optional[float] = None
+    tot_mass: Optional[float] = None
+    nom_cap: Optional[float] = None
+    nom_cap_specifics: Optional[str] = None
+    active_electrode_area: Optional[float] = None
+    active_electrode_thickness: Optional[float] = None
+    active_electrode_loading: Optional[float] = None
+    electrolyte_volume: Optional[float] = None
+    electrolyte_type: Optional[str] = None
+    active_electrode_type: Optional[str] = None
+    counter_electrode_type: Optional[str] = None
+    reference_electrode_type: Optional[str] = None
+    separator_type: Optional[str] = None
+    cell_type: Optional[str] = None
+    experiment_type: Optional[str] = None
+    active_electrode_current_collector: Optional[str] = None
+    reference_electrode_current_collector: Optional[str] = None
+    comment: Optional[str] = None
+
+
+@dataclass
+class TestMeta:
+    """Test-dependent metadata, one record per test run (keyed by ``test_id``).
+
+    Mirrors the "Test metadata (TestMeta)" table in
+    ``docs/data_format_specifications/harmonized_raw.md`` and the test-dependent
+    fields of legacy ``CellpyMetaIndividualTest``. ``cell`` optionally links the
+    cell-dependent metadata so the two-level split is captured without forcing a
+    separate table.
+
+    All fields are optional (``test_id`` defaults to ``0``, the single-unmerged-test
+    convention), so a bare ``TestMeta()`` is valid scaffolding.
+
+    Attributes:
+        test_id: Compact per-test grouping key; matches ``raw.test_id``. ``0`` for
+            a single, unmerged test.
+        uuid: Stable, globally-unique id for this test run.
+        cell_name: Human-readable cell / test name.
+        test_family: Broad classification of the overall test (free text).
+        test_type: Detailed classification within a family (free text).
+        cycle_mode: ``"anode"`` / ``"cathode"`` / ``"full"``.
+        source_kind: Where the data came from (see ``SourceKind``).
+        source_type: Cycler / instrument type (e.g. ``"Neware"``).
+        source_uri: File path or DB/API locator for the source.
+        source_uuid: Original identifier from the source; matches ``raw.source_uuid``.
+        raw_file_names: Original raw file(s) backing this test.
+        schedule_file_name: Cycler schedule / protocol file.
+        creator: Who produced / imported the test.
+        channel: Tester channel id.
+        tester_id: Tester / server identity.
+        voltage_lim_low: Lower voltage limit used for the test.
+        voltage_lim_high: Upper voltage limit used for the test.
+        start_datetime: Test start time (ISO 8601 string).
+        time_zone: Time zone for naive timestamps.
+        loaded_datetime: When the data was imported (ISO 8601 string).
+        comment: Free text.
+        cell: Optional cell-dependent metadata for this test.
+    """
+
+    # Named ``TestMeta`` to match the spec, but it is data, not a pytest case;
+    # this flag stops pytest from trying to collect it as a test class.
+    __test__ = False
+
+    test_id: int = 0
+    uuid: Optional[str] = None
+    cell_name: Optional[str] = None
+    test_family: Optional[str] = None
+    test_type: Optional[str] = None
+    cycle_mode: Optional[str] = None
+    source_kind: Optional[SourceKind] = None
+    source_type: Optional[str] = None
+    source_uri: Optional[str] = None
+    source_uuid: Optional[str] = None
+    raw_file_names: list[str] = field(default_factory=list)
+    schedule_file_name: Optional[str] = None
+    creator: Optional[str] = None
+    channel: Optional[str] = None
+    tester_id: Optional[str] = None
+    voltage_lim_low: Optional[float] = None
+    voltage_lim_high: Optional[float] = None
+    start_datetime: Optional[str] = None
+    time_zone: Optional[str] = None
+    loaded_datetime: Optional[str] = None
+    comment: Optional[str] = None
+    cell: Optional[CellMeta] = None
+
+
+@dataclass
+class TestMetaCollection:
+    """A keyed collection of ``TestMeta`` records (one per ``test_id``).
+
+    This is the "many merged test files" container: merging raw data is a vertical
+    concat on a tiny ``test_id`` column, and the test-level descriptors are stored
+    once per test here instead of being repeated on every raw row.
+
+    Attributes:
+        records: Mapping of ``test_id`` to its ``TestMeta`` record.
+    """
+
+    __test__ = False
+
+    records: dict[int, TestMeta] = field(default_factory=dict)
+
+    def add(self, meta: TestMeta, *, replace: bool = False) -> None:
+        """Add a record, keyed by its ``test_id``.
+
+        Args:
+            meta: The record to add.
+            replace: If ``False`` (default), raise on a duplicate ``test_id``.
+                If ``True``, overwrite the existing record.
+
+        Raises:
+            KeyError: If ``meta.test_id`` already exists and ``replace`` is False.
+        """
+        if not replace and meta.test_id in self.records:
+            raise KeyError(f"test_id {meta.test_id} already present")
+        self.records[meta.test_id] = meta
+
+    def get(self, test_id: int) -> Optional[TestMeta]:
+        """Return the record for ``test_id`` (or ``None`` if absent)."""
+        return self.records.get(test_id)
+
+    @property
+    def test_ids(self) -> list[int]:
+        """The sorted ``test_id`` keys currently held."""
+        return sorted(self.records)
+
+    def next_free_id(self) -> int:
+        """Return the smallest non-negative ``test_id`` not yet used."""
+        existing = set(self.records)
+        candidate = 0
+        while candidate in existing:
+            candidate += 1
+        return candidate
+
+    def __iter__(self):
+        return iter(self.records.values())
+
+    def __len__(self) -> int:
+        return len(self.records)
+
+    def __contains__(self, test_id: object) -> bool:
+        return test_id in self.records

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,0 +1,119 @@
+"""Tests for the metadata scaffolding (issue #30)."""
+
+import pytest
+
+from cellpycore.metadata import (
+    CellMeta,
+    SourceKind,
+    TestMeta,
+    TestMetaCollection,
+    fetch_from_db,
+    from_dict,
+    from_json,
+    load_archive,
+    merge_test_meta,
+    push_to_db,
+    save_archive,
+    to_dict,
+    to_json,
+)
+
+
+def test_bare_records_are_valid():
+    """Core must degrade gracefully: empty metadata records are valid."""
+    cell = CellMeta()
+    meta = TestMeta()
+    assert cell.mass is None
+    assert meta.test_id == 0
+    assert meta.raw_file_names == []
+    assert meta.cell is None
+
+
+def test_raw_file_names_are_independent_per_instance():
+    """The list default must not be shared between instances."""
+    a = TestMeta()
+    b = TestMeta()
+    a.raw_file_names.append("run1.ndax")
+    assert b.raw_file_names == []
+
+
+def test_dict_round_trip_preserves_values():
+    meta = TestMeta(
+        test_id=2,
+        cell_name="cell_001",
+        source_kind=SourceKind.FILE,
+        raw_file_names=["run1.ndax"],
+        cell=CellMeta(mass=1.23, nom_cap=3.5),
+    )
+    restored = from_dict(TestMeta, to_dict(meta))
+    assert restored == meta
+    assert isinstance(restored.cell, CellMeta)
+    assert restored.source_kind is SourceKind.FILE
+
+
+def test_json_round_trip_preserves_values():
+    meta = TestMeta(
+        test_id=1,
+        source_kind=SourceKind.DB,
+        cell=CellMeta(material="graphite"),
+    )
+    restored = from_json(TestMeta, to_json(meta))
+    assert restored == meta
+
+
+def test_from_dict_ignores_unknown_keys():
+    restored = from_dict(TestMeta, {"test_id": 5, "not_a_field": "x"})
+    assert restored.test_id == 5
+
+
+def test_collection_keying_and_duplicate_guard():
+    coll = TestMetaCollection()
+    coll.add(TestMeta(test_id=0))
+    coll.add(TestMeta(test_id=1))
+    assert len(coll) == 2
+    assert coll.test_ids == [0, 1]
+    assert 0 in coll
+    assert coll.get(1).test_id == 1
+    with pytest.raises(KeyError):
+        coll.add(TestMeta(test_id=0))
+    coll.add(TestMeta(test_id=0, cell_name="replaced"), replace=True)
+    assert coll.get(0).cell_name == "replaced"
+
+
+def test_merge_renumbers_colliding_ids():
+    a = TestMetaCollection()
+    a.add(TestMeta(test_id=0, cell_name="a0"))
+    b = TestMetaCollection()
+    b.add(TestMeta(test_id=0, cell_name="b0"))
+
+    merged = merge_test_meta(a, b)
+    assert len(merged) == 2
+    assert merged.test_ids == [0, 1]
+    # earlier collection keeps id 0; later one is renumbered to 1
+    assert merged.get(0).cell_name == "a0"
+    assert merged.get(1).cell_name == "b0"
+    # inputs are untouched
+    assert b.get(0).test_id == 0
+
+
+def test_merge_without_renumber_raises_on_collision():
+    a = TestMetaCollection()
+    a.add(TestMeta(test_id=0))
+    b = TestMetaCollection()
+    b.add(TestMeta(test_id=0))
+    with pytest.raises(KeyError):
+        merge_test_meta(a, b, renumber=False)
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        lambda: load_archive("x.h5"),
+        lambda: save_archive(TestMeta(), "x.h5"),
+        lambda: fetch_from_db("db://x/tests/1"),
+        lambda: push_to_db(TestMeta(), "db://x/tests/1"),
+    ],
+)
+def test_persistence_stubs_raise_not_implemented(call):
+    with pytest.raises(NotImplementedError):
+        call()


### PR DESCRIPTION
## Summary

Adds a new `cellpycore.metadata` sub-package with **scaffolding** for test-/cell-level metadata, per the metadata-boundary decision in `cellpy-core-migration.md` §4: core owns the *shape and the tools*; the consumer (e.g. cellpy v2.0) owns the *content and persistence*.

- **`models.py`** — `MetaLevel` / `SourceKind` (`StrEnum`); `CellMeta` (cell-dependent, mined from legacy `CellpyMetaCommon`); `TestMeta` (test-dependent, one record per `test_id`, mirrors the `TestMeta` spec table + `CellpyMetaIndividualTest`, optional `cell` link); `TestMetaCollection` (keyed container for merged objects).
- **`io.py`** — *real* stdlib `to_dict`/`from_dict`, `to_json`/`from_json`, `merge_test_meta` (renumbers colliding `test_id`s); *stubs* `load_archive`/`save_archive` (HDF5) and `fetch_from_db`/`push_to_db` (DB/API JSON-LD) raising `NotImplementedError`.
- **`__init__.py`** — public re-exports.
- Durable design note `metadata-scaffolding.md` + a pointer from `harmonized_raw.md` (spec stays authoritative for fields).

### Guardrails
- **Non-breaking / additive**: `Data.meta_test_dependent` scalar and `cycle_mode` untouched; no edits to `cell_core.py` / `summarizers.py`.
- **Lean / loader-free**: no new runtime dependencies; HDF5 + JSON-LD are stubs.
- **Degrades gracefully**: every field optional; a bare `TestMeta()` / `CellMeta()` is valid.

### Deferred (out of scope; design issue)
- `CellMeta` as a separate normalized table vs the optional `TestMeta.cell` link.
- Real HDF5 archive I/O and DB/API (JSON-LD) transport (consumer-owned).
- Wiring `TestMetaCollection` onto `Data` (replacing the scalar `meta_test_dependent`) — a v2.0 concern.

## Test plan

- [x] `uv run pytest` — **62 passed** (50 prior + 12 new), no warnings.
- New `tests/test_metadata.py` covers: bare-record validity, per-instance list defaults, dict/JSON round-trips, unknown-key tolerance, collection keying + duplicate guard, merge renumber / no-renumber, and stub `NotImplementedError`.

Closes #30

Made with [Cursor](https://cursor.com)