### PR TITLE
Add reset-granularity normalization for cumulative raw capacity inputs

### DIFF
--- a/.issueflows/03-solved-issues/issue42_original.md
+++ b/.issueflows/03-solved-issues/issue42_original.md
@@ -1,0 +1,19 @@
+# Issue #42: Engine: reset-granularity normalization for cumulative raw inputs
+
+Source: https://github.com/cellpy/cellpy-core/issues/42
+
+## Original issue text
+
+Deferred follow-up recorded in `.issueflows/04-designs-and-guides/step-table-polars-migration.md` ("Reset-granularity normalization ... a deliberate future follow-up, not done now").
+
+## Context
+
+The harmonized raw capacity columns (`cumulative_charge_capacity` / `cumulative_discharge_capacity`) mandate **cycle-cumulative** semantics (per cycle, per direction, reset at each cycle boundary). The summary path depends on this (it reads the cycle's last raw datapoint as that cycle's capacity).
+
+## Scope
+
+- Add an engine normalization step that also accepts **step-cumulative** and **test-cumulative** raw from other cyclers and normalizes them to the cycle-cumulative convention before aggregation.
+- Keep cycle-cumulative inputs a no-op; goldens (STEP-06) unchanged.
+- Add fixtures/tests for the non-cycle-cumulative input variants.
+
+Lower priority: only the cycle-cumulative Arbin path is exercised today.

