### PR TITLE
docs: switch README developer workflow to uv sync / uv add

### DIFF
--- a/.issueflows/03-solved-issues/issue64_original.md
+++ b/.issueflows/03-solved-issues/issue64_original.md
@@ -1,0 +1,7 @@
+# Issue #64: small update in readme
+
+Source: https://github.com/cellpy/cellpy-core/issues/64
+
+## Original issue text
+
+The developer section in readme mentions running "uv venv". We should instead use the built in project manager in uv (so, developers should run "uv sync" after cloning the repo, and "uv add some-package" when adding new dependencies).

--- a/.issueflows/03-solved-issues/issue64_plan.md
+++ b/.issueflows/03-solved-issues/issue64_plan.md
@@ -1,0 +1,28 @@
+# Issue #64 plan: small update in readme
+
+## Goal
+
+The Developing section in `README.md` tells developers to run `uv venv` +
+`uv pip install -e ".[dev]"`. Switch to uv's built-in project workflow:
+`uv sync` after cloning, `uv add` for new dependencies.
+
+## Approach
+
+Rewrite the "Development Workflow" and "Common Commands" parts of the
+Developing section:
+
+- Drop `uv venv` + activate + `uv pip install -e ".[dev]"`; replace with a
+  single `uv sync` step (creates `.venv` and installs all locked deps).
+- Keep `uv add` / `uv add --dev` for adding dependencies.
+- Run tests via `uv run pytest`.
+- Update "Common Commands" to project-manager equivalents (`uv remove`,
+  `uv sync --upgrade`, `uv tree`).
+
+## Files to touch
+
+- `README.md` (only)
+
+## Test strategy
+
+Docs-only change; run `uv run pytest` before commit to confirm the suite is
+still green (yolo chain requirement).

--- a/.issueflows/03-solved-issues/issue64_status.md
+++ b/.issueflows/03-solved-issues/issue64_status.md
@@ -1,0 +1,17 @@
+# Issue #64 status: small update in readme
+
+- [x] Done
+
+## What was done
+
+- Rewrote the "Development Workflow" part of `README.md` Developing section:
+  replaced `uv venv` + activate + `uv pip install -e ".[dev]"` with a single
+  `uv sync` step; kept `uv add` / `uv add --dev`; tests now via `uv run pytest`.
+- Updated "Common Commands" to project-manager equivalents (`uv sync`,
+  `uv remove`, `uv sync --upgrade`, `uv tree`), dropping the `uv pip ...`
+  commands.
+- Added a `HISTORY.md` bullet under `[Unreleased]`.
+
+## Remaining work
+
+None. Docs-only change; test suite green (107 passed).

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Update the README developer section to uv's project workflow: `uv sync` after
+  cloning, `uv add` for new dependencies, `uv run pytest` for tests (#64).
+
 ## [0.1.2] - 2026-07-02
 
 - Add `summarizers.normalize_capacity_granularity` + `config.ResetGranularity`

--- a/README.md
+++ b/README.md
@@ -32,22 +32,13 @@ pip install uv
 
 ### Development Workflow
 
-1. Create and activate a virtual environment:
+1. Install all dependencies (creates `.venv` automatically):
 
 ```bash
-uv venv
-source .venv/bin/activate  # On Unix/macOS
-# OR
-.venv\Scripts\activate     # On Windows
+uv sync
 ```
 
-2. Install development dependencies:
-
-```bash
-uv pip install -e ".[dev]"
-```
-
-3. Adding new dependencies:
+2. Adding new dependencies:
 
 ```bash
 # Add a new package
@@ -57,24 +48,17 @@ uv add <package-name>
 uv add --dev <package-name>
 ```
 
-4. Updating dependencies:
+3. Running tests:
 
 ```bash
-# Update all packages
-uv sync
-```
-
-5. Running tests:
-
-```bash
-pytest
+uv run pytest
 ```
 
 ### Common Commands
 
-- List installed packages: `uv pip list`
+- Reinstall dependencies from the lock file: `uv sync`
 - Remove a package: `uv remove <package-name>`
-- Show package info: `uv pip show <package-name>`
-- Export requirements: `uv pip freeze > requirements.txt`
+- Upgrade all packages within constraints: `uv sync --upgrade`
+- Show the dependency tree: `uv tree`
 
 For more information about `uv`, visit the [official documentation](https://github.com/astral-sh/uv).


### PR DESCRIPTION
## Summary

- Replace the `uv venv` + activate + `uv pip install -e ".[dev]"` developer setup in the README with uv's built-in project workflow: a single `uv sync` after cloning.
- Keep `uv add` / `uv add --dev` for adding dependencies; run tests via `uv run pytest`.
- Update Common Commands to project-manager equivalents (`uv sync`, `uv remove`, `uv sync --upgrade`, `uv tree`).

Closes #64

## Test plan

- Docs-only change; `uv run pytest` green locally (107 passed).

Made with [Cursor](https://cursor.com)