### PR TITLE
docs: use absolute GitHub URLs for README doc links (fixes #62)

### DIFF
--- a/.issueflows/01-current-issues/issue62_original.md
+++ b/.issueflows/01-current-issues/issue62_original.md
@@ -1,0 +1,13 @@
+# Issue #62 — readme links not working on pypi
+
+- **URL:** https://github.com/cellpy/cellpy-core/issues/62
+- **State:** open
+- **Labels:** yolo
+- **Captured:** 2026-07-02
+
+## Original description
+
+The links in the readme do not work on pypi. I guess the docs folder is not a
+part of the package. If so, consider either linking to the locations in the
+github repo or include those three files that have links on readme into the
+package.

--- a/.issueflows/01-current-issues/issue62_plan.md
+++ b/.issueflows/01-current-issues/issue62_plan.md
@@ -1,0 +1,22 @@
+# Issue #62 — plan
+
+## Goal
+
+Make the documentation links in `README.md` work when rendered on PyPI.
+
+## Approach
+
+Relative links (`docs/...`) break on PyPI because the docs folder is not part
+of the rendered page context. Replace the three relative doc links in the
+README with absolute GitHub URLs pointing at `main`
+(`https://github.com/cellpy/cellpy-core/blob/main/docs/...`). No packaging
+changes — simplest fix, keeps the sdist/wheel lean.
+
+## Files to touch
+
+- `README.md`
+
+## Test strategy
+
+- `uv run pytest` (no code changes, suite must stay green).
+- Visual check that the rewritten URLs resolve on GitHub.

--- a/.issueflows/01-current-issues/issue62_status.md
+++ b/.issueflows/01-current-issues/issue62_status.md
@@ -1,0 +1,14 @@
+# Issue #62 — status
+
+- [x] Done
+
+## What was done
+
+- 2026-07-02: Replaced the three relative doc links in `README.md` with
+  absolute GitHub URLs (`https://github.com/cellpy/cellpy-core/blob/main/docs/...`)
+  so they render correctly on PyPI. Verified all three target files exist.
+  Full test suite green (107 passed). No packaging changes needed.
+
+## Remaining work
+
+None.

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ Source: <https://github.com/cellpy/cellpy-core>
 
 ## Documentation
 
-- [Using cellpy-core standalone (slim-consumer guide)](docs/standalone-use.md) —
+- [Using cellpy-core standalone (slim-consumer guide)](https://github.com/cellpy/cellpy-core/blob/main/docs/standalone-use.md) —
   get step tables and per-cycle summaries from a native-schema polars frame
   without full cellpy.
-- [Harmonized raw format specification](docs/data_format_specifications/harmonized_raw.md)
-- [The Data object](docs/data-object-definition.md)
+- [Harmonized raw format specification](https://github.com/cellpy/cellpy-core/blob/main/docs/data_format_specifications/harmonized_raw.md)
+- [The Data object](https://github.com/cellpy/cellpy-core/blob/main/docs/data-object-definition.md)
 
 ## Developing
 


### PR DESCRIPTION
## Summary
- Relative `docs/...` links in `README.md` break when the README is rendered on PyPI, since the docs folder is not part of the rendered page context.
- Replaced the three doc links with absolute GitHub URLs pointing at `main`. No packaging changes needed.

Fixes #62.

## Test plan
- [x] `uv run pytest` — 107 passed
- [x] Verified all three linked files exist in `docs/`

Made with [Cursor](https://cursor.com)