--- a/.issueflows/03-solved-issues/issue42_plan.md
+++ b/.issueflows/03-solved-issues/issue42_plan.md
@@ -1,0 +1,85 @@
+# Issue #42 plan — reset-granularity normalization for cumulative raw inputs
+
+## Goal
+
+Let the engine accept raw capacity/energy columns that are **step-cumulative** or
+**test-cumulative** and normalize them to the mandated **cycle-cumulative** convention
+before aggregation. Cycle-cumulative input stays an exact no-op (goldens unchanged).
+
+## Constraints
+
+- Cycle-cumulative is the mandated raw convention (`harmonized_raw.md` §Capacity convention,
+  `step-table-polars-migration.md` issue #13). Only cycle-cumulative Arbin path is exercised
+  today → keep it byte-identical.
+- Engine is polars-native, schema-injected, thread-safe (no module globals). Match that.
+- No auto-detection of granularity (fragile). Caller declares it explicitly; default = cycle.
+- KISS: one small function + one enum + tests. No new module.
+
+### Prior art
+- `summarizers._ensure_test_id` / `_group_keys` (module `summarizers.py`) — reuse for the
+  per-test composite grouping. Mirror convention.
+- `summarizers.make_step_table` / `make_summary` — both read the four `cumulative_*` raw
+  columns (`RawCols.cumulative_charge/discharge_capacity`, `..._energy`). The normalized frame
+  must feed both.
+- Enum style: `config.TestMode` / `StepType` (StrEnum) — mirror for the new granularity enum.
+- Toolbox `.issueflows/00-tools/` — empty, nothing to reuse.
+- Mock builders: `tests/test_schema.py::_build_cumulative_raw` (cycle-cumulative oracle) —
+  base the step/test-cumulative fixtures on it.
+
+## Approach
+
+**Granularity-agnostic reconstruction** (works uniformly, no reset-point sniffing):
+
+For each present cumulative column, ordered by `datapoint_num`:
+1. `increment(row) = value - value(prev row in the source-granularity reset group)`, with the
+   first row of each source group = its own value. Source reset group:
+   - `STEP`  → `(test_id, cycle_num, step_num)`
+   - `CYCLE` → `(test_id, cycle_num)`  (target; identity)
+   - `TEST`  → `(test_id)`
+2. `cycle_cumulative = increment.cum_sum().over((test_id, cycle_num))` (target reset boundary).
+
+This is exact for all three inputs and provably identity for `CYCLE` (reconstruct per-cycle
+diffs, re-accumulate per cycle = original). Direction-agnostic: an inactive-direction column
+that holds constant or zeros contributes zero increments, so prior accumulation is preserved.
+Uses polars `diff`/`cum_sum` `over(...)` window expressions (fast, thread-safe).
+
+**Where it lives:** a standalone engine step `normalize_capacity_granularity(data, schema, granularity)`
+in `summarizers.py` that rewrites `data.raw` in place and returns `data`. Running it once
+up front means both `make_step_table` and `make_summary` consume the normalized raw. When
+`granularity == CYCLE` it returns `data` untouched (no frame rewrite → goldens byte-stable).
+
+**Columns:** normalize whichever of the four `cumulative_*` columns are present
+(`RawCols.cumulative_charge_capacity`, `cumulative_discharge_capacity`,
+`cumulative_charge_energy`, `cumulative_discharge_energy`). Missing ones skipped.
+
+## Files to touch
+
+- `src/cellpycore/config.py` — add `ResetGranularity(StrEnum)` with `CYCLE`/`STEP`/`TEST`
+  (Google docstring; note cycle = the mandated raw convention / default).
+- `src/cellpycore/summarizers.py` — add `normalize_capacity_granularity(data, schema=None,
+  granularity=ResetGranularity.CYCLE)`; reuse `_ensure_test_id` + composite keys; polars
+  window impl; pandas-in → pandas-out convenience like the sibling functions.
+- `tests/test_schema.py` — add fixtures `_build_step_cumulative_raw` /
+  `_build_test_cumulative_raw` (same underlying increments as `_build_cumulative_raw`) and
+  tests: STEP→cycle and TEST→cycle each equal the cycle-cumulative frame; CYCLE input is an
+  exact no-op.
+
+## Test strategy
+
+- Command: `uv run pytest` (or activate `.venv` then `pytest`).
+- New unit tests as above (equivalence of normalized step/test-cumulative to the
+  cycle-cumulative oracle; no-op on cycle input).
+- Regression: full suite green, esp. `tests/test_golden.py` (goldens must not move — the
+  default `CYCLE` path never rewrites the frame).
+
+## Open questions
+
+1. **Wiring into the pipeline.** Recommend keeping it a **standalone step** the caller runs
+   before `make_step_table`/`make_summary` (default no-op), rather than adding a kwarg to
+   `make_step_table`. Add a thin `CellpyCellCore` convenience method now, or defer wiring
+   until a real non-cycle-cumulative consumer exists? (Recommend: ship the engine function +
+   tests now, defer method/bridge wiring — matches the issue's "lower priority" framing.)
+2. **Energy columns.** Include the two `cumulative_*_energy` columns in the same pass
+   (recommended, same semantics) — confirm.
+3. **Negative/`null` handling.** Assume clean monotonic-within-group inputs; treat a leading
+   `null` as start-of-group. OK to not special-case malformed raw here?

--- a/.issueflows/03-solved-issues/issue42_status.md
+++ b/.issueflows/03-solved-issues/issue42_status.md
@@ -1,0 +1,28 @@
+# Issue #42 status — reset-granularity normalization
+
+- [x] Done
+
+## What's done
+
+- Plan confirmed (`issue42_plan.md`); open questions resolved: ship engine fn + tests now,
+  defer pipeline/bridge wiring; include energy columns; assume clean monotonic-within-group raw.
+- `config.ResetGranularity` StrEnum (`CYCLE`/`STEP`/`TEST`), CYCLE = mandated default.
+- `summarizers.normalize_capacity_granularity(data, schema, granularity)`: reconstructs the
+  per-row increment within the source reset group and re-accumulates over `(test_id, cycle_num)`.
+  Two-pass polars window impl (nested windows disallowed). Normalizes the present
+  `cumulative_*_capacity` / `cumulative_*_energy` columns; polars-in→polars-out /
+  pandas-in→pandas-out. CYCLE returns the object untouched.
+- Tests in `tests/test_schema.py`: parametrized STEP/TEST→cycle equivalence vs the
+  `_build_cumulative_raw` oracle, plus CYCLE no-op (same object + unchanged values).
+- Full suite green: `uv run pytest` → 91 passed (goldens byte-stable).
+
+## Remaining work
+
+- None for this issue. Deferred (separate follow-up if a real non-cycle consumer appears):
+  wiring the normalizer into `make_step_table`/`make_summary` or a `CellpyCellCore` method,
+  and the legacy bridge.
+
+## Notes
+
+- Pipeline/bridge wiring intentionally deferred (issue is "lower priority"; default no-op
+  keeps the exercised cycle-cumulative Arbin path untouched).

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Add `summarizers.normalize_capacity_granularity` + `config.ResetGranularity`
+  (`CYCLE`/`STEP`/`TEST`) to normalize step-cumulative or test-cumulative raw capacity /
+  energy columns to the mandated cycle-cumulative convention before aggregation; a
+  cycle-cumulative input is an exact no-op so the exercised path stays byte-stable (#42).
 - Add `test_id` to `StepCols`/`CycleCols` and key all per-step/per-cycle aggregation,
   cumulation, and joins on the composite `(test_id, cycle_num, step_num, …)` so a
   merged `Data` holding many tests never mixes cycles across tests (default `test_id=0`

--- a/src/cellpycore/config.py
+++ b/src/cellpycore/config.py
@@ -75,6 +75,31 @@ class TestMode(StrEnum):
     INVERTED = "inverted"
 
 
+class ResetGranularity(StrEnum):
+    """Reset granularity of a cumulative raw capacity / energy column.
+
+    Describes where a cycler's cumulative capacity / energy counter resets to
+    zero. The harmonized raw format mandates ``CYCLE`` (see
+    ``docs/data_format_specifications/harmonized_raw.md`` §Capacity convention);
+    :func:`cellpycore.summarizers.normalize_capacity_granularity` uses this enum
+    to normalize ``STEP`` / ``TEST`` cumulative raw from other cyclers to the
+    mandated ``CYCLE`` convention before aggregation.
+
+    Attributes:
+        CYCLE (``"cycle"``): Counter resets at each cycle boundary (accumulates
+            across a cycle's steps for its direction). The mandated harmonized
+            convention and the default; normalizing a ``CYCLE`` input is a no-op.
+        STEP (``"step"``): Counter resets at each step boundary (accumulates only
+            within a step).
+        TEST (``"test"``): Counter never resets (accumulates across the whole
+            test for its direction).
+    """
+
+    CYCLE = "cycle"
+    STEP = "step"
+    TEST = "test"
+
+
 class StepType(StrEnum):
     """Canonical step-type labels for the ``step_type`` column of the step table.
 

--- a/src/cellpycore/summarizers.py
+++ b/src/cellpycore/summarizers.py
@@ -4,7 +4,7 @@ from typing import Optional, Sequence, TypeVar, Union
 
 import polars as pl
 
-from cellpycore.config import Schema, TestMode, default_schema
+from cellpycore.config import ResetGranularity, Schema, TestMode, default_schema
 from cellpycore.cell_core import Data
 from cellpycore.extractors import LastIRExtractor, SummaryExtractor
 from cellpycore.legacy import CellpyLimits
@@ -75,6 +75,93 @@ def _group_keys(frame: "pl.DataFrame", base_keys: list, test_id_col: str) -> lis
     if test_id_col in frame.columns:
         return [test_id_col, *base_keys]
     return list(base_keys)
+
+
+# The four cumulative raw columns (per direction) that carry a reset-granularity
+# convention. Whichever are present get normalized to cycle-cumulative.
+_CUMULATIVE_ATTRS = (
+    "cumulative_charge_capacity",
+    "cumulative_discharge_capacity",
+    "cumulative_charge_energy",
+    "cumulative_discharge_energy",
+)
+
+
+def normalize_capacity_granularity(
+    data: Data,
+    schema: Optional[Schema] = None,
+    granularity: ResetGranularity = ResetGranularity.CYCLE,
+) -> Data:
+    """Normalize cumulative raw capacity / energy columns to cycle-cumulative.
+
+    The engine mandates **cycle-cumulative** raw capacity / energy (reset at each
+    cycle boundary; see ``docs/data_format_specifications/harmonized_raw.md``).
+    Cyclers that instead deliver **step-cumulative** (reset per step) or
+    **test-cumulative** (never reset) raw can be normalized here before
+    aggregation. The transform is granularity-agnostic: for each present column,
+    the per-row increment within the *source* reset group is reconstructed and
+    re-accumulated over ``(test_id, cycle_num)``, which is provably an identity
+    for a ``CYCLE`` input.
+
+    Args:
+        data (Data): The data object (its ``raw`` frame is rewritten in place).
+        schema: The column-header schema to use. Defaults to the native
+            cellpy-core schema when not provided.
+        granularity (ResetGranularity): The reset granularity of the source raw.
+            ``ResetGranularity.CYCLE`` (the default and mandated convention)
+            returns ``data`` untouched.
+
+    Returns:
+        Data: The data object with the cumulative columns normalized to
+        cycle-cumulative (the same object; ``raw`` matches the input frame's
+        type — polars in, polars out; pandas in, pandas out).
+    """
+    if granularity == ResetGranularity.CYCLE:
+        return data
+
+    if schema is None:
+        schema = default_schema()
+    nhdr = schema.raw
+
+    raw = data.raw
+    # The engine is polars-native; accept a pandas frame for convenience and
+    # return the same type the caller supplied.
+    was_pandas = not isinstance(raw, pl.DataFrame)
+    if was_pandas:
+        raw = pl.from_pandas(raw)
+
+    raw = _ensure_test_id(raw, nhdr.test_id)
+    raw = raw.sort(nhdr.datapoint_num)
+
+    if granularity == ResetGranularity.STEP:
+        source_keys = [nhdr.test_id, nhdr.cycle_num, nhdr.step_num]
+    else:  # ResetGranularity.TEST
+        source_keys = [nhdr.test_id]
+    cycle_keys = [nhdr.test_id, nhdr.cycle_num]
+
+    cols = [
+        getattr(nhdr, attr)
+        for attr in _CUMULATIVE_ATTRS
+        if getattr(nhdr, attr) in raw.columns
+    ]
+    if cols:
+        # Two passes (polars disallows a window expr nested inside another
+        # window's aggregation): (1) per-row increment within the source reset
+        # group (first row of the group keeps its own value), then (2)
+        # re-accumulate over the cycle.
+        increments = []
+        for col in cols:
+            diff = pl.col(col) - pl.col(col).shift(1).over(source_keys)
+            increments.append(
+                pl.when(diff.is_null()).then(pl.col(col)).otherwise(diff).alias(col)
+            )
+        raw = raw.with_columns(increments)
+        raw = raw.with_columns(
+            [pl.col(col).cum_sum().over(cycle_keys).alias(col) for col in cols]
+        )
+
+    data.raw = raw.to_pandas() if was_pandas else raw
+    return data
 
 
 def _delta_expr(base: str) -> pl.Expr:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -13,7 +13,14 @@ import pytest
 from cellpycore import selectors, summarizers
 from cellpycore.cell_core import CellpyCellCore, OldCellpyCellCore, Data
 from cellpycore import config
-from cellpycore.config import RawCols, CycleCols, StepCols, Schema, default_schema
+from cellpycore.config import (
+    RawCols,
+    CycleCols,
+    StepCols,
+    Schema,
+    ResetGranularity,
+    default_schema,
+)
 from cellpycore.legacy import HeadersNormal
 
 
@@ -531,3 +538,129 @@ def test_single_test_defaults_test_id_to_zero():
 
     assert set(data.steps[shdr.test_id].to_list()) == {0}
     assert set(data.summary[chdr.test_id].to_list()) == {0}
+
+
+# --- issue #42: reset-granularity normalization ----------------------------
+def _build_step_cumulative_raw(nhdr: RawCols) -> pd.DataFrame:
+    """Same increments as ``_build_cumulative_raw`` but counters reset per step.
+
+    Each capacity column restarts at the start of every step, so within the
+    discharge step the (inactive) charge capacity is 0 rather than the held
+    cycle-cumulative 0.5. Normalizing this to cycle-cumulative must reproduce
+    ``_build_cumulative_raw``.
+    """
+    records = []
+    dp = 0
+    for cyc in (1, 2):
+        for k in range(5):  # charge step: cc restarts at 0 -> 0.1..0.5, dc 0
+            records.append({
+                nhdr.datapoint_num: dp, nhdr.test_time: float(dp),
+                nhdr.step_time: float(k), nhdr.step_num: 1, nhdr.cycle_num: cyc,
+                nhdr.current: 1.0, nhdr.potential: 3.5 + 0.01 * k,
+                nhdr.cumulative_charge_capacity: 0.1 * (k + 1),
+                nhdr.cumulative_discharge_capacity: 0.0,
+                nhdr.internal_resistance: 0.0,
+            })
+            dp += 1
+        for k in range(5):  # discharge step: cc restarts at 0, dc 0.08..0.4
+            records.append({
+                nhdr.datapoint_num: dp, nhdr.test_time: float(dp),
+                nhdr.step_time: float(k), nhdr.step_num: 2, nhdr.cycle_num: cyc,
+                nhdr.current: -1.0, nhdr.potential: 3.9 - 0.01 * k,
+                nhdr.cumulative_charge_capacity: 0.0,
+                nhdr.cumulative_discharge_capacity: 0.08 * (k + 1),
+                nhdr.internal_resistance: 0.0,
+            })
+            dp += 1
+    return pd.DataFrame(records)
+
+
+def _build_test_cumulative_raw(nhdr: RawCols) -> pd.DataFrame:
+    """Same increments as ``_build_cumulative_raw`` but counters never reset.
+
+    Capacities accumulate across the whole test (cycle 2 charge continues from
+    cycle 1's 0.5, etc.). Normalizing to cycle-cumulative must reproduce
+    ``_build_cumulative_raw``.
+    """
+    records = []
+    dp = 0
+    cc = 0.0  # running test-cumulative charge capacity
+    dc = 0.0  # running test-cumulative discharge capacity
+    for cyc in (1, 2):
+        for k in range(5):  # charge: cc grows by 0.1/row, dc held
+            cc += 0.1
+            records.append({
+                nhdr.datapoint_num: dp, nhdr.test_time: float(dp),
+                nhdr.step_time: float(k), nhdr.step_num: 1, nhdr.cycle_num: cyc,
+                nhdr.current: 1.0, nhdr.potential: 3.5 + 0.01 * k,
+                nhdr.cumulative_charge_capacity: cc,
+                nhdr.cumulative_discharge_capacity: dc,
+                nhdr.internal_resistance: 0.0,
+            })
+            dp += 1
+        for k in range(5):  # discharge: dc grows by 0.08/row, cc held
+            dc += 0.08
+            records.append({
+                nhdr.datapoint_num: dp, nhdr.test_time: float(dp),
+                nhdr.step_time: float(k), nhdr.step_num: 2, nhdr.cycle_num: cyc,
+                nhdr.current: -1.0, nhdr.potential: 3.9 - 0.01 * k,
+                nhdr.cumulative_charge_capacity: cc,
+                nhdr.cumulative_discharge_capacity: dc,
+                nhdr.internal_resistance: 0.0,
+            })
+            dp += 1
+    return pd.DataFrame(records)
+
+
+def _cap_lists(raw) -> tuple:
+    """Return the (charge, discharge) cumulative capacity lists, datapoint-ordered."""
+    nhdr = RawCols()
+    if not isinstance(raw, pl.DataFrame):
+        raw = pl.from_pandas(raw)
+    raw = raw.sort(nhdr.datapoint_num)
+    return (
+        raw[nhdr.cumulative_charge_capacity].to_list(),
+        raw[nhdr.cumulative_discharge_capacity].to_list(),
+    )
+
+
+@pytest.mark.parametrize(
+    "builder, granularity",
+    [
+        (_build_step_cumulative_raw, ResetGranularity.STEP),
+        (_build_test_cumulative_raw, ResetGranularity.TEST),
+    ],
+)
+def test_normalize_capacity_granularity_matches_cycle_oracle(builder, granularity):
+    """STEP / TEST cumulative raw normalizes to the cycle-cumulative oracle."""
+    nhdr = RawCols()
+    schema = _native_schema()
+
+    data = Data()
+    data.raw = builder(nhdr)
+    summarizers.normalize_capacity_granularity(data, schema, granularity)
+
+    got_cc, got_dc = _cap_lists(data.raw)
+    exp_cc, exp_dc = _cap_lists(_build_cumulative_raw(nhdr))
+    assert got_cc == pytest.approx(exp_cc)
+    assert got_dc == pytest.approx(exp_dc)
+
+
+def test_normalize_capacity_granularity_cycle_is_noop():
+    """A CYCLE input is returned untouched (goldens stay byte-stable)."""
+    nhdr = RawCols()
+    schema = _native_schema()
+
+    original = _build_cumulative_raw(nhdr)
+    data = Data()
+    data.raw = original
+    result = summarizers.normalize_capacity_granularity(
+        data, schema, ResetGranularity.CYCLE
+    )
+
+    # untouched: same object, unchanged values
+    assert result.raw is original
+    got_cc, got_dc = _cap_lists(result.raw)
+    exp_cc, exp_dc = _cap_lists(original)
+    assert got_cc == pytest.approx(exp_cc)
+    assert got_dc == pytest.approx(exp_dc)


### PR DESCRIPTION
## Summary

The engine mandates **cycle-cumulative** raw capacity/energy (reset at each cycle boundary), which only the Arbin path currently delivers. This adds the ability to accept raw from cyclers that emit **step-cumulative** or **test-cumulative** counters and normalize it to the cycle-cumulative convention before aggregation.

- `config.ResetGranularity` StrEnum (`CYCLE`/`STEP`/`TEST`; `CYCLE` = mandated default).
- `summarizers.normalize_capacity_granularity(data, schema, granularity)`: reconstructs the per-row increment within the source reset group and re-accumulates over `(test_id, cycle_num)`. Normalizes the present `cumulative_*_capacity` / `cumulative_*_energy` columns; polars-in→polars-out / pandas-in→pandas-out.
- Provably an **identity** for a cycle-cumulative input, so `CYCLE` returns the object untouched and the exercised path stays byte-stable (goldens do not move).

Pipeline/bridge wiring (into `make_step_table`/`make_summary` or a `CellpyCellCore` method) is intentionally **deferred** until a real non-cycle-cumulative consumer appears (the issue is lower-priority).

## Test plan

- [x] `uv run pytest` → 91 passed (goldens byte-stable).
- [x] New `tests/test_schema.py`: parametrized STEP→cycle and TEST→cycle equivalence vs the cycle-cumulative oracle, plus `CYCLE` no-op.

Closes #42.

Made with [Cursor](https://cursor.com)