### PR TITLE
Add test_id to StepCols/CycleCols + composite group keys (#41)

### DIFF
--- a/.issueflows/03-solved-issues/issue41_original.md
+++ b/.issueflows/03-solved-issues/issue41_original.md
@@ -1,0 +1,22 @@
+# Issue #41: Per-test metadata: add test_id to StepCols/CycleCols + composite group keys
+
+Source: https://github.com/cellpy/cellpy-core/issues/41
+
+## Original issue text
+
+Forward work from `.issueflows/04-designs-and-guides/test-metadata-and-merging.md` ("Not yet implemented (needs its own issue)"). Enables a single `Data` object to hold many merged test files without silently mixing cycles across tests.
+
+## Scope (cellpy-core)
+
+- Add `test_id` to `config.StepCols` and `config.CycleCols` (it already exists on `RawCols`, `config.py:519`).
+- Group all per-step / per-cycle engine aggregation by the composite key `(test_id, cycle_num, step_num, ...)`, never `cycle_num` alone, so merged objects don't collide. Default `test_id = 0` for a single unmerged test (graceful, behaviour-preserving).
+- Keep goldens (STEP-06, `tests/test_golden.py`) byte-identical for the single-test fixture; add a synthetic merged-object test proving cross-test isolation.
+
+## Deferred (documented tail, NOT in this issue)
+
+Replacing the scalar `Data.meta_test_dependent` (`cell_core.py:26`, two `# TODO: v2.0` markers at `cell_core.py:115`/`:134`) with the keyed `TestMetaCollection` is the **v2.0 / consumer opt-in** move per `cellpy-core-migration.md` §4. The metadata scaffolding (`cellpycore.metadata`, STEP-10) already exists; this issue only lands the `test_id` plumbing into the table schemas + group keys.
+
+## Anchors
+
+- `test-metadata-and-merging.md` (decision: hybrid compact key + normalized TestMeta table).
+- Metadata scaffolding: STEP-10, `metadata-scaffolding.md`.

--- a/.issueflows/03-solved-issues/issue41_plan.md
+++ b/.issueflows/03-solved-issues/issue41_plan.md
@@ -1,0 +1,130 @@
+# Issue #41 plan — `test_id` in StepCols/CycleCols + composite group keys
+
+## Goal
+
+Thread `test_id` into the per-step (`StepCols`) and per-cycle (`CycleCols`) table
+schemas and make every per-step / per-cycle aggregation, cumulation and join key
+on the composite `(test_id, cycle_num, step_num, …)` instead of `cycle_num`
+alone, so a single merged `Data` holding many tests never mixes cycles across
+tests. Single-test behaviour (and all goldens) stay byte-identical.
+
+## Constraints
+
+- **Goldens byte-identical** (`tests/test_golden.py`): the arbin fixture has a
+  single `test_id == 1`, so grouping / `over` / joins that add `test_id` as a
+  constant leading key produce identical rows, order and values. The legacy
+  bridge output column-order lists (`_legacy_step_column_order`,
+  `_legacy_summary_column_order`) do **not** include `test_id`, so even though the
+  native frames now carry it, it is dropped from the legacy pandas output.
+- **Graceful default** (`test-metadata-and-merging.md`): when `raw` has no
+  `test_id` column, materialize it as constant `0` at engine entry so the step /
+  cycle tables always carry `test_id` (behaviour-preserving; equivalent to a
+  single unmerged test).
+- **Cross-frame consistency**: cross-frame joins (summary↔steps↔raw) key on
+  `test_id` **only when every frame involved carries it**. This keeps the legacy
+  *summary* bridge correct: there the rebuilt native `steps` lack `test_id`
+  (dropped by the step bridge) while native `raw` has it — so those joins fall
+  back to `cycle_num` only, exactly as today.
+- KISS: single cohesive feature, one PR. No metadata-class work (v2.0 tail is
+  explicitly deferred by the issue).
+
+### Prior art
+
+- `.issueflows/04-designs-and-guides/test-metadata-and-merging.md` — the decision
+  record (hybrid compact `raw.test_id` key + composite group keys). Directly drives
+  this plan.
+- `src/cellpycore/header_mapping.py` — `test_id` already declared `NATIVE_ONLY_RAW`
+  / `LEGACY_ONLY_RAW` (intentionally *not* raw-bridged). Same pattern reused for
+  step/cycle: add `test_id` to `NATIVE_ONLY_STEP` / `NATIVE_ONLY_CYCLE` (no legacy
+  counterpart), keeping the totality tests balanced.
+- `config.RawCols.test_id` (`config.py:519`) already exists — mirror its naming.
+- `.issueflows/00-tools/` — empty toolbox, nothing reusable. (toolbox + grep +
+  graph checked.)
+
+## Approach
+
+Add a tiny presence helper in `summarizers.py`:
+
+```python
+def _group_keys(frame, base_keys, test_id_col):
+    """Prepend test_id when the frame carries it, else the base keys unchanged."""
+    return ([test_id_col, *base_keys]
+            if test_id_col in frame.columns else list(base_keys))
+```
+
+and a `_ensure_test_id(raw, col)` that adds `pl.lit(0).alias(col)` when absent.
+
+Composite-key each stage:
+
+- **`make_step_table`** — `_ensure_test_id` on `raw`; prepend `nhdr.test_id` to the
+  group-by `by` list; extend the group-key rename to map `nhdr.test_id →
+  shdr.test_id` (no-op for native names). Result: native step table always carries
+  `test_id` as its leading column. `sort(by)` with a constant/single-value leading
+  key preserves current row order.
+- **`make_summary`** — `_ensure_test_id` on `raw`; compute
+  `use_tid = nhdr.test_id in raw and shdr.test_id in steps`.
+  - `finals` groups `steps` by `_group_keys(steps, [cycle], test_id)`.
+  - `selected` sorts by `[test_id, cycle]` when `use_tid`.
+  - carry `chdr.test_id` onto the summary (from raw) when `use_tid`.
+  - `charge_capacity_loss` / `discharge_capacity_loss` (`shift(1)`) and all
+    `test_cumulated_*` (`cum_sum`) become `.over(chdr.test_id)` when `use_tid`.
+  - `_add_end_potentials` groups steps and joins on
+    `[test_id, cycle]` when both frames carry `test_id`, else `cycle` only.
+- **`c_rates_to_summary`** — `_first_rate` groups `steps` by composite; join to
+  summary on the keys present in both (`[test_id, cycle]` or `[cycle]`).
+- **`extractors.LastIRExtractor` / `ir_to_summary`** — group `raw` by
+  `[test_id, cycle, step]` and `steps` by `[test_id, cycle]` when present; the
+  per-cycle frame carries `test_id` when the inputs do; `ir_to_summary` joins onto
+  the summary on the keys common to both the extractor output and the summary
+  (so custom extractors returning only `cycle_num`, e.g. the test `ConstIR`, still
+  work).
+
+Because the legacy step bridge drops `test_id` from its pandas output, the legacy
+*summary* bridge sees `steps` without `test_id` → `use_tid = False` everywhere →
+identical to today. Native callers get full per-test isolation.
+
+## Files to touch
+
+- `src/cellpycore/config.py` — add `test_id: str = "test_id"` as the **first**
+  field of `StepCols` and of `CycleCols`.
+- `src/cellpycore/summarizers.py` — `_ensure_test_id` + `_group_keys` helpers;
+  composite keys in `make_step_table`, `make_summary`, `_add_end_potentials`,
+  `c_rates_to_summary`.
+- `src/cellpycore/extractors.py` — composite grouping in `LastIRExtractor`;
+  presence-aware join in `ir_to_summary` (in `summarizers.py`).
+- `src/cellpycore/header_mapping.py` — add `"test_id"` to `NATIVE_ONLY_STEP` and
+  `NATIVE_ONLY_CYCLE` (keeps totality tests balanced).
+- `tests/test_config_columns.py` — prepend `test_id` to `STEP_EXPECTED` and
+  `CYCLE_EXPECTED`.
+- `docs/data_format_specifications/step_table.md`, `cycle_table.md` — add a
+  `test_id` row (first) to the column-header tables.
+- `tests/test_schema.py` — new merged-object isolation test (below).
+
+## Test strategy
+
+Command: activate the venv then `pytest` (or `uv run pytest`) from the repo root.
+
+- **Regression / parity (must stay green, unchanged):** `tests/test_golden.py`
+  (step + summary snapshots, cellpy cross-repo step-types), `test_header_mapping.py`
+  (totality), `test_config_columns.py`, `test_harmonized_fixture.py`,
+  `test_schema.py` (native no-`test_id` fixtures exercise the graceful fallback).
+- **New — cross-test isolation** (`test_schema.py`): build a native raw of two
+  `test_id`s (e.g. `0` and `1`) with **overlapping** `cycle_num`/`step_num`, run
+  `make_step_table` + `make_summary` (+ `c_rates` + `ir`). Assert:
+  - step-table row count == sum of both tests' step counts (no collapse across
+    tests sharing `(cycle_num, step_num)`);
+  - summary row count == sum of both tests' cycle counts;
+  - `test_cumulated_charge_capacity` restarts per `test_id` (test 1's first cycle
+    equals its own charge_capacity, not continuing test 0's cumulation);
+  - `charge_capacity_loss` first row of each test is null/independent.
+- **New — default fallback**: assert a raw *without* `test_id` yields tables whose
+  `test_id` column is all `0` (graceful default).
+
+## Open questions
+
+1. **Position of `test_id`** in `StepCols`/`CycleCols`: plan puts it **first**
+   (leading composite key, mirrors the `(test_id, cycle_num, …)` ordering in the
+   design doc). This fixes the spec-doc and `*_EXPECTED` ordering. OK? (Recommended.)
+2. **Always materialize `test_id=0`** when `raw` lacks it (so tables always carry
+   the column) vs. only carry it when present. Plan chooses **always materialize**
+   per the design doc ("tables should carry `test_id`", "default 0"). OK?

--- a/.issueflows/03-solved-issues/issue41_status.md
+++ b/.issueflows/03-solved-issues/issue41_status.md
@@ -1,0 +1,36 @@
+# Issue #41 status — test_id + composite group keys
+
+- [x] Done
+
+## What's done
+
+- `config.py`: added `test_id` as the leading field of `StepCols` and `CycleCols`.
+- `summarizers.py`: `_ensure_test_id` (default 0) + `_group_keys` helpers;
+  composite keys in `make_step_table` (group `by`), `make_summary` (finals,
+  sort, per-test `cum_sum`/`shift` via `.over(test_id)`, summary `test_id` col),
+  `_add_end_potentials`, `c_rates_to_summary`, and the `ir_to_summary` join.
+- `extractors.py`: `LastIRExtractor` groups/joins per `(test_id, cycle, step)`
+  when present, gracefully falling back to cycle-only otherwise.
+- `header_mapping.py`: `test_id` added to `NATIVE_ONLY_STEP` / `NATIVE_ONLY_CYCLE`
+  (kept out of the legacy step/summary bridge, mirroring the raw `test_id`).
+- Specs updated: `step_table.md`, `cycle_table.md` (leading `test_id` row).
+- Tests: `test_config_columns.py` expected lists updated; new `test_schema.py`
+  cases for merged-object step/summary isolation and the default-0 fallback.
+
+### Design note (cross-frame consistency)
+
+Cross-frame joins use `test_id` only when **all** involved frames carry it. This
+keeps the legacy *summary* bridge (rebuilt native steps lack `test_id`) on the
+cycle-only path = byte-identical to before. The single-test goldens
+(`arbin_cc`, `test_id == 1`) are unchanged.
+
+### Behaviour change caught by a fixture
+
+`arbin_small_raw.parquet` is actually a merged object with three `test_id`s
+(1, 2, 3) sharing `(cycle, step)`. The old engine collapsed them to 3 steps; the
+composite key correctly yields 7. `test_small_step_table_runs_on_real_data`
+updated accordingly (this is the bug the issue fixes, on real data).
+
+## Remaining work
+
+- None. Full suite green (88 passed). Ready for `/iflow-close`.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,5 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Add `test_id` to `StepCols`/`CycleCols` and key all per-step/per-cycle aggregation,
+  cumulation, and joins on the composite `(test_id, cycle_num, step_num, …)` so a
+  merged `Data` holding many tests never mixes cycles across tests (default `test_id=0`
+  for a single unmerged test; single-test goldens stay byte-identical) (#41).
 - Promote `CellpyUnits` into `cellpycore.units` (first-class unit-spec module) with a
   `legacy.py` re-export, plus converter-parity and pint-optional guard tests (STEP-12, #40).

--- a/docs/data_format_specifications/cycle_table.md
+++ b/docs/data_format_specifications/cycle_table.md
@@ -9,6 +9,7 @@ Date: 2025-09-08
 
 | Column name | Data type | Unit | Sample data | Description |
 | --- | --- | --- | --- | --- |
+| test_id | int | - | 0 | Per-test key (leading component of the composite `(test_id, cycle_num, …)` group key); `0` for a single unmerged test |
 | cycle_num | int | - | 12 | Cycle number |
 | mask | boolean | - | True | Selection flag; default True (row is selected / used) |
 | datapoint_num_first | int | - | 123 | First datapoint number in cycle |

--- a/docs/data_format_specifications/step_table.md
+++ b/docs/data_format_specifications/step_table.md
@@ -17,6 +17,7 @@ calculations and to classify steps.
 
 | Column name | Data type | Unit | Sample data | Description |
 | --- | --- | --- | --- | --- |
+| test_id | int | - | 0 | Per-test key (leading component of the composite `(test_id, cycle_num, step_num, …)` group key); `0` for a single unmerged test |
 | cycle_num | int | - | 12 | Cycle number |
 | step_num | int | - | 123 | Step number |
 | sub_step_num | int | - | 123 | Sub-step number |

--- a/src/cellpycore/config.py
+++ b/src/cellpycore/config.py
@@ -284,6 +284,11 @@ class CycleCols(Cols):
     durations, per-direction current/potential/power statistics, etc.).
     """
 
+    # Compact per-test key (mirrors ``RawCols.test_id``); the leading component of
+    # the composite ``(test_id, cycle_num, …)`` group key so merged objects
+    # holding many tests never mix cycles across tests. Defaults to ``0`` for a
+    # single unmerged test.
+    test_id: str = "test_id"
     cycle_num: str = "cycle_num"
     mask: str = "mask"
     datapoint_num_first: str = "datapoint_num_first"
@@ -413,6 +418,11 @@ class StepCols(Cols):
     resistance, plus the per-step C-rate estimate).
     """
 
+    # Compact per-test key (mirrors ``RawCols.test_id``); the leading component of
+    # the composite ``(test_id, cycle_num, step_num, …)`` group key so merged
+    # objects holding many tests never mix cycles/steps across tests. Defaults to
+    # ``0`` for a single unmerged test.
+    test_id: str = "test_id"
     cycle_num: str = "cycle_num"
     step_num: str = "step_num"
     sub_step_num: str = "sub_step_num"

--- a/src/cellpycore/extractors.py
+++ b/src/cellpycore/extractors.py
@@ -93,31 +93,64 @@ class LastIRExtractor(SummaryExtractor):
         headers_steps = schema.step
         headers_cycle = schema.cycle
 
+        # Group per (test, cycle, step) when the frames carry a ``test_id`` key so
+        # merged objects never mix steps/cycles across tests; otherwise fall back
+        # to (cycle, step), byte-identical to the single-test path.
+        use_tid = (
+            headers_raw.test_id in raw.columns
+            and headers_steps.test_id in steps.columns
+        )
+        raw_step_keys = (
+            [headers_raw.test_id, headers_raw.cycle_num, headers_raw.step_num]
+            if use_tid
+            else [headers_raw.cycle_num, headers_raw.step_num]
+        )
+        step_group_keys = (
+            [headers_steps.test_id, headers_steps.cycle_num]
+            if use_tid
+            else [headers_steps.cycle_num]
+        )
+
         # internal resistance of the last raw datapoint of each (cycle, step).
         # maintain_order (no sort) mirrors the raw frame's natural acquisition
         # order, so ``last`` is the chronologically last reading of the step.
-        ir_per_step = raw.group_by(
-            [headers_raw.cycle_num, headers_raw.step_num], maintain_order=True
-        ).agg(pl.col(headers_raw.internal_resistance).last().alias("__ir"))
+        ir_per_step = raw.group_by(raw_step_keys, maintain_order=True).agg(
+            pl.col(headers_raw.internal_resistance).last().alias("__ir")
+        )
 
         def _side(step_type: str, out_name: str) -> "pl.DataFrame":
             last_step = (
                 steps.filter(pl.col(headers_steps.step_type) == step_type)
-                .group_by(headers_steps.cycle_num, maintain_order=True)
+                .group_by(step_group_keys, maintain_order=True)
                 .agg(pl.col(headers_steps.step_num).last().alias("__step"))
             )
-            return last_step.join(
-                ir_per_step,
-                left_on=[headers_steps.cycle_num, "__step"],
-                right_on=[headers_raw.cycle_num, headers_raw.step_num],
-                how="left",
-            ).select(
+            left_keys = (
+                [headers_steps.test_id, headers_steps.cycle_num, "__step"]
+                if use_tid
+                else [headers_steps.cycle_num, "__step"]
+            )
+            select_exprs = [
                 pl.col(headers_steps.cycle_num).alias(headers_cycle.cycle_num),
                 pl.col("__ir").alias(out_name),
-            )
+            ]
+            if use_tid:
+                select_exprs.insert(
+                    0, pl.col(headers_steps.test_id).alias(headers_cycle.test_id)
+                )
+            return last_step.join(
+                ir_per_step,
+                left_on=left_keys,
+                right_on=raw_step_keys,
+                how="left",
+            ).select(select_exprs)
 
         ir_charge = _side("charge", headers_cycle.ir_charge)
         ir_discharge = _side("discharge", headers_cycle.ir_discharge)
+        join_on = (
+            [headers_cycle.test_id, headers_cycle.cycle_num]
+            if use_tid
+            else headers_cycle.cycle_num
+        )
         return ir_charge.join(
-            ir_discharge, on=headers_cycle.cycle_num, how="full", coalesce=True
+            ir_discharge, on=join_on, how="full", coalesce=True
         )

--- a/src/cellpycore/header_mapping.py
+++ b/src/cellpycore/header_mapping.py
@@ -148,9 +148,13 @@ NATIVE_ONLY_RAW = frozenset({
 LEGACY_ONLY_STEP = frozenset({"test", "ustep", "info", "ir_pct_change"})
 
 # Native StepCols *signals* with no legacy counterpart (power / energy
-# statistics, and the boolean ``mask``). Compared at base-signal granularity,
-# i.e. after stripping the ``STAT_SUFFIXES`` from statistic columns.
-NATIVE_ONLY_STEP = frozenset({"power", "charge_energy", "discharge_energy", "mask"})
+# statistics, the boolean ``mask``, and the per-test ``test_id`` key). Compared at
+# base-signal granularity, i.e. after stripping the ``STAT_SUFFIXES`` from
+# statistic columns. ``test_id`` is intentionally not step-bridged (it is dropped
+# from the legacy step table), matching the raw-bridge treatment of ``test_id``.
+NATIVE_ONLY_STEP = frozenset(
+    {"power", "charge_energy", "discharge_energy", "mask", "test_id"}
+)
 
 # Legacy HeadersSummary column values with no native CycleCols counterpart
 # (legacy-only cruft: cumulated CE, shifted / RIC capacities, OCV mins/maxes,
@@ -166,7 +170,10 @@ LEGACY_ONLY_CYCLE = frozenset({
 })
 
 # Native CycleCols column values with no legacy HeadersSummary counterpart.
+# (``test_id`` is the per-test key; intentionally not summary-bridged, so it is
+# dropped from the legacy summary table like the raw/step ``test_id``.)
 NATIVE_ONLY_CYCLE = frozenset({
+    "test_id",
     "mask", "datapoint_num_first", "first_epoch_time_utc", "last_epoch_time_utc",
     "first_test_time", "cycle_duration", "charge_duration", "discharge_duration",
     "rest_duration", "test_net_capacity", "charge_energy", "discharge_energy",

--- a/src/cellpycore/summarizers.py
+++ b/src/cellpycore/summarizers.py
@@ -52,6 +52,31 @@ _SIGNAL_BASES = (
 )
 
 
+def _ensure_test_id(frame: "pl.DataFrame", test_id_col: str) -> "pl.DataFrame":
+    """Return ``frame`` with a ``test_id`` column, defaulting to ``0`` when absent.
+
+    A single unmerged test has no explicit ``test_id``; materializing a constant
+    ``0`` keeps the step/cycle tables carrying the key (and the composite group
+    keys well-defined) while being behaviour-preserving.
+    """
+    if test_id_col in frame.columns:
+        return frame
+    return frame.with_columns(pl.lit(0, dtype=pl.Int64).alias(test_id_col))
+
+
+def _group_keys(frame: "pl.DataFrame", base_keys: list, test_id_col: str) -> list:
+    """Prepend ``test_id`` to ``base_keys`` when ``frame`` carries that column.
+
+    Grouping / joining on the composite ``(test_id, …)`` key isolates cycles and
+    steps across merged tests. Frames without a ``test_id`` column (e.g. the
+    rebuilt native steps inside the legacy summary bridge) fall back to the base
+    keys, reproducing the pre-merge single-test behaviour exactly.
+    """
+    if test_id_col in frame.columns:
+        return [test_id_col, *base_keys]
+    return list(base_keys)
+
+
 def _delta_expr(base: str) -> pl.Expr:
     """Per-step delta in percent (mirrors legacy cellpy's ``delta``).
 
@@ -231,6 +256,10 @@ def make_step_table(
     if not isinstance(raw, pl.DataFrame):
         raw = pl.from_pandas(raw)
 
+    # Ensure a per-test key so the step table always carries ``test_id`` and the
+    # group key is composite (``0`` for a single unmerged test).
+    raw = _ensure_test_id(raw, nhdr.test_id)
+
     if from_data_point is not None:
         raw = raw.filter(pl.col(nhdr.datapoint_num) >= from_data_point)
 
@@ -264,7 +293,7 @@ def make_step_table(
         logging.debug(f"omitting steps {skip_steps}")
         raw = raw.filter(~pl.col(nhdr.step_num).is_in(skip_steps))
 
-    by = [nhdr.cycle_num, nhdr.step_num, sub_col]
+    by = [nhdr.test_id, nhdr.cycle_num, nhdr.step_num, sub_col]
     if usteps:
         raw = raw.with_columns(
             (pl.col(nhdr.step_num).diff().fill_null(1) != 0)
@@ -319,13 +348,14 @@ def make_step_table(
         )
 
     # Rename group-key columns to the (native) step schema names.
-    steps = steps.rename(
-        {
-            nhdr.cycle_num: shdr.cycle_num,
-            nhdr.step_num: shdr.step_num,
-            sub_col: shdr.sub_step_num,
-        }
-    )
+    rename_keys = {
+        nhdr.cycle_num: shdr.cycle_num,
+        nhdr.step_num: shdr.step_num,
+        sub_col: shdr.sub_step_num,
+    }
+    if nhdr.test_id != shdr.test_id:
+        rename_keys[nhdr.test_id] = shdr.test_id
+    steps = steps.rename(rename_keys)
 
     if sort_rows and "test_time_first" in steps.columns:
         logger.debug("sorting the step rows")
@@ -346,17 +376,26 @@ def _add_end_potentials(summary: "pl.DataFrame", steps: "pl.DataFrame", schema: 
     shdr, chdr = schema.step, schema.cycle
     steps_sorted = steps.sort(shdr.test_time_first)
 
+    group_keys = _group_keys(steps, [shdr.cycle_num], shdr.test_id)
+    # Join on the per-test key too, but only when the summary also carries it
+    # (aligned with the step frame; see ``use_tid`` in ``make_summary``).
+    join_on = (
+        [chdr.test_id, chdr.cycle_num]
+        if shdr.test_id in steps.columns and chdr.test_id in summary.columns
+        else [chdr.cycle_num]
+    )
+
     def _end(prefix: str, out_name: str) -> "pl.DataFrame":
         return (
             steps_sorted.filter(pl.col(shdr.step_type).str.starts_with(prefix))
-            .group_by(shdr.cycle_num, maintain_order=True)
+            .group_by(group_keys, maintain_order=True)
             .agg(pl.col(shdr.potential_last).last().alias(out_name))
         )
 
     discharge_end = _end("discharge", chdr.potential_end_discharge)
     charge_end = _end("charge", chdr.potential_end_charge)
-    summary = summary.join(discharge_end, on=chdr.cycle_num, how="left")
-    summary = summary.join(charge_end, on=chdr.cycle_num, how="left")
+    summary = summary.join(discharge_end, on=join_on, how="left")
+    summary = summary.join(charge_end, on=join_on, how="left")
     return summary
 
 
@@ -404,26 +443,46 @@ def make_summary(
     if not isinstance(steps, pl.DataFrame):
         steps = pl.from_pandas(steps)
 
+    raw = _ensure_test_id(raw, nhdr.test_id)
+
+    # Use the per-test key only when both the raw and the step frames carry it, so
+    # cumulations/joins stay isolated per test. When the step frame lacks it (e.g.
+    # the rebuilt native steps in the legacy summary bridge), fall back to
+    # cycle-only behaviour, byte-identical to the single-test path.
+    use_tid = nhdr.test_id in raw.columns and shdr.test_id in steps.columns
+
     # cycle-end datapoint per cycle = the last step's last datapoint
     if final_data_points is None:
         finals = (
             steps.sort(shdr.datapoint_num_last)
-            .group_by(shdr.cycle_num, maintain_order=True)
+            .group_by(
+                _group_keys(steps, [shdr.cycle_num], shdr.test_id),
+                maintain_order=True,
+            )
             .agg(pl.col(shdr.datapoint_num_last).last().alias("__fp"))
         )
         final_data_points = finals["__fp"].to_list()
 
+    sort_keys = [nhdr.test_id, nhdr.cycle_num] if use_tid else [nhdr.cycle_num]
     selected = raw.filter(
         pl.col(nhdr.datapoint_num).is_in(list(final_data_points))
-    ).sort(nhdr.cycle_num)
+    ).sort(sort_keys)
 
-    summary = selected.select(
+    select_exprs = [
         pl.col(nhdr.cycle_num).alias(chdr.cycle_num),
         pl.col(nhdr.datapoint_num).alias(chdr.datapoint_num_last),
         pl.col(nhdr.test_time).alias(chdr.last_test_time),
         pl.col(nhdr.cumulative_charge_capacity).alias(chdr.charge_capacity),
         pl.col(nhdr.cumulative_discharge_capacity).alias(chdr.discharge_capacity),
-    )
+    ]
+    if use_tid:
+        select_exprs.insert(0, pl.col(nhdr.test_id).alias(chdr.test_id))
+    summary = selected.select(select_exprs)
+
+    # Per-test cumulations / shifts: window over ``test_id`` so a merged object
+    # never carries capacity/CE from one test into the next.
+    def _per_test(expr: pl.Expr) -> pl.Expr:
+        return expr.over(chdr.test_id) if use_tid else expr
 
     cc = pl.col(chdr.charge_capacity)
     dc = pl.col(chdr.discharge_capacity)
@@ -439,21 +498,21 @@ def make_summary(
     summary = summary.with_columns(
         coulombic_efficiency,
         coulombic_difference,
-        (cc.shift(1) - cc).alias(chdr.charge_capacity_loss),
-        (dc.shift(1) - dc).alias(chdr.discharge_capacity_loss),
+        (_per_test(cc.shift(1)) - cc).alias(chdr.charge_capacity_loss),
+        (_per_test(dc.shift(1)) - dc).alias(chdr.discharge_capacity_loss),
     )
     summary = summary.with_columns(
-        cc.cum_sum().alias(chdr.test_cumulated_charge_capacity),
-        dc.cum_sum().alias(chdr.test_cumulated_discharge_capacity),
-        pl.col(chdr.coulombic_difference)
-        .cum_sum()
-        .alias(chdr.test_cumulated_coulombic_difference),
-        pl.col(chdr.charge_capacity_loss)
-        .cum_sum()
-        .alias(chdr.test_cumulated_charge_capacity_loss),
-        pl.col(chdr.discharge_capacity_loss)
-        .cum_sum()
-        .alias(chdr.test_cumulated_discharge_capacity_loss),
+        _per_test(cc.cum_sum()).alias(chdr.test_cumulated_charge_capacity),
+        _per_test(dc.cum_sum()).alias(chdr.test_cumulated_discharge_capacity),
+        _per_test(pl.col(chdr.coulombic_difference).cum_sum()).alias(
+            chdr.test_cumulated_coulombic_difference
+        ),
+        _per_test(pl.col(chdr.charge_capacity_loss).cum_sum()).alias(
+            chdr.test_cumulated_charge_capacity_loss
+        ),
+        _per_test(pl.col(chdr.discharge_capacity_loss).cum_sum()).alias(
+            chdr.test_cumulated_discharge_capacity_loss
+        ),
     )
 
     summary = _add_end_potentials(summary, steps, schema)
@@ -648,12 +707,28 @@ def c_rates_to_summary(
             summary, schema, normalization_cycles, step_txt
         )
 
+    group_keys = _group_keys(steps, [headers_steps.cycle_num], headers_steps.test_id)
+    use_tid = (
+        headers_steps.test_id in steps.columns
+        and headers_summary.test_id in summary.columns
+    )
+    left_on = (
+        [headers_summary.test_id, headers_summary.cycle_num]
+        if use_tid
+        else [headers_summary.cycle_num]
+    )
+    right_on = (
+        [headers_steps.test_id, headers_steps.cycle_num]
+        if use_tid
+        else [headers_steps.cycle_num]
+    )
+
     def _first_rate(step_type: str, out_name: str) -> "pl.DataFrame":
-        # First step of the given type per cycle (mirrors legacy drop_duplicates
-        # keep="first" on the step-table row order).
+        # First step of the given type per (test, cycle) (mirrors legacy
+        # drop_duplicates keep="first" on the step-table row order).
         return (
             steps.filter(pl.col(headers_steps.step_type) == step_type)
-            .group_by(headers_steps.cycle_num, maintain_order=True)
+            .group_by(group_keys, maintain_order=True)
             .agg(pl.col(headers_steps.c_rate).first().alias(out_name))
             .with_columns(
                 (pl.col(out_name) / nom_cap * current_conversion_factor).alias(out_name)
@@ -663,18 +738,8 @@ def c_rates_to_summary(
     charge = _first_rate("charge", headers_summary.charge_c_rate)
     discharge = _first_rate("discharge", headers_summary.discharge_c_rate)
 
-    summary = summary.join(
-        charge,
-        left_on=headers_summary.cycle_num,
-        right_on=headers_steps.cycle_num,
-        how="left",
-    )
-    summary = summary.join(
-        discharge,
-        left_on=headers_summary.cycle_num,
-        right_on=headers_steps.cycle_num,
-        how="left",
-    )
+    summary = summary.join(charge, left_on=left_on, right_on=right_on, how="left")
+    summary = summary.join(discharge, left_on=left_on, right_on=right_on, how="left")
     data.summary = summary
     return data
 
@@ -724,7 +789,13 @@ def ir_to_summary(
 
     per_cycle = ir_extractor(raw=raw, steps=steps, summary=summary, schema=schema)
 
-    summary = summary.join(per_cycle, on=headers_summary.cycle_num, how="left")
+    join_on = (
+        [headers_summary.test_id, headers_summary.cycle_num]
+        if headers_summary.test_id in per_cycle.columns
+        and headers_summary.test_id in summary.columns
+        else headers_summary.cycle_num
+    )
+    summary = summary.join(per_cycle, on=join_on, how="left")
     # Missing IR (e.g. a cycle without a charge/discharge step) stays NaN rather
     # than the legacy 0.0, so "no measurement" is distinguishable from a real 0.
     summary = summary.with_columns(

--- a/tests/test_config_columns.py
+++ b/tests/test_config_columns.py
@@ -34,6 +34,7 @@ RAW_EXPECTED = [
 
 # --- step_table.md ----------------------------------------------------------
 STEP_EXPECTED = [
+    "test_id",
     "cycle_num", "step_num", "sub_step_num", "step_type", "sub_step_type", "mask",
     "datapoint_num_first", "datapoint_num_last", "test_time_first", "test_time_last",
     *_aggregates("step_time"),
@@ -46,6 +47,7 @@ STEP_EXPECTED = [
 
 # --- cycle_table.md ---------------------------------------------------------
 CYCLE_EXPECTED = [
+    "test_id",
     "cycle_num", "mask", "datapoint_num_first", "datapoint_num_last",
     "first_epoch_time_utc", "last_epoch_time_utc", "first_test_time",
     "last_test_time", "cycle_duration", "charge_duration", "discharge_duration",

--- a/tests/test_golden.py
+++ b/tests/test_golden.py
@@ -160,16 +160,18 @@ def test_arbin_step_types_match_cellpy_reference():
 
 @pytest.mark.skipif(not ARBIN_SMALL_RAW.is_file(), reason="small fixture missing")
 def test_small_step_table_runs_on_real_data():
-    """Smoke test: a tiny (47-row, 3-step) real raw frame flows through the engine.
+    """Smoke test: a tiny real raw frame flows through the engine.
 
-    Note: this fixture's ``step 2`` is a degenerate synthetic slice (non-monotonic
-    duplicated ``data_point``, mixed current signs, zero capacity-delta), so the
-    engine leaves its ``type`` blank. That matches legacy cellpy classification and
-    is a fixture artifact, not an engine defect; we only assert the structural
-    result here.
+    This fixture is actually a *merged* object holding three ``test_id`` values
+    (1, 2, 3), all at ``cycle_index == 1`` with overlapping ``step_index``. With
+    the composite ``(test_id, cycle_num, step_num)`` group key (issue #41) the
+    steps of the three tests stay isolated instead of collapsing on the shared
+    ``(cycle, step)`` pairs: test 1 has 1 step, tests 2 and 3 have 3 steps each,
+    so 7 step rows in total. (Before the composite key this incorrectly returned
+    3 rows.)
     """
     schema = _legacy_schema()
     steps = _step_table(ARBIN_SMALL_RAW)
-    assert len(steps) == 3
+    assert len(steps) == 7
     assert schema.step.type in steps.columns
     assert int(steps[schema.step.cycle].max()) == 1

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -419,3 +419,115 @@ def test_native_add_scaled_summary_columns_end_to_end():
     grav = data.summary[f"{chdr.charge_capacity}_gravimetric"].to_list()
     for b, g in zip(base, grav):
         assert g == pytest.approx(10.0 * b)
+
+
+# --- issue #41: per-test key + composite group keys -------------------------
+def _build_merged_raw(nhdr: RawCols) -> pd.DataFrame:
+    """Two tests (test_id 0 and 1) with **overlapping** cycle_num/step_num.
+
+    Each test has 2 cycles; each cycle is charge (step 1, cc 0.1..0.5) then
+    discharge (step 2, dc 0.08..0.4, cc held 0.5). ``datapoint_num`` stays globally
+    unique across the merged object; ``(cycle_num, step_num)`` collide across
+    tests, so anything keyed on cycle alone would mix them.
+    """
+    records = []
+    dp = 0
+    for test_id in (0, 1):
+        # slightly different capacities per test so cross-test leakage is visible
+        scale = 1.0 if test_id == 0 else 2.0
+        for cyc in (1, 2):
+            for k in range(5):  # charge
+                records.append({
+                    nhdr.test_id: test_id, nhdr.datapoint_num: dp,
+                    nhdr.test_time: float(dp), nhdr.step_time: float(k),
+                    nhdr.step_num: 1, nhdr.cycle_num: cyc,
+                    nhdr.current: 1.0, nhdr.potential: 3.5 + 0.01 * k,
+                    nhdr.cumulative_charge_capacity: scale * 0.1 * (k + 1),
+                    nhdr.cumulative_discharge_capacity: 0.0,
+                    nhdr.internal_resistance: 0.0,
+                })
+                dp += 1
+            for k in range(5):  # discharge
+                records.append({
+                    nhdr.test_id: test_id, nhdr.datapoint_num: dp,
+                    nhdr.test_time: float(dp), nhdr.step_time: float(k),
+                    nhdr.step_num: 2, nhdr.cycle_num: cyc,
+                    nhdr.current: -1.0, nhdr.potential: 3.9 - 0.01 * k,
+                    nhdr.cumulative_charge_capacity: scale * 0.5,
+                    nhdr.cumulative_discharge_capacity: scale * 0.08 * (k + 1),
+                    nhdr.internal_resistance: 0.0,
+                })
+                dp += 1
+    return pd.DataFrame(records)
+
+
+def test_merged_object_step_table_isolated_per_test():
+    """A merged object (2 tests, overlapping cycle/step) keeps every step row.
+
+    Without the composite ``(test_id, cycle_num, step_num)`` key the four
+    colliding (cycle, step) pairs shared by the two tests would collapse.
+    """
+    nhdr = RawCols()
+    schema = _native_schema()
+    shdr = schema.step
+
+    data = Data()
+    data.raw = _build_merged_raw(nhdr)
+    summarizers.make_step_table(data, schema=schema, nom_cap=1.0)
+    steps = data.steps
+
+    # 2 tests * 2 cycles * 2 steps = 8 rows, and test_id present with both tests.
+    assert steps.height == 8
+    assert set(steps[shdr.test_id].to_list()) == {0, 1}
+    # each (test_id, cycle_num, step_num) triple is unique (no cross-test collapse)
+    key = steps.select(shdr.test_id, shdr.cycle_num, shdr.step_num)
+    assert key.n_unique() == 8
+
+
+def test_merged_object_summary_cumulation_resets_per_test():
+    """Per-cycle cumulations restart at each test; no capacity leaks across tests."""
+    nhdr = RawCols()
+    schema = _native_schema()
+    chdr = schema.cycle
+
+    data = Data()
+    data.raw = _build_merged_raw(nhdr)
+    summarizers.make_step_table(data, schema=schema, nom_cap=1.0)
+    summarizers.make_summary(data, schema=schema)
+    s = data.summary.sort([chdr.test_id, chdr.cycle_num])
+
+    # 2 tests * 2 cycles = 4 rows.
+    assert s.height == 4
+    assert s[chdr.test_id].to_list() == [0, 0, 1, 1]
+
+    cc = s[chdr.charge_capacity].to_list()
+    cum = s[chdr.test_cumulated_charge_capacity].to_list()
+    loss = s[chdr.charge_capacity_loss].to_list()
+
+    # test 0: cc = [0.5, 0.5]; test 1: cc = [1.0, 1.0] (scale 2x)
+    assert cc == pytest.approx([0.5, 0.5, 1.0, 1.0])
+    # cumulation restarts per test: first cycle of each test == its own cc
+    assert cum[0] == pytest.approx(cc[0])           # test 0, cycle 1
+    assert cum[1] == pytest.approx(cc[0] + cc[1])   # test 0, cycle 2
+    assert cum[2] == pytest.approx(cc[2])           # test 1, cycle 1 -> RESET
+    assert cum[3] == pytest.approx(cc[2] + cc[3])   # test 1, cycle 2
+    # first-cycle capacity loss is null within each test (shift is per-test)
+    import math
+    assert loss[0] is None or math.isnan(loss[0])
+    assert loss[2] is None or math.isnan(loss[2])
+
+
+def test_single_test_defaults_test_id_to_zero():
+    """A raw frame without test_id yields tables whose test_id column is all 0."""
+    nhdr = RawCols()
+    schema = _native_schema()
+    shdr, chdr = schema.step, schema.cycle
+
+    data = _data_with_raw(nhdr)  # _build_raw has no test_id column
+    assert nhdr.test_id not in data.raw.columns
+
+    summarizers.make_step_table(data, schema=schema, nom_cap=1.0)
+    summarizers.make_summary(data, schema=schema)
+
+    assert set(data.steps[shdr.test_id].to_list()) == {0}
+    assert set(data.summary[chdr.test_id].to_list()) == {0}


### PR DESCRIPTION
## Summary

Threads the per-test key `test_id` (already on `RawCols`) into the per-step
(`StepCols`) and per-cycle (`CycleCols`) table schemas and switches all
per-step/per-cycle aggregation, cumulation, and joins from `cycle_num` alone to
the composite `(test_id, cycle_num, step_num, …)` key. A single merged `Data`
can now hold many test files without silently mixing cycles/steps across tests.

- `config.py`: `test_id` is the leading field of `StepCols`/`CycleCols`.
- `summarizers.py`: `_ensure_test_id` (default `0` when absent) + `_group_keys`;
  composite keys in `make_step_table`, `make_summary` (per-test `cum_sum`/`shift`
  via `.over(test_id)`), `_add_end_potentials`, `c_rates_to_summary`, and the
  `ir_to_summary` join.
- `extractors.py`: `LastIRExtractor` groups/joins per `(test_id, cycle, step)`
  when present, cycle-only fallback otherwise.
- `header_mapping.py`: `test_id` added to `NATIVE_ONLY_STEP`/`NATIVE_ONLY_CYCLE`
  (kept out of the legacy step/summary bridge, like the raw `test_id`).
- Format specs (`step_table.md`, `cycle_table.md`) and tests updated.

### Design / back-compat

- Cross-frame joins use `test_id` only when **every** involved frame carries it,
  so the legacy summary bridge (rebuilt native steps drop `test_id`) stays on the
  cycle-only path and the single-test goldens (`arbin_cc`, `test_id == 1`) remain
  **byte-identical**.
- Default `test_id = 0` is materialized when raw lacks the column, so the step/
  cycle tables always carry it (behaviour-preserving for a single unmerged test).
- The `arbin_small_raw` fixture is actually a merged object with three `test_id`s
  sharing `(cycle, step)`; the composite key correctly yields 7 step rows instead
  of the previously cross-test-collapsed 3 (its smoke test is updated).

### Deferred (per the issue)

Replacing the scalar `Data.meta_test_dependent` with a keyed `TestMetaCollection`
is the v2.0 / consumer opt-in move and is **not** in this PR.

## Test plan

- [x] `pytest` — full suite green (88 passed).
- [x] Single-test step/summary goldens byte-identical (`test_golden.py`).
- [x] New `test_schema.py` cases: merged-object step + summary isolation, per-test
  cumulation reset, and default-`0` fallback.
- [x] Header-mapping totality + config-column spec tests updated and passing.

Closes #41

Made with [Cursor](https://cursor.com)