### PR TITLE
docs: finalize cellpy-core integration roadmap (#39)

### DIFF
--- a/.issueflows/03-solved-issues/issue39_original.md
+++ b/.issueflows/03-solved-issues/issue39_original.md
@@ -1,0 +1,11 @@
+# Issue #39: check and create issues for finalizing cellpy-core integration roadmap
+
+Source: https://github.com/cellpy/cellpy-core/issues/39
+
+## Original issue text
+
+Go through the roadmap carefully.
+
+Identify missing steps.
+
+Create a plan and create issues for implementing the plan.

--- a/.issueflows/03-solved-issues/issue39_plan.md
+++ b/.issueflows/03-solved-issues/issue39_plan.md
@@ -1,0 +1,72 @@
+# Issue #39 plan: finalize cellpy-core integration roadmap
+
+Source issue: https://github.com/cellpy/cellpy-core/issues/39
+
+## Goal
+
+Close out the roadmap planning: review the integration roadmap, capture the remaining
+gaps as a finalized durable record in the roadmap doc, and open a focused, ranked set of
+**cellpy-core** GitHub issues for the leftover work. cellpy-side work stays tracked on
+jepegit/cellpy.
+
+## Gap analysis
+
+Roadmap (`.issueflows/04-designs-and-guides/cellpy-core-integration-roadmap.md`) has 12
+steps, 10 done. Not closed: STEP-06 (golden fixtures, continuous) and STEP-12 (unit
+boundary, partly). Forward work that existed in the design docs but was not tracked as an
+open cellpy-core issue:
+
+- **STEP-12 core side** — `CellpyUnits` still lives in `legacy.py`, not a first-class
+  unit-spec module; converter-parity / pint-optional guard tests not pinned. (cellpy's
+  duplicate converters are cellpy-side, out of scope.)
+- **Per-test metadata wiring** (`test-metadata-and-merging.md`) — `test_id` is on
+  `RawCols` but not `StepCols`/`CycleCols`; engine groups by `cycle_num` not
+  `(test_id, cycle_num, step_num)`; scalar `meta_test_dependent` (`cell_core.py:26`,
+  `# TODO: v2.0` at `:115`/`:134`) not yet keyed to `TestMetaCollection`.
+- **Reset-granularity normalization** — accept step-/test-cumulative raw from other cyclers
+  (deferred in `step-table-polars-migration.md`).
+- **`ref_potential`/`ref_voltage`** native `RawCols` gap (deferred; absent in golden data).
+- **Selector dead-code removal** — `create_selector`/`summary_selector_exluder`, gated on
+  cellpy migrating off them (`selector-dead-code-deferral.md`).
+- **Release path** — tag/publish cellpy-core so cellpy can pin a release ref instead of
+  `@main`.
+- **Doc nit** — "Implementation Flow" placeholder text was stale (a mermaid diagram
+  already existed).
+
+## Decisions
+
+- New issues target **cellpy-core only**; cellpy-side delegation stays on jepegit/cellpy.
+- **Update the roadmap doc itself** as the durable finalized record, then create issues
+  from it.
+- Issue set: created the full ranked set (A–F).
+- Issue B keeps the scalar→keyed `meta_test_dependent` replacement as a documented v2.0
+  deferral; only lands `test_id` on the table schemas + composite group keys.
+- No milestone/labels attached (none exist on #39).
+
+## Issues created (final list)
+
+| Item | Issue | Status |
+|------|-------|--------|
+| Finalize STEP-12 (core): promote `CellpyUnits` to a unit-spec module + converter-parity / pint-optional tests | [#40](https://github.com/cellpy/cellpy-core/issues/40) | actionable |
+| Per-test metadata: add `test_id` to `StepCols`/`CycleCols` + composite group keys | [#41](https://github.com/cellpy/cellpy-core/issues/41) | actionable |
+| Engine: reset-granularity normalization for cumulative raw inputs | [#42](https://github.com/cellpy/cellpy-core/issues/42) | future |
+| Native schema: add `ref_potential`/`ref_voltage` support | [#43](https://github.com/cellpy/cellpy-core/issues/43) | future |
+| Release: tag cellpy-core (and decide PyPI publish) | [#44](https://github.com/cellpy/cellpy-core/issues/44) | future |
+| Cleanup: remove `create_selector`/`summary_selector_exluder` once cellpy migrates off | [#45](https://github.com/cellpy/cellpy-core/issues/45) | blocked |
+
+Not created: STEP-06 golden-fixture oracle (continuous activity, extended per-port).
+
+## Files touched
+
+- `.issueflows/04-designs-and-guides/cellpy-core-integration-roadmap.md` — fixed the stale
+  Implementation Flow placeholder; added the "Remaining work (STEP-13+)" section with
+  design-doc anchors and issue numbers #40–#45; refreshed the status-at-a-glance note.
+- `.issueflows/01-current-issues/issue39_plan.md` — this file.
+
+No source/code edits (this is a planning/meta issue).
+
+## Test strategy
+
+No code change in #39 itself, so no test run required. Each spawned issue carries its own
+test criteria (parity tests via `uv run pytest`, golden oracle in `tests/test_golden.py`).
+Roadmap edits are docs-only.

--- a/.issueflows/03-solved-issues/issue39_status.md
+++ b/.issueflows/03-solved-issues/issue39_status.md
@@ -1,0 +1,23 @@
+# Issue #39 status: finalize cellpy-core integration roadmap
+
+- [x] Done
+
+## What was done (2026-06-28)
+
+- Reviewed the roadmap (`cellpy-core-integration-roadmap.md`) and all companion design
+  docs; produced the gap analysis (see `issue39_plan.md`).
+- Created six cellpy-core GitHub issues for the remaining work:
+  - #40 — Finalize STEP-12 (core): promote `CellpyUnits` to a unit-spec module + parity tests
+  - #41 — Per-test metadata: add `test_id` to `StepCols`/`CycleCols` + composite group keys
+  - #42 — Engine: reset-granularity normalization for cumulative raw inputs
+  - #43 — Native schema: add `ref_potential`/`ref_voltage` support
+  - #44 — Release: tag cellpy-core (and decide PyPI publish)
+  - #45 — Cleanup (blocked): remove `create_selector`/`summary_selector_exluder`
+- Updated the roadmap doc: fixed the stale Implementation Flow placeholder, added the
+  "Remaining work (STEP-13+)" section (anchored to design docs + issues #40–#45), and
+  refreshed the status-at-a-glance note.
+
+## Remaining work
+
+None for #39 itself. The spawned issues (#40–#45) carry the forward implementation work.
+cellpy-side delegation (units converters, seam) remains tracked on jepegit/cellpy.

--- a/.issueflows/04-designs-and-guides/cellpy-core-integration-roadmap.md
+++ b/.issueflows/04-designs-and-guides/cellpy-core-integration-roadmap.md
@@ -49,6 +49,9 @@ Reconciled against the actual repo state on **2026-06-26**. Status legend: ✅ d
 | STEP-12 Unit-handling boundary | 🟡 partly done | `CellpyUnits` schema + `units.py` tooling behind the optional `units` extra; factors cross the seam by value; `cellpy` still keeps duplicate converters |
 
 Per-step `Status:` lines below repeat this for context; this table is the quick reference.
+The forward work beyond these twelve steps (STEP-13+) is enumerated in
+[Remaining work (STEP-13+)](#remaining-work-step-13--finalized-2026-06-28-issue-39),
+each tracked as its own GitHub issue (#40–#45).
 
 ## STEP-01 Resolve the Python floor
 
@@ -296,13 +299,34 @@ of `legacy.py` into a first-class core unit-spec module.
 - Goldens (STEP-06) are unchanged whether converters are resolved upstream or delegated to
   core.
 
+## Remaining work (STEP-13+) — finalized 2026-06-28 (issue #39)
+
+The original twelve steps are complete except for the two intentionally-continuous /
+partly-done ones (STEP-06 golden fixtures, STEP-12 unit boundary). Going through the
+roadmap and the companion design docs surfaced the remaining work below. Each item is now
+tracked as its own **cellpy-core** GitHub issue (the cellpy-side delegation work stays on
+jepegit/cellpy). Captured under issue #39.
+
+| Item | Issue | Status | Source / anchor |
+|------|-------|--------|-----------------|
+| Finalize STEP-12 (core): promote `CellpyUnits` out of `legacy.py` into a unit-spec module; add converter-parity + pint-optional guard tests | [#40](https://github.com/cellpy/cellpy-core/issues/40) | ⬜ actionable | STEP-12; `cellpy-core-migration.md` §4 |
+| Per-test metadata: add `test_id` to `StepCols`/`CycleCols` + composite group keys `(test_id, cycle_num, step_num, …)` | [#41](https://github.com/cellpy/cellpy-core/issues/41) | ⬜ actionable | `test-metadata-and-merging.md` |
+| Engine: reset-granularity normalization for step-/test-cumulative raw inputs | [#42](https://github.com/cellpy/cellpy-core/issues/42) | ⬜ future | `step-table-polars-migration.md` |
+| Native schema: add `ref_potential`/`ref_voltage` support | [#43](https://github.com/cellpy/cellpy-core/issues/43) | ⬜ future | `step-table-polars-migration.md` (Phase 1) |
+| Release: tag cellpy-core (and decide PyPI publish) so `cellpy` can pin a release ref | [#44](https://github.com/cellpy/cellpy-core/issues/44) | ⬜ future | `cellpy-core-migration.md` §2/§5 |
+| Cleanup: remove `create_selector`/`summary_selector_exluder` once `cellpy` migrates off them | [#45](https://github.com/cellpy/cellpy-core/issues/45) | ⬜ blocked | `selector-dead-code-deferral.md` |
+
+Not tracked as a discrete issue: **STEP-06** (golden-fixture oracle) is a continuous
+activity — extended per-port against `cellpy`'s published goldens, not a closeable unit.
+The scalar→keyed `meta_test_dependent` replacement (the `# TODO: v2.0` markers in
+`cell_core.py`) stays a deliberate **v2.0 / consumer opt-in** per `cellpy-core-migration.md`
+§4; #41 only lands the `test_id` plumbing into the table schemas + group keys.
+
 ## Implementation Flow
 
-> Placeholder for the visual flow of the roadmap. We will fill this in together with one
-> or more mermaid diagrams (e.g. step dependency graph, the two-repo branch/dev-wiring
-> setup, and the parity-test feedback loop).
-
-Node labels carry the reconciled status (✅ done · 🟡 partly · ⬜ not started).
+The step-dependency graph below carries the reconciled status (✅ done · 🟡 partly ·
+⬜ not started). STEP-13+ (the remaining-work items, see the section above) are tracked as
+their own GitHub issues rather than as nodes here.
 
 ```mermaid
 flowchart TD


### PR DESCRIPTION
## Summary

Finalizes the cellpy-core integration roadmap (issue #39, a planning/meta issue).

- Reviewed the roadmap and all companion design docs; the 12 steps are complete except STEP-06 (continuous golden fixtures) and STEP-12 (unit boundary, partly).
- Added a **"Remaining work (STEP-13+)"** section to `cellpy-core-integration-roadmap.md` enumerating the forward work surfaced from the design docs, each anchored to its source doc and tracked as its own cellpy-core issue.
- Fixed the stale "Implementation Flow" placeholder text (a mermaid diagram already existed) and refreshed the status-at-a-glance note.
- Recorded the plan/status under `.issueflows/03-solved-issues/`.

## Issues created from this review (cellpy-core)

- #40 — Finalize STEP-12 (core): promote `CellpyUnits` to a unit-spec module + converter-parity/pint-optional tests (actionable)
- #41 — Per-test metadata: add `test_id` to `StepCols`/`CycleCols` + composite group keys (actionable)
- #42 — Engine: reset-granularity normalization for cumulative raw inputs (future)
- #43 — Native schema: add `ref_potential`/`ref_voltage` support (future)
- #44 — Release: tag cellpy-core (and decide PyPI publish) (future)
- #45 — Cleanup (blocked): remove `create_selector`/`summary_selector_exluder` once cellpy migrates off

cellpy-side delegation work stays tracked on jepegit/cellpy.

## Test plan

- [x] Docs/tracking-only change; no source edits.
- [x] `uv run pytest` — 73 passed.

Closes #39

Made with [Cursor](https://cursor.com)