### PR TITLE
docs: add standalone slim-consumer guide + release 0.1.2 (#56)

### DIFF
--- a/.issueflows/03-solved-issues/issue56_original.md
+++ b/.issueflows/03-solved-issues/issue56_original.md
@@ -1,0 +1,64 @@
+# Issue #56: Document standalone use of cellpy-core (slim-consumer guide)
+
+Source: https://github.com/cellpy/cellpy-core/issues/56
+
+## Original issue text
+
+## Context
+
+cellpy-core is designed to be usable on its own: anyone who can produce a polars DataFrame in the native `config.RawCols` schema should be able to get step tables and per-cycle summaries without pulling in full cellpy. That story currently lives only in design docs and code docstrings — there is no user-facing documentation for it.
+
+## Proposal
+
+Add a "Using cellpy-core standalone" guide to `docs/` covering:
+
+### 1. The recommended entry point
+
+Native `CellpyCellCore` (not the `OldCellpyCellCore` legacy bridge, which exists only to serve legacy cellpy headers):
+
+```python
+from cellpycore.cell_core import CellpyCellCore, Data
+
+core = CellpyCellCore(initialize=True)
+core.data.raw = my_polars_frame          # native config.RawCols schema
+core.cycle_mode = "anode"                # only for half-cells; default "standard"
+
+data = core.make_core_step_table(
+    core.data,
+    nom_cap=my_nom_cap_abs,              # absolute Ah, for the per-step C-rate
+    raw_limits=my_instrument_limits,     # optional; DEFAULT_RAW_LIMITS otherwise
+)
+data = core.make_core_summary(
+    data,
+    current_conversion_factor=1.0,       # raw-current -> output-current, by value
+)
+# optional: specific / normalized columns
+data = core.add_scaled_summary_columns(
+    data,
+    nom_cap_abs=my_nom_cap_abs,
+    normalization_cycles=None,
+    specific_converters={"gravimetric": f_g, "areal": f_a, "absolute": f_abs},
+)
+
+steps, summary = data.steps, data.summary  # polars frames (StepCols / CycleCols)
+```
+
+Also mention the class-free alternative (`summarizers.make_step_table(data)` + `summarizers.make_summary(data)` with the default schema) and when the class is worth it (cycle-mode -> TestMode handling, IR/C-rate orchestration).
+
+### 2. The contract the caller must honor
+
+- **Order matters:** step table before summary (`make_summary` reads `data.steps`).
+- **No metadata required:** `Data()` ships `MockMetaTestDependent`; only `cycle_mode` changes the math (CE direction).
+- **Units by value:** core never sees unit objects — the caller precomputes floats (`nom_cap`, `current_conversion_factor`, `specific_converters`); pint fallback only via the optional `units` extra.
+- **Raw shape assumptions:** `epoch_time_utc` is int64 ns UTC; capacities are cycle-cumulative per direction (point at `normalize_capacity_granularity` for step-/test-cumulative inputs); `test_id` optional, defaults to 0.
+- **Legacy cruft absent by design:** native summary is the clean `CycleCols` subset + C-rate/IR; cumulated CE / shifted / RIC columns exist only on the legacy bridge.
+
+### 3. Housekeeping
+
+- Link the guide from the README.
+- Once #55 (`Data.from_raw_frame`) lands, switch the example to use it.
+
+## Links
+
+- Raised together with #55 while discussing the future slim-consumer / cellpy v2 interaction pattern.
+- Background: `.issueflows/04-designs-and-guides/cellpy-core-integration-roadmap.md`, `cellpy-core-migration.md` §4 (metadata/units boundaries).

--- a/.issueflows/03-solved-issues/issue56_plan.md
+++ b/.issueflows/03-solved-issues/issue56_plan.md
@@ -1,0 +1,48 @@
+# Issue #56 — plan
+
+## Goal
+
+Add a user-facing "Using cellpy-core standalone" guide to `docs/` so slim consumers
+(anyone with a polars frame in the native `config.RawCols` schema) can get step
+tables and per-cycle summaries without full cellpy. Link it from the README.
+
+## Approach
+
+- New `docs/standalone-use.md` covering:
+  - Recommended entry point: native `CellpyCellCore` + `Data.from_raw_frame`
+    (#55 landed, so the example uses the validating front door, not bare
+    `core.data.raw = ...`).
+  - Full pipeline example: `make_core_step_table` (nom_cap, raw_limits) →
+    `make_core_summary` (current_conversion_factor, exclude_step_types) →
+    optional `add_scaled_summary_columns` (specific_converters).
+  - Class-free alternative: `summarizers.make_step_table` + `summarizers.make_summary`
+    with the default schema, and when the class is worth it (cycle_mode → TestMode,
+    IR/C-rate orchestration).
+  - Caller contract: step table before summary; no metadata required; units by
+    value (pint only via the optional `units` extra); raw-shape assumptions
+    (`epoch_time_utc` int64 ns UTC, cycle-cumulative capacities →
+    `normalize_capacity_granularity` for step-/test-cumulative inputs, `test_id`
+    optional); legacy cruft only on the `OldCellpyCellCore` bridge.
+  - Links to `docs/data_format_specifications/harmonized_raw.md` and
+    `docs/data-object-definition.md`.
+- README: add a short Documentation section linking the guide (and install note —
+  package is on PyPI as `cellpycore` since v0.1.1, README still says GitHub-only;
+  fix that line while touching it).
+
+## Files to touch
+
+- `docs/standalone-use.md` (new)
+- `README.md` (link + install line)
+- `.issueflows/01-current-issues/issue56_*.md` (tracking)
+- `HISTORY.md`, `pyproject.toml` (at close: patch bump + promote)
+
+## Test strategy
+
+Docs-only change — no engine code touched. Re-run `uv run pytest` (107 tests) to
+confirm the suite stays green; verify the example snippets against the real
+signatures in `cell_core.py` / `summarizers.py` (done while writing).
+
+## Design docs consulted
+
+`cellpy-core-integration-roadmap.md`, `cellpy-core-migration.md` §4,
+`release-procedure.md` (for the close/release steps).

--- a/.issueflows/03-solved-issues/issue56_status.md
+++ b/.issueflows/03-solved-issues/issue56_status.md
@@ -1,0 +1,26 @@
+# Issue #56 — status
+
+- [x] Done
+
+## What was done (2026-07-02)
+
+- Added `docs/standalone-use.md` — the slim-consumer guide:
+  - Native `CellpyCellCore` + `Data.from_raw_frame` pipeline (uses the #55
+    validating front door, per the issue's housekeeping note).
+  - Class-free alternative (`summarizers.make_step_table` / `make_summary`)
+    and when the class is worth it.
+  - Caller contract (order, no metadata, units by value, raw shape
+    assumptions incl. `normalize_capacity_granularity`, legacy cruft only on
+    the bridge) plus a "cycle-mode trap" note (placeholder defaults to
+    `"anode"`).
+  - Links to the harmonized-raw spec and the Data-object doc.
+- README: new Documentation section linking the guide; fixed the stale
+  "only available on GitHub" install note (package is on PyPI as `cellpycore`).
+- Verified both documented pipelines run end-to-end against
+  `_helpers.create_raw_data()` mock data; full suite green (107 passed).
+- Version bumped 0.1.1 → 0.1.2; `HISTORY.md` `[Unreleased]` promoted to
+  `[0.1.2] - 2026-07-02` with a bullet for this issue.
+
+## Remaining work
+
+None — docs-only change, fully resolved.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-07-02
+
 - Add `summarizers.normalize_capacity_granularity` + `config.ResetGranularity`
   (`CYCLE`/`STEP`/`TEST`) to normalize step-cumulative or test-cumulative raw capacity /
   energy columns to the mandated cycle-cumulative convention before aggregation; a
@@ -40,3 +42,7 @@ All notable changes to this project will be documented in this file.
   before any derived column (prefix match on step type, e.g. `["cv_"]` for a non-CV summary),
   forwarded by both `make_core_summary` signatures — natively replacing the exclusion feature
   lost with the removed pandas selector pair; parity locked by a pandas-oracle test (#54).
+- Document standalone use of cellpy-core: new slim-consumer guide
+  (`docs/standalone-use.md`) covering the native `CellpyCellCore` +
+  `Data.from_raw_frame` pipeline, the class-free `summarizers` alternative, and the
+  caller contract; linked from the README together with a fixed PyPI install note (#56).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,21 @@
 
 ## Installing
 
-only available on <https://github.com/cellpy/cellpy-core>
+Available on PyPI as [`cellpycore`](https://pypi.org/project/cellpycore/):
+
+```bash
+pip install cellpycore
+```
+
+Source: <https://github.com/cellpy/cellpy-core>
+
+## Documentation
+
+- [Using cellpy-core standalone (slim-consumer guide)](docs/standalone-use.md) —
+  get step tables and per-cycle summaries from a native-schema polars frame
+  without full cellpy.
+- [Harmonized raw format specification](docs/data_format_specifications/harmonized_raw.md)
+- [The Data object](docs/data-object-definition.md)
 
 ## Developing
 

--- a/docs/standalone-use.md
+++ b/docs/standalone-use.md
@@ -1,0 +1,130 @@
+# Using cellpy-core standalone (slim-consumer guide)
+
+cellpy-core is designed to be usable on its own: if you can produce a polars
+`DataFrame` in the native raw schema (`config.RawCols`), you can get step tables
+and per-cycle summaries without pulling in the full
+[cellpy](https://github.com/jepegit/cellpy) package.
+
+```bash
+pip install cellpycore            # or: uv add cellpycore
+pip install "cellpycore[units]"   # optional: pint-backed unit helpers
+```
+
+The engine is polars-native, schema-agnostic (column names are injected via a
+`Schema` object), and thread-safe (no module-level mutable state).
+
+## The recommended entry point
+
+Use the native `CellpyCellCore` — not the `OldCellpyCellCore` legacy bridge,
+which exists only to serve legacy cellpy headers and pandas frames.
+
+```python
+from cellpycore.cell_core import CellpyCellCore, Data
+
+core = CellpyCellCore()
+core.data = Data.from_raw_frame(my_polars_frame)  # validates against config.RawCols
+core.cycle_mode = "standard"                      # see the cycle-mode trap below
+
+data = core.make_core_step_table(
+    core.data,
+    nom_cap=my_nom_cap_abs,              # absolute (e.g. Ah), for the per-step C-rate
+    raw_limits=my_instrument_limits,     # optional; DEFAULT_RAW_LIMITS otherwise
+)
+data = core.make_core_summary(
+    data,
+    current_conversion_factor=1.0,       # raw-current -> output-current, by value
+)
+# optional: specific / normalized columns
+data = core.add_scaled_summary_columns(
+    data,
+    nom_cap_abs=my_nom_cap_abs,
+    normalization_cycles=None,
+    specific_converters={"gravimetric": f_g, "areal": f_a, "absolute": f_abs},
+)
+
+steps, summary = data.steps, data.summary  # polars frames (StepCols / CycleCols)
+```
+
+`Data.from_raw_frame` is the validating front door: it checks that the frame is
+a polars `DataFrame` carrying the load-bearing `RawCols` columns with sane
+dtypes and reports every problem in a single error. Pass `validate=False` to
+skip the checks (e.g. in a hot loop after the shape is known-good).
+
+### The cycle-mode trap
+
+`cycle_mode` decides the coulombic-efficiency direction (and which capacity
+column "comes first"). For historical cellpy reasons the metadata placeholder
+on a fresh `Data` defaults to `"anode"` (anode half-cell, inverted convention)
+— **not** `"standard"`. Set it explicitly:
+
+- `"anode"` — anode half-cell (inverted; `CE = 100 * charge / discharge`).
+- anything else (`"standard"`, `"cathode"`, `"full_cell"`, …) — normal
+  convention (`CE = 100 * discharge / charge`).
+
+### Useful knobs
+
+- `make_core_step_table(..., raw_limits=...)`: instrument resolution thresholds
+  for step-type classification (what counts as "constant" / "zero"). Defaults
+  to `summarizers.DEFAULT_RAW_LIMITS` (mirrors legacy cellpy's `CellpyLimits`).
+- `make_core_summary(..., exclude_step_types=["cv_"])`: subtract the
+  capacity contributions of matching step types (prefix match) from the
+  summary — e.g. a non-CV summary.
+- `make_core_summary(..., find_ir=...)` / `ir_extractor=...`: per-cycle
+  internal-resistance columns, when the raw carries `internal_resistance`.
+- `add_scaled_summary_columns(...)`: adds `normalized_cycle_index` (equivalent
+  cycles) plus `{column}_{gravimetric,areal,absolute}` variants of the
+  capacity-like columns (`CycleCols().specific_columns`).
+
+## The class-free alternative
+
+The engine functions in `cellpycore.summarizers` work directly on a `Data`
+object with the default native schema — no class required:
+
+```python
+from cellpycore.cell_core import Data
+from cellpycore import summarizers
+
+data = Data.from_raw_frame(my_polars_frame)
+data = summarizers.make_step_table(data)
+data = summarizers.make_summary(data)   # test_mode=config.TestMode.INVERTED for anode cells
+```
+
+The class is worth it when you want the `cycle_mode` string → `config.TestMode`
+handling done for you, and the IR / C-rate orchestration
+(`make_core_summary` chains `make_summary` + `ir_to_summary` +
+`c_rates_to_summary` in the right order).
+
+## The contract the caller must honor
+
+- **Order matters.** Step table before summary — `make_summary` reads
+  `data.steps`.
+- **No metadata required.** `Data()` ships a `MockMetaTestDependent`
+  placeholder; the engine never needs populated cell metadata. Only
+  `cycle_mode` changes the math (CE direction — see the trap above).
+- **Units by value.** The core never sees unit objects. The caller precomputes
+  plain floats: `nom_cap` / `nom_cap_abs`, `current_conversion_factor`, and the
+  `specific_converters` mapping. The pint-backed helpers in `cellpycore.units`
+  are an optional fallback (install the `units` extra) — the engine itself does
+  not require pint.
+- **Raw shape assumptions.**
+  - `epoch_time_utc` is int64 nanoseconds since the Unix epoch, UTC (see
+    `cellpycore.timestamps` for conversion helpers); `test_time` / `step_time`
+    are relative elapsed seconds (float).
+  - Capacity / energy columns are **cycle-cumulative per direction** (reset at
+    each cycle boundary). If your cycler delivers step-cumulative or
+    test-cumulative counters, run
+    `summarizers.normalize_capacity_granularity(data, granularity=config.ResetGranularity.STEP)`
+    (or `.TEST`) first.
+  - `test_id` is optional and defaults to `0`; it only matters for merged
+    `Data` objects holding several tests.
+- **Legacy cruft is absent by design.** The native summary is the clean
+  `CycleCols` subset plus C-rate / IR columns. Cumulated CE, shifted
+  capacities, and RIC columns exist only on the legacy bridge
+  (`OldCellpyCellCore`).
+
+## Reference
+
+- Raw-format spec (authoritative column list and conventions):
+  [`docs/data_format_specifications/harmonized_raw.md`](data_format_specifications/harmonized_raw.md)
+- The `Data` object: [`docs/data-object-definition.md`](data-object-definition.md)
+- Column names: `cellpycore.config` (`RawCols`, `StepCols`, `CycleCols`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cellpycore"
-version = "0.1.1"
+version = "0.1.2"
 license = "MIT"
 license-files = ["LICEN[CS]E*"]
 description = "Add your description here"

--- a/uv.lock
+++ b/uv.lock
@@ -16,7 +16,7 @@ wheels = [
 
 [[package]]
 name = "cellpycore"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
## Summary

- Adds `docs/standalone-use.md` — the slim-consumer guide for using cellpy-core without full cellpy: native `CellpyCellCore` + `Data.from_raw_frame` pipeline, class-free `summarizers` alternative, and the caller contract (step table before summary, no metadata required, units by value, raw-shape assumptions incl. `normalize_capacity_granularity`, legacy cruft only on the bridge).
- Links the guide from the README and fixes the stale "only available on GitHub" install note (`cellpycore` is on PyPI).
- Bumps the version to 0.1.2 and promotes `HISTORY.md` `[Unreleased]` → `[0.1.2] - 2026-07-02` (release cut after merge).

## Test plan

- [x] Both documented pipelines smoke-tested end-to-end against `_helpers.create_raw_data()` mock data (class path and class-free path).
- [x] Full suite green: 107 passed.

Closes #56

Made with [Cursor](https://cursor.com)