### PR TITLE
feat(schema): re-land per-cycle cell-temperature columns in CycleCols

### DIFF
--- a/.issueflows/03-solved-issues/issue36_original.md
+++ b/.issueflows/03-solved-issues/issue36_original.md
@@ -1,0 +1,13 @@
+# Issue 36 — Iterative fixes: header-schema-review
+
+Source: https://github.com/cellpy/cellpy-core/issues/36
+
+Interactive `/iflow-fix` session.
+
+After landing the authoritative native<->legacy column mapping in
+`src/cellpycore/header_mapping.py`, re-evaluate whether the native header schema
+(`config.RawCols` / `StepCols` / `CycleCols`) is optimal, and consider promoting
+selected legacy-only columns into the native schema.
+
+Individual fixes are recorded in `issue36_status.md` under an "Iterative fixes
+log" and landed together via `/iflow-close`.

--- a/.issueflows/03-solved-issues/issue36_status.md
+++ b/.issueflows/03-solved-issues/issue36_status.md
@@ -1,0 +1,23 @@
+# Issue 36 — Status
+
+Interactive `/iflow-fix` session: re-evaluate the native header schema and
+promote selected legacy-only columns into cellpy-core where they represent real
+signals (not legacy cruft).
+
+- [x] Done
+
+## Iterative fixes log
+
+- 2026-07-02 — Re-landed from the stale `36-header-schema-review` remote branch
+  (commit `07d0c01`, never PR'd; found during remote-branch cleanup). Cherry-picked
+  onto current `main` as branch `36-temperature-cell-columns-reland`.
+
+- 2026-06-24 — Added per-cycle cell-temperature summary headers to `CycleCols`
+  (`temperature_cell_mean` / `_max` / `_min` / `_last`), closing the asymmetry
+  where native raw ingests `aux_temperature_cell` but the cycle summary had no
+  temperature column. `_mean` / `_last` map to legacy `temperature_mean` /
+  `temperature_last` (moved out of `LEGACY_ONLY_CYCLE` into `CYCLE_PAIRS`);
+  `_max` / `_min` added to `NATIVE_ONLY_CYCLE`. Header-declaration only — engine
+  population in `make_summary` deferred. Updated `config.py`,
+  `header_mapping.py`, `docs/data_format_specifications/cycle_table.md`,
+  `tests/test_config_columns.py`. Full suite green (50 passed).

--- a/docs/data_format_specifications/cycle_table.md
+++ b/docs/data_format_specifications/cycle_table.md
@@ -91,6 +91,10 @@ Date: 2025-09-08
 | cc_charge_capacity | float | Ampere-hour (Ah) | 3.1234 | Total cycle charge capacity from cycling in CC-mode |
 | cc_charge_energy | float | Watt-hour (Wh) | 3.1234 | Total cycle charge energy from cycling in CC-mode |
 | cc_charge_time | float | Seconds (s) | 3.1234 | Total cycle charge time cycling in CC-mode |
+| temperature_cell_mean | float | Degree Celsius (°C) | 25.4 | Arithmetic mean of cell temperature over the cycle (from aux_temperature_cell). |
+| temperature_cell_max | float | Degree Celsius (°C) | 25.4 | Maximum cell temperature over the cycle (from aux_temperature_cell). |
+| temperature_cell_min | float | Degree Celsius (°C) | 25.4 | Minimum cell temperature over the cycle (from aux_temperature_cell). |
+| temperature_cell_last | float | Degree Celsius (°C) | 25.4 | Cell temperature at the end of the cycle (from aux_temperature_cell). |
 | normalized_cycle_index | float | - | 3.14 | Equivalent cycle number (test_cumulated_charge_capacity / nominal capacity) |
 | charge_c_rate | float | C-rate (1/h) | 0.05 | C-rate of the first charge step in the cycle |
 | discharge_c_rate | float | C-rate (1/h) | 0.05 | C-rate of the first discharge step in the cycle |

--- a/src/cellpycore/config.py
+++ b/src/cellpycore/config.py
@@ -397,6 +397,15 @@ class CycleCols(Cols):
     cc_charge_capacity: str = "cc_charge_capacity"
     cc_charge_energy: str = "cc_charge_energy"
     cc_charge_time: str = "cc_charge_time"
+    # Per-cycle cell-temperature statistics, aggregated from the raw
+    # ``aux_temperature_cell`` signal. Declared here (like the per-direction
+    # current/potential/power stats above) ahead of engine support; the summary
+    # engine does not populate them yet. ``_mean`` / ``_last`` map to the legacy
+    # ``temperature_mean`` / ``temperature_last`` summary columns.
+    temperature_cell_mean: str = "temperature_cell_mean"
+    temperature_cell_max: str = "temperature_cell_max"
+    temperature_cell_min: str = "temperature_cell_min"
+    temperature_cell_last: str = "temperature_cell_last"
     # Derived/scaled columns produced by the standalone native summary path
     # (``add_scaled_summary_columns`` + the C-rate / IR helpers). These were
     # previously legacy-only "bridge extras" (see step-table-polars-migration.md,

--- a/src/cellpycore/header_mapping.py
+++ b/src/cellpycore/header_mapping.py
@@ -109,6 +109,8 @@ CYCLE_PAIRS = [
     ("test_cumulated_discharge_capacity_loss", "cumulated_discharge_capacity_loss"),
     ("potential_end_charge", "end_voltage_charge"),
     ("potential_end_discharge", "end_voltage_discharge"),
+    ("temperature_cell_mean", "temperature_mean"),
+    ("temperature_cell_last", "temperature_last"),
     # Identity pass-throughs (native name already equals the legacy name).
     ("ir_charge", "ir_charge"),
     ("ir_discharge", "ir_discharge"),
@@ -172,7 +174,7 @@ LEGACY_ONLY_CYCLE = frozenset({
     "shifted_discharge_capacity", "ocv_first_min", "ocv_second_min",
     "ocv_first_max", "ocv_second_max", "cumulated_ric_disconnect",
     "cumulated_ric_sei", "cumulated_ric", "low_level", "high_level",
-    "temperature_last", "temperature_mean", "aux_",
+    "aux_",
 })
 
 # Native CycleCols column values with no legacy HeadersSummary counterpart.
@@ -202,7 +204,7 @@ NATIVE_ONLY_CYCLE = frozenset({
     "relaxation_potential_discharge", "open_circuit_potential_charge",
     "open_circuit_potential_discharge", "cv_share", "cv_charge_capacity",
     "cv_charge_energy", "cv_charge_time", "cc_charge_capacity", "cc_charge_energy",
-    "cc_charge_time",
+    "cc_charge_time", "temperature_cell_max", "temperature_cell_min",
 })
 
 

--- a/tests/test_config_columns.py
+++ b/tests/test_config_columns.py
@@ -79,6 +79,8 @@ CYCLE_EXPECTED = [
     "open_circuit_potential_discharge", "cv_share", "cv_charge_capacity",
     "cv_charge_energy", "cv_charge_time", "cc_charge_capacity", "cc_charge_energy",
     "cc_charge_time",
+    "temperature_cell_mean", "temperature_cell_max", "temperature_cell_min",
+    "temperature_cell_last",
     "normalized_cycle_index", "charge_c_rate", "discharge_c_rate",
     "ir_charge", "ir_discharge",
 ]


### PR DESCRIPTION
## Summary

- Re-lands the last fix from the stale `36-header-schema-review` remote branch (commit `07d0c01`, 2026-06-25), which was never opened as a PR — recovered during remote-branch cleanup before deleting stale branches.
- Adds `temperature_cell_mean` / `_max` / `_min` / `_last` to the native `CycleCols` (+ `cycle_table.md` spec rows), closing the asymmetry where native raw ingests `aux_temperature_cell` but the cycle summary had no temperature columns.
- `_mean` / `_last` map to legacy `temperature_mean` / `temperature_last` (moved from `LEGACY_ONLY_CYCLE` into `CYCLE_PAIRS`); `_max` / `_min` declared in `NATIVE_ONLY_CYCLE`.
- Header declaration only — engine population in `make_summary` is deferred (same stance as the original commit).

## Test plan

- [x] `uv run pytest` — 94 passed (header-mapping totality + code↔spec conformance cover the new columns)

Refs #36 (closed iterative-fixes session; this is its last unlanded fix)

Made with [Cursor](https://cursor.com)