### PR TITLE
fix: remove unused pytest import failing ruff in release CI

### DIFF
--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -1,5 +1,3 @@
-import pytest
-
 from cellpycore.cell_core import Data
 
 def test_data_creation(mock_data_empty: Data):


### PR DESCRIPTION
## Summary
- Remove unused `import pytest` in `tests/test_creation.py` — it tripped ruff F401 in the release workflow's test job and blocked PyPI publish.

## Test plan
- [x] `uv run ruff check src/ tests/` passes locally
- [x] `uv run pytest` — 94 passed

Part of #44.

Made with [Cursor](https://cursor.com)