### PR TITLE
docs: add 2026-07 code review report (issue 50)

### DIFF
--- a/.issueflows/03-solved-issues/issue50_original.md
+++ b/.issueflows/03-solved-issues/issue50_original.md
@@ -1,0 +1,20 @@
+# Issue 50 — Code review report: weaknesses, improvements, plan forward
+
+> Local-only issue captured via cloud agent (`gh` is read-only in this
+> environment, so no GitHub issue was created). Number 50 chosen as the next
+> free number after GitHub issue/PR #49.
+
+## Task (as requested by the user)
+
+Go through the code base and find possible weaknesses and suggestions for
+improvements and suggestions for a plan forward. Write the findings up as a
+code report markdown file and put it in `.issueflows/04-designs-and-guides/`
+(the project's durable memory). Docs-only: no production code is touched.
+
+## Scope
+
+- Full review of `src/cellpycore/` (engine, config/schema, legacy bridge,
+  header mapping, units, selectors, timestamps, metadata scaffolding).
+- Packaging (`pyproject.toml`), CI (`.github/workflows/simpletest.yml`),
+  repo hygiene, and test coverage.
+- Deliverable: `.issueflows/04-designs-and-guides/code-review-2026-07.md`.

--- a/.issueflows/03-solved-issues/issue50_plan.md
+++ b/.issueflows/03-solved-issues/issue50_plan.md
@@ -1,0 +1,25 @@
+# Issue 50 — Plan
+
+Run in `/iflow-yolo` mode (small, low-risk, docs-only; single consolidated
+confirmation given by the user up front: "no actual code is touched", "feel
+free to merge the PR you create yourself").
+
+## Approach
+
+1. Review the code base (done in the analysis session preceding this issue):
+   read every module in `src/cellpycore/`, the tests, packaging, and CI;
+   verify each suspected defect by executing code (e.g. confirm the native
+   schema lacks the legacy attributes `selectors.py` dereferences); run the
+   full test suite (88 passed).
+2. Write the findings up as
+   `.issueflows/04-designs-and-guides/code-review-2026-07.md`, structured as:
+   overall verdict → verified bugs → design gaps → packaging/hygiene →
+   sequenced plan forward → test gaps.
+3. No production code changes. No `graphify update` needed (markdown only).
+4. Close: status file with `- [x] Done`, move the issue group to
+   `03-solved-issues`, commit, push, PR, merge (explicitly authorized).
+
+## Non-goals
+
+- Fixing any of the reported defects (each gets its own follow-up issue; see
+  the "Plan forward" section of the report).

--- a/.issueflows/03-solved-issues/issue50_status.md
+++ b/.issueflows/03-solved-issues/issue50_status.md
@@ -1,0 +1,20 @@
+# Issue 50 — Status
+
+- [x] Done
+
+## What was done
+
+- 2026-07-02: Full code-base review executed (all `src/cellpycore/` modules,
+  tests, packaging, CI, repo hygiene). Suspected defects verified by running
+  code; full test suite green at review time (88 passed).
+- 2026-07-02: Findings written up as
+  `.issueflows/04-designs-and-guides/code-review-2026-07.md` (verdict,
+  verified bugs A1–A6, design gaps B1–B4, packaging/hygiene C, sequenced plan
+  forward D1–D7).
+- Docs-only change; no production code touched, so no `graphify update`
+  needed.
+
+## Remaining work
+
+None for this issue. Follow-up work is enumerated in the report's
+"Plan forward" section (items D1–D7); each should become its own issue.

--- a/.issueflows/04-designs-and-guides/code-review-2026-07.md
+++ b/.issueflows/04-designs-and-guides/code-review-2026-07.md
@@ -1,0 +1,193 @@
+# Code review — weaknesses, improvements, and plan forward (2026-07)
+
+Full-codebase review of `cellpy-core` at commit `076fac7` (post issue #48,
+composite `test_id` group keys). Every claimed defect below was **verified by
+executing code**, not just by reading it. The full test suite was green at the
+time of review (88 passed, ~1.9 s).
+
+Reviewed: all modules in `src/cellpycore/` (engine, config/schema, legacy
+bridge, header mapping, units, selectors, timestamps, metadata scaffolding),
+`tests/`, `pyproject.toml`, CI (`.github/workflows/simpletest.yml`), and repo
+hygiene.
+
+Related issue: local issue 50 (docs-only; this report is the deliverable).
+
+## Overall verdict
+
+The core is healthy. The polars engine (`summarizers.py`, `extractors.py`) is
+clean, schema-injected, and well-documented. The header mapping
+(`header_mapping.py`) is disciplined: totality-tested, with explicit exception
+sets. The golden/parity test strategy is strong. The metadata scaffolding
+matches the boundary decision in `cellpy-core-migration.md` §4. The weak spots
+concentrate in the **edges**: legacy helpers, packaging, and the public API
+surface.
+
+## A. Bugs / latent breakage (verified)
+
+### A1. `selectors.py` is broken with its own default schema
+
+All four public functions (`summary_selector_exluder`, `get_step_numbers`,
+`get_cycle_numbers`, `get_rates`) default to `default_schema()` but then
+dereference **legacy-only** attribute names:
+
+```python
+# selectors.py — summary_selector_exluder
+d_n_txt = custom_headers_normal.data_point_txt   # RawCols has `datapoint_num`
+v_n_txt = custom_headers_normal.voltage_txt      # RawCols has `potential`
+c_n_txt = custom_headers_normal.cycle_index_txt  # RawCols has `cycle_num`
+```
+
+Verified: the native `RawCols` has none of `data_point_txt` / `voltage_txt` /
+`cycle_index_txt`, and the native `StepCols` has none of `cycle` / `type` /
+`rate_avr` / `ustep` / `point`. So every function raises `AttributeError`
+unless the caller injects the legacy `HeadersNormal` / `HeadersStepTable`.
+
+Additional problems in the same module:
+
+- Pandas-only (`.loc`, `.groupby`, `raw.copy()`) inside an otherwise
+  polars-native package (`pl.DataFrame` has no `.copy()`).
+- **Zero test coverage** — there is no `tests/test_selectors.py`.
+- Open issue #45 covers removing `create_selector` /
+  `summary_selector_exluder` only; `get_step_numbers`, `get_cycle_numbers`
+  and `get_rates` share the same defect but are not in its scope.
+
+### A2. `units.py` fallback path crashes on the core `Data` object
+
+`get_converter_to_specific` reads `data.raw_units`, `data.mass`,
+`data.active_electrode_area`, `data.volume`; `nominal_capacity_as_absolute`
+reads `data.nom_cap_specifics`, `data.nom_cap`. The core `Data` class has
+**none** of these attributes, so the fallback path (taken whenever a caller
+omits `specific_converters` in `add_scaled_summary_columns`) raises
+`AttributeError`. It only works when cellpy hands in its own richer data
+object — a silent trap for standalone cellpy-core users.
+
+Minor in the same file: `nominal_capacity_as_absolute` contains a pointless
+`try: ... except Exception as e: raise e` block.
+
+### A3. Falsy-override bug in step classification
+
+`summarizers._classify_steps` resolves override limits with:
+
+```python
+current_hard = orl.get("current_hard") or raw_limits["current_hard"]
+```
+
+An explicit override of `0` / `0.0` is falsy and silently ignored, falling
+back to the default. Use `if "current_hard" in orl:` (or
+`orl.get(key, default)` with a sentinel) instead. Applies to all four
+override keys.
+
+### A4. Dead-parameter API lies in `make_core_summary`
+
+The native `CellpyCellCore.make_core_summary` accepts `selector`,
+`select_columns` and `find_end_voltage` but never uses them (end potentials
+are always added by `make_summary`; `find_end_voltage` only affects the
+**legacy** bridge's column ordering). A caller passing `selector=...` gets a
+silent no-op.
+
+### A5. Shared mutable default: `DEFAULT_RAW_LIMITS`
+
+`DEFAULT_RAW_LIMITS = asdict(CellpyLimits())` is a module-level `dict` used
+as a default argument of `make_step_table`. Any caller mutating it changes
+behaviour process-wide — this conflicts with the project's stated
+thread-safety goal. Freeze it (`types.MappingProxyType`) or build a fresh
+dict per call.
+
+### A6. Dead fields on `Data`
+
+`Data.cycle` / `Data.step` are declared as "legacy aliases for backwards
+compatibility", but nothing in the code base ever reads or writes them (the
+engine uses `steps` / `summary`). Misleading; delete them or wire them as
+properties over `steps` / `summary`.
+
+## B. Design gaps
+
+### B1. Schema-agnosticism is only partial in the step engine
+
+The per-step statistic columns are hardcoded as `f"{base}_{stat}"` (and the
+classifier reads `pl.col("current_mean")` etc.). The injected `StepCols`
+values are applied only to the group keys, `step_type` and `c_rate`. A custom
+`StepCols.current_mean` is silently ignored. Either derive the stat column
+names from the schema, or (cheaper, recommended) document that the
+`<signal>_<stat>` names are a fixed engine contract.
+
+### B2. Default-polarity inconsistency in `cycle_mode`
+
+`MockMetaTestDependent.cycle_mode = "anode"` means an **initialized** `Data`
+defaults to INVERTED mode, while an uninitialized cell
+(`_cycle_mode = None`) resolves to NORMAL. This is exactly the
+"default-polarity trap" the `config.TestMode` docstring warns about, live
+inside the same package.
+
+### B3. No input validation at the engine entry points
+
+`make_step_table` / `make_summary` on `data.raw = None` produce a cryptic
+`pl.from_pandas(None)` traceback. `NoDataFound` exists but the engine never
+raises it. A cheap guard (raise `NoDataFound` for missing `raw`/`steps`, a
+clear `ValueError` for missing required columns) is a big usability win.
+
+### B4. Empty `__init__.py` — no public API surface
+
+No exports, no `__version__` (one test even probes for it "if defined").
+Consumers must deep-import `cellpycore.summarizers` etc.; there is no declared
+stable surface for cellpy to build against.
+
+## C. Packaging / hygiene
+
+- **`pyproject.toml`:** description is still `"Add your description here"`;
+  the classifier `Topic :: Software Development :: Build Tools` is wrong;
+  and there are **unused heavy dependencies** — `duckdb`, `duckdb-engine`,
+  `sqlalchemy`, `narwhals` have zero imports under `src/` (verified by
+  search). `pyarrow` should stay (pandas↔polars conversion needs it).
+- **Dead build dependency:** `uv-dynamic-versioning` is in
+  `[build-system].requires` but never configured (no
+  `[tool.uv-dynamic-versioning]` section, no hatch version source); the
+  version stays static `0.1.0`.
+- **Committed junk:** `scratch.db`, `tmp/simple.csv`, `tmp/simple.parquet`
+  are tracked in git.
+- **CI:** the single workflow runs tests only; `ruff` is in the dev group but
+  there is no lint/format step, no ruff config, no coverage reporting.
+- **Logging:** root-logger calls (`logging.debug(...)` instead of
+  `logger.debug`) in `summarizers.py` (inside `make_step_table`),
+  `settings_base.py` and `units.py` — violates the project's own
+  logging rule.
+- **Docs:** `README.md` is generic uv boilerplate with no project
+  description; `.issueflows/04-designs-and-guides/this-project.md` is all
+  TODO stubs — it is the first thing every agent is told to read and is
+  currently empty.
+- **Typing:** no `py.typed` marker; the `DataFrame = TypeVar("DataFrame")`
+  idiom misuses a `TypeVar` as a type alias (use `TypeAlias` or real
+  optional-import types).
+
+## D. Plan forward (sequenced; one issue/PR each)
+
+1. **Hygiene PR (small, zero risk):** drop the unused dependencies and
+   `uv-dynamic-versioning`; fix the pyproject metadata; delete `scratch.db`
+   and `tmp/`; add a ruff check to CI; replace the root-logger calls; remove
+   `Data.cycle` / `Data.step`; fix the falsy-override bug (A3) with a
+   regression test; freeze `DEFAULT_RAW_LIMITS` (A5).
+2. **API truthing:** delete the unused `make_core_summary` parameters (or
+   implement a native `find_end_voltage` gate); populate `__init__.py` with
+   the public exports and a `__version__`; add `py.typed`. Fill in
+   `this-project.md` and the README description while at it.
+3. **Selectors decision (feeds #45):** either port `get_step_numbers` /
+   `get_cycle_numbers` / `get_rates` to the native schema + polars with
+   tests, or move the whole module next to `legacy.py` and document it as
+   bridge-only until removal. The current state — broken by default and
+   untested — is the worst of both.
+4. **Units fallback (A2):** make `get_converter_to_specific` /
+   `nominal_capacity_as_absolute` take explicit values or a
+   `metadata.CellMeta` (which already has `mass`, `active_electrode_area`,
+   `nom_cap`, `nom_cap_specifics` — a natural fit with the metadata-boundary
+   decision). This removes the crashing `data.<attr>` fallback.
+5. **Engine guards (B3):** raise `NoDataFound` / a clear `ValueError` for
+   missing frames and missing required columns at the `make_step_table` /
+   `make_summary` entry points.
+6. **Then release (#44):** after items 1–2 land, tag `v0.1.0` and have cellpy
+   pin it (per the migration doc: pin a tag before a cellpy release). Open
+   issues #42 (reset-granularity normalization) and #43 (`ref_potential`
+   support) slot in after the release — both are additive.
+7. **Test gaps to backfill alongside:** selectors (none today); summarizer
+   edge cases (empty raw frame, cycle without a charge step,
+   `override_raw_limits` with `0.0`); and a thread-safety smoke test (two
+   schemas, parallel `make_step_table`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Docs-only PR adding a full code-base review report to the project's durable memory:

- `.issueflows/04-designs-and-guides/code-review-2026-07.md` — the report: overall verdict, verified bugs (A1–A6), design gaps (B1–B4), packaging/hygiene findings (C), and a sequenced plan forward (D1–D7).
- `.issueflows/03-solved-issues/issue50_{original,plan,status}.md` — the issue-flow paperwork for local issue 50 (closed; `gh` is read-only in the cloud-agent environment, so no GitHub issue was created).

## Highlights of the review

- Core engine, header mapping, and golden/parity test strategy are healthy.
- Verified defects concentrated at the edges: `selectors.py` raises `AttributeError` with its own default (native) schema and has no tests; the `units.py` fallback path crashes on the core `Data` object; `override_raw_limits` values of `0.0` are silently ignored; `make_core_summary` carries dead parameters; `DEFAULT_RAW_LIMITS` is a shared mutable default; `Data.cycle`/`Data.step` are dead fields.
- Packaging: placeholder description, unused heavy dependencies (`duckdb`, `duckdb-engine`, `sqlalchemy`, `narwhals`), unconfigured `uv-dynamic-versioning`, committed junk files, no lint step in CI.
- The report ends with a sequenced plan (hygiene PR → API truthing → selectors decision → units fallback → engine guards → release tag), each intended to become its own issue.

## Verification

- No production code touched (markdown only).
- Full test suite green before this change: 88 passed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f22ba-ff1d-70dc-a48d-b85a86e67450"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f22ba-ff1d-70dc-a48d-b85a86e67450"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

