### PR TITLE
fix(units): accept CellMeta and explicit values instead of crashing on bare Data

### DIFF
--- a/.issueflows/03-solved-issues/issue68_original.md
+++ b/.issueflows/03-solved-issues/issue68_original.md
@@ -1,0 +1,13 @@
+# Issue #68: Units fallback: replace crashing data.<attr> fallback with explicit values or CellMeta
+
+Source: https://github.com/cellpy/cellpy-core/issues/68
+
+## Original issue text
+
+Deferred from #66 (code review 2026-07, item D4/A2).
+
+`units.get_converter_to_specific` reads `data.raw_units`, `data.mass`, `data.active_electrode_area`, `data.volume`; `nominal_capacity_as_absolute` reads `data.nom_cap_specifics`, `data.nom_cap`. The core `Data` class has none of these attributes, so the fallback path (taken whenever a caller omits `specific_converters` in `add_scaled_summary_columns`) raises `AttributeError` for standalone cellpy-core users.
+
+Make these functions take explicit values or a `metadata.CellMeta` (which already has `mass`, `active_electrode_area`, `nom_cap`, `nom_cap_specifics`) — a natural fit with the metadata-boundary decision. Also remove the pointless `try/except Exception: raise` block in `nominal_capacity_as_absolute`.
+
+See `.issueflows/04-designs-and-guides/code-review-2026-07.md` (A2, D4).

--- a/.issueflows/03-solved-issues/issue68_plan.md
+++ b/.issueflows/03-solved-issues/issue68_plan.md
@@ -1,0 +1,90 @@
+# Issue #68 plan: units fallback → explicit values / `CellMeta`
+
+## Goal
+
+Stop `get_converter_to_specific` and `nominal_capacity_as_absolute` from crashing on bare `Data` when callers omit `specific_converters`. Accept explicit scalars or `metadata.CellMeta`, keep cellpy duck-typed objects working, and fail with clear errors when required inputs are missing.
+
+## Constraints
+
+- **Metadata boundary** ([cellpy-core-migration.md](../04-designs-and-guides/cellpy-core-migration.md) §4): core must not require populated metadata on `Data`; `CellMeta` is opt-in scaffolding.
+- **Units boundary** ([cellpy-core-integration-roadmap.md](../04-designs-and-guides/cellpy-core-integration-roadmap.md) STEP-12): pint stays optional (`units` extra); hot path still passes conversion factors **by value** via `specific_converters`.
+- **Back-compat**: cellpy's richer data object (attrs on `.data`) must keep working without changes upstream in this PR.
+- **Parity**: existing golden floats in `tests/test_units_converters.py` must stay green.
+- **Scope**: `units.py` + thin `cell_core` wiring + tests only — no `CellpyUnits` promotion, no cellpy delegation.
+
+### Prior art
+
+- `cellpycore.units.get_converter_to_specific` / `nominal_capacity_as_absolute` — verbatim cellpy ports; duck-read `data.<attr>` today ([units.py](../../src/cellpycore/units.py)).
+- `CellpyCellCore._resolve_specific_converter` — only pint touch on summary path when `specific_converters` omitted ([cell_core.py](../../src/cellpycore/cell_core.py) ~382–399).
+- `metadata.CellMeta` — has `mass`, `active_electrode_area`, `nom_cap`, `nom_cap_specifics`; no `volume` / `raw_units` ([models.py](../../src/cellpycore/metadata/models.py)).
+- `tests/test_units_converters.py` — `_stub()` `SimpleNamespace` parity goldens (issue #40).
+- `tests/test_units_optional.py` — pint-absent guard; `_DummyData` fakes attrs pre-pint.
+- `tests/test_schema.py::test_native_add_scaled_summary_columns_end_to_end` — always passes `specific_converters` (bypasses broken fallback).
+- Toolbox: none relevant (`00-tools/` empty).
+
+## Approach
+
+### 1. Shared resolution helper(s) in `units.py`
+
+Add small private helpers (one generic `_resolve_attr` or per-field) with precedence:
+
+1. **Explicit kwarg** (e.g. `mass=`, `raw_units=`, `nom_cap=`)
+2. **`cell_meta: CellMeta | None`**
+3. **Duck-typed `data`** — `getattr(data, name, None)` only when not `None` (cellpy bridge)
+4. **`ValueError`** with actionable message (mode + which fields missing)
+
+`raw_units`: explicit `from_units` kwarg → duck `data.raw_units` → default `CellpyUnits()` (documented; matches “assume cellpy default units” when loader units unknown).
+
+`volume` (volumetric): explicit `value` only — `CellMeta` has `electrolyte_volume`, not electrode volume; do not map unless issue expands scope.
+
+### 2. `get_converter_to_specific`
+
+- Add optional kwargs: `cell_meta`, and/or explicit `mass`, `active_electrode_area`, `volume` (mode-dependent).
+- Keep `data` parameter (may be `None`) for signature stability and cellpy callers.
+- Apply resolution per mode before pint math.
+- Unknown mode → still return `1.0` (unchanged).
+
+### 3. `nominal_capacity_as_absolute`
+
+- Add optional `cell_meta: CellMeta | None`.
+- Explicit `value`, `specific`, `nom_cap_specifics` already exist — wire resolution: kwarg → `cell_meta` → duck `data`.
+- Add optional `raw_units` kwarg (default chain above) instead of only `data.raw_units` for `convert_charge_units=True`.
+- **Delete** the `try/except Exception as e: raise e` block; let pint errors propagate naturally.
+
+### 4. `cell_core` fallback path
+
+- Add optional `cell_meta: CellMeta | None = None` to `add_scaled_summary_columns` on `CellpyCellCore` (inherited by `OldCellpyCellCore`).
+- Thread `cell_meta` into `_resolve_specific_converter` → `get_converter_to_specific`.
+- Docstring: bare `Data` without `specific_converters` **or** `cell_meta` (and required geometry for the mode) raises `ValueError` — not `AttributeError`.
+
+No new attrs on `Data` itself (metadata boundary).
+
+## Files to touch
+
+| File | Change |
+|------|--------|
+| [`src/cellpycore/units.py`](../../src/cellpycore/units.py) | Resolution helpers; extend both public functions; remove pointless try/except |
+| [`src/cellpycore/cell_core.py`](../../src/cellpycore/cell_core.py) | `cell_meta` on `add_scaled_summary_columns` + `_resolve_specific_converter` |
+| [`tests/test_units_converters.py`](../../tests/test_units_converters.py) | `CellMeta` path tests; bare-missing-input `ValueError` tests; keep goldens |
+| [`tests/test_units_optional.py`](../../tests/test_units_optional.py) | Adjust `_DummyData` / guard test if signature changes |
+| [`tests/test_schema.py`](../../tests/test_schema.py) *(optional)* | One test: `add_scaled_summary_columns` without `specific_converters` but with `cell_meta` |
+
+## Test strategy
+
+```bash
+uv run pytest tests/test_units_converters.py tests/test_units_optional.py -q
+uv run pytest  # full suite before close
+```
+
+New cases:
+
+- `get_converter_to_specific(cell_meta=CellMeta(mass=2.0), mode="gravimetric")` → same golden as `_stub()`.
+- `nominal_capacity_as_absolute(cell_meta=CellMeta(...))` → gravimetric golden.
+- `get_converter_to_specific(data=Data(), mode="gravimetric")` → `ValueError` mentioning `mass`.
+- `add_scaled_summary_columns(..., specific_converters=None, cell_meta=...)` end-to-end on native polars summary (if not too heavy).
+
+## Open questions
+
+1. **`data` required vs optional** — plan keeps `data` as first positional arg (can be `None`) to avoid breaking cellpy; OK?
+2. **`raw_units` default** — `CellpyUnits()` when nothing supplied (vs hard error). Recommended: default, document in docstring.
+3. **Volumetric + `CellMeta`** — defer; volumetric still needs explicit `value` / duck `data.volume`. No `electrolyte_volume` mapping in this PR.

--- a/.issueflows/03-solved-issues/issue68_status.md
+++ b/.issueflows/03-solved-issues/issue68_status.md
@@ -1,0 +1,16 @@
+# Issue #68 status: units fallback → explicit values / `CellMeta`
+
+- [x] Done
+
+Plan: [issue68_plan.md](issue68_plan.md) (confirmed 2026-07-03)
+
+## What's done
+
+- `units.py`: `_resolve_optional_attr`, `_require_attr`, `_resolve_raw_units`; both public helpers accept explicit kwargs + `CellMeta`; pointless try/except removed
+- `cell_core.py`: optional `cell_meta` on `add_scaled_summary_columns` (native + legacy bridge) and `_resolve_specific_converter`
+- Tests: `CellMeta` + `ValueError` cases in `test_units_converters.py`; `test_native_add_scaled_summary_columns_with_cell_meta` in `test_schema.py`
+- Suite green: 127 passed (+ 3 deselected benchmarks)
+
+## Remaining work
+
+None.

--- a/.issueflows/04-designs-and-guides/this-project.md
+++ b/.issueflows/04-designs-and-guides/this-project.md
@@ -16,7 +16,7 @@ thread-safe, schema-injected, easy to extend.
 - Python >= 3.13, managed with `uv` (`.venv` in the repo root).
 - Engine is polars-native; pandas + pyarrow only for the legacy bridge and
   parquet fixtures. `pint` is an optional extra (`units`) for the unit helpers.
-- Lint/format: `ruff` (checked in CI). Tests: `pytest`.
+- Lint/format: `ruff` (checked in CI — same commands as the workflow). Tests: `pytest`.
 
 ## How to run / test
 
@@ -24,8 +24,21 @@ thread-safe, schema-injected, easy to extend.
 uv sync                      # install / sync dependencies
 uv run pytest                # full test suite (benchmarks excluded by default)
 uv run pytest -m benchmark   # opt-in performance benchmarks
-uv run ruff check && uv run ruff format --check   # lint / format checks
+
+# Lint / format — run before push (matches CI)
+uv run ruff check && uv run ruff format --check
+
+# Auto-fix what ruff can (unused imports, format, etc.)
+uv run ruff check --fix && uv run ruff format
 ```
+
+Run **both** check and format before opening a PR. CI runs `ruff check` and
+`ruff format --check` with no `--fix`; autofix locally, then re-run the check
+commands to confirm green.
+
+Optional: install [pre-commit](https://pre-commit.com/) and add a local hook that
+runs the same ruff commands — not configured in-repo yet, but a good guard if
+you commit often without running CI locally.
 
 ## Conventions
 
@@ -58,6 +71,6 @@ uv run ruff check && uv run ruff format --check   # lint / format checks
 - No instrument loaders, no file IO beyond test fixtures, no unit conversion
   on the hot path (conversion factors are passed by value).
 - `legacy_selectors.py` is bridge-only (pandas + `legacy_schema()`); not part of
-  the public API. `units.py` fallback needs a richer data object (issue #68).
+  the public API.
 - Per-step stat column names (`<signal>_<stat>`) are a fixed engine contract,
   not schema-injected (issue #70).

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Fix units fallback so `get_converter_to_specific` and
+  `nominal_capacity_as_absolute` accept explicit values or `CellMeta` instead of
+  crashing on bare `Data`; thread optional `cell_meta` through
+  `add_scaled_summary_columns`. (#68)
 - Move broken `selectors.py` helpers to bridge-only `legacy_selectors.py` with
   `legacy_schema()` default and unit + golden tests. (#67)
 - Rename test-data fixture prefix from vendor-specific `arbin` to generic `cycler`

--- a/src/cellpycore/cell_core.py
+++ b/src/cellpycore/cell_core.py
@@ -8,6 +8,7 @@ from typing import Callable, Iterable, List, Optional, Sequence, TypeVar, Union
 # The Data class can be accessed through the data property (setter and getter).
 from cellpycore import config, header_mapping
 from cellpycore.legacy import Meta, MockMetaTestDependent, NoDataFound
+from cellpycore.metadata.models import CellMeta
 
 DataFrame = TypeVar("DataFrame")
 
@@ -329,6 +330,7 @@ class CellpyCellCore:  # Rename to CellpyCell when cellpy core is ready
         step_txt: Optional[str] = None,
         specifics: Optional[List[str]] = None,
         specific_converters: Optional[dict] = None,
+        cell_meta: Optional[CellMeta] = None,
     ) -> Data:
         """Add specific summary columns to the summary.
 
@@ -342,6 +344,10 @@ class CellpyCellCore:  # Rename to CellpyCell when cellpy core is ready
                 by value by the caller (so this method needs no unit handling). If
                 not provided, the factors are computed lazily via the units helper
                 using ``self.cellpy_units`` as a fallback (legacy / standalone).
+            cell_meta: Optional ``CellMeta`` supplying geometry for the units
+                fallback when ``specific_converters`` is omitted. Bare ``Data``
+                without ``specific_converters`` or ``cell_meta`` raises
+                ``ValueError`` (not ``AttributeError``).
 
         Returns:
             The data with the specific summary columns added.
@@ -371,7 +377,7 @@ class CellpyCellCore:  # Rename to CellpyCell when cellpy core is ready
         specific_columns = schema.cycle.specific_columns
         for mode in specifics:
             converter = self._resolve_specific_converter(
-                data, mode, specific_converters
+                data, mode, specific_converters, cell_meta=cell_meta
             )
             data = summarizers.generate_specific_summary_columns(
                 data, mode, specific_columns, converter
@@ -380,7 +386,12 @@ class CellpyCellCore:  # Rename to CellpyCell when cellpy core is ready
         return data
 
     def _resolve_specific_converter(
-        self, data: Data, mode: str, specific_converters: Optional[dict]
+        self,
+        data: Data,
+        mode: str,
+        specific_converters: Optional[dict],
+        *,
+        cell_meta: Optional[CellMeta] = None,
     ) -> float:
         """Resolve the specific-capacity conversion factor for a mode.
 
@@ -395,7 +406,10 @@ class CellpyCellCore:  # Rename to CellpyCell when cellpy core is ready
         from cellpycore import units
 
         return units.get_converter_to_specific(
-            data=data, mode=mode, to_units=getattr(self, "cellpy_units", None)
+            data=data,
+            mode=mode,
+            to_units=getattr(self, "cellpy_units", None),
+            cell_meta=cell_meta,
         )
 
     def make_core_step_table(
@@ -775,6 +789,7 @@ class OldCellpyCellCore(CellpyCellCore):
         step_txt: Optional[str] = None,
         specifics: Optional[List[str]] = None,
         specific_converters: Optional[dict] = None,
+        cell_meta: Optional[CellMeta] = None,
     ) -> Data:
         """Legacy-bridge ``add_scaled_summary_columns`` (pandas<->polars seam).
 
@@ -810,7 +825,7 @@ class OldCellpyCellCore(CellpyCellCore):
         specific_columns = native_schema.cycle.specific_columns
         for mode in specifics:
             converter = self._resolve_specific_converter(
-                data, mode, specific_converters
+                data, mode, specific_converters, cell_meta=cell_meta
             )
             summarizers.generate_specific_summary_columns(
                 nd, mode, specific_columns, converter

--- a/src/cellpycore/units.py
+++ b/src/cellpycore/units.py
@@ -3,13 +3,10 @@ from __future__ import annotations
 import functools
 import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Optional, TypeVar
+from typing import Any, Optional, TypeVar
 
 from cellpycore.metadata.models import CellMeta
 from cellpycore.settings_base import BaseSettings
-
-if TYPE_CHECKING:
-    from cellpycore.cell_core import Data
 
 DataFrame = TypeVar("DataFrame")
 
@@ -226,36 +223,48 @@ def get_converter_to_specific(
     old_units = _resolve_raw_units(from_units, data)
 
     if mode == "gravimetric":
-        scale = value if value is not None else _resolve_optional_attr(
-            explicit=mass,
-            cell_meta=cell_meta,
-            meta_attr="mass",
-            data=data,
-            data_attr="mass",
+        scale = (
+            value
+            if value is not None
+            else _resolve_optional_attr(
+                explicit=mass,
+                cell_meta=cell_meta,
+                meta_attr="mass",
+                data=data,
+                data_attr="mass",
+            )
         )
         scale = _require_attr(scale, "mass", context="gravimetric mode")
         value = Q(scale, new_units["mass"])
         to_unit_specific = Q(1.0, new_units["specific_gravimetric"])
 
     elif mode == "areal":
-        scale = value if value is not None else _resolve_optional_attr(
-            explicit=active_electrode_area,
-            cell_meta=cell_meta,
-            meta_attr="active_electrode_area",
-            data=data,
-            data_attr="active_electrode_area",
+        scale = (
+            value
+            if value is not None
+            else _resolve_optional_attr(
+                explicit=active_electrode_area,
+                cell_meta=cell_meta,
+                meta_attr="active_electrode_area",
+                data=data,
+                data_attr="active_electrode_area",
+            )
         )
         scale = _require_attr(scale, "active_electrode_area", context="areal mode")
         value = Q(scale, new_units["area"])
         to_unit_specific = Q(1.0, new_units["specific_areal"])
 
     elif mode == "volumetric":
-        scale = value if value is not None else _resolve_optional_attr(
-            explicit=volume,
-            cell_meta=None,
-            meta_attr="volume",
-            data=data,
-            data_attr="volume",
+        scale = (
+            value
+            if value is not None
+            else _resolve_optional_attr(
+                explicit=volume,
+                cell_meta=None,
+                meta_attr="volume",
+                data=data,
+                data_attr="volume",
+            )
         )
         scale = _require_attr(scale, "volume", context="volumetric mode")
         value = Q(scale, new_units["volume"])

--- a/src/cellpycore/units.py
+++ b/src/cellpycore/units.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import functools
 import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional, TypeVar
+from typing import TYPE_CHECKING, Any, Optional, TypeVar
 
+from cellpycore.metadata.models import CellMeta
 from cellpycore.settings_base import BaseSettings
 
 if TYPE_CHECKING:
@@ -137,12 +138,63 @@ def get_default_output_units(*args, **kwargs) -> CellpyUnits:
     return CellpyUnits()
 
 
+def _resolve_optional_attr(
+    *,
+    explicit: Any,
+    cell_meta: Optional[CellMeta],
+    meta_attr: str,
+    data: Any,
+    data_attr: str,
+) -> Any:
+    """Resolve a scalar from explicit kwarg, ``CellMeta``, or duck-typed ``data``."""
+    if explicit is not None:
+        return explicit
+    if cell_meta is not None:
+        from_meta = getattr(cell_meta, meta_attr, None)
+        if from_meta is not None:
+            return from_meta
+    if data is not None:
+        from_data = getattr(data, data_attr, None)
+        if from_data is not None:
+            return from_data
+    return None
+
+
+def _require_attr(resolved: Any, name: str, *, context: str) -> Any:
+    """Raise ``ValueError`` when a required conversion input is missing."""
+    if resolved is None:
+        raise ValueError(
+            f"{name} is required for {context}; pass it explicitly, "
+            f"supply cell_meta, or use a data object with .{name}"
+        )
+    return resolved
+
+
+def _resolve_raw_units(
+    from_units: Optional[CellpyUnits],
+    data: Any,
+) -> CellpyUnits:
+    """Resolve raw/input charge units: explicit → duck ``data.raw_units`` → default."""
+    if from_units is not None:
+        return from_units
+    if data is not None:
+        raw_units = getattr(data, "raw_units", None)
+        if raw_units is not None:
+            return raw_units
+    return CellpyUnits()
+
+
 def get_converter_to_specific(
-    data: Data,
+    data: Any = None,
     value: float = None,
     from_units: CellpyUnits = None,
     to_units: CellpyUnits = None,
     mode: str = "gravimetric",
+    *,
+    cell_meta: Optional[CellMeta] = None,
+    mass: Optional[float] = None,
+    active_electrode_area: Optional[float] = None,
+    volume: Optional[float] = None,
 ) -> float:
     """Convert from absolute units to specific (areal or gravimetric).
 
@@ -150,35 +202,63 @@ def get_converter_to_specific(
     values with to get them into specific values.
 
     Args:
-        data: data instance
-        value: value used to scale on.
-        from_units: defaults to data.raw_units.
-        to_units: defaults to cellpy_units.
-        mode (str): gravimetric, areal or absolute
+        data: Optional data instance (cellpy's richer object may supply attrs).
+        value: Explicit scale value for the mode (mass, area, or volume).
+        from_units: Raw/input charge units; defaults to ``data.raw_units`` or
+            ``CellpyUnits()`` when unset.
+        to_units: Output units; defaults to cellpy units.
+        mode: ``gravimetric``, ``areal``, ``volumetric``, or ``absolute``.
+        cell_meta: Optional cell metadata (``mass``, ``active_electrode_area``).
+        mass: Explicit active-material mass (gravimetric mode).
+        active_electrode_area: Explicit electrode area (areal mode).
+        volume: Explicit electrode volume (volumetric mode).
 
     Returns:
-        conversion factor (float)
+        Conversion factor (float).
 
+    Raises:
+        ValueError: When a required scale value is missing for the chosen mode.
     """
     # TODO @jepe: implement handling of edge-cases
     # TODO @jepe: fix all the instrument readers (replace floats in raw_units with strings)
 
     new_units = to_units or get_cellpy_units()
-    old_units = from_units or data.raw_units
+    old_units = _resolve_raw_units(from_units, data)
 
     if mode == "gravimetric":
-        value = value or data.mass
-        value = Q(value, new_units["mass"])
+        scale = value if value is not None else _resolve_optional_attr(
+            explicit=mass,
+            cell_meta=cell_meta,
+            meta_attr="mass",
+            data=data,
+            data_attr="mass",
+        )
+        scale = _require_attr(scale, "mass", context="gravimetric mode")
+        value = Q(scale, new_units["mass"])
         to_unit_specific = Q(1.0, new_units["specific_gravimetric"])
 
     elif mode == "areal":
-        value = value or data.active_electrode_area
-        value = Q(value, new_units["area"])
+        scale = value if value is not None else _resolve_optional_attr(
+            explicit=active_electrode_area,
+            cell_meta=cell_meta,
+            meta_attr="active_electrode_area",
+            data=data,
+            data_attr="active_electrode_area",
+        )
+        scale = _require_attr(scale, "active_electrode_area", context="areal mode")
+        value = Q(scale, new_units["area"])
         to_unit_specific = Q(1.0, new_units["specific_areal"])
 
     elif mode == "volumetric":
-        value = value or data.volume
-        value = Q(value, new_units["volume"])
+        scale = value if value is not None else _resolve_optional_attr(
+            explicit=volume,
+            cell_meta=None,
+            meta_attr="volume",
+            data=data,
+            data_attr="volume",
+        )
+        scale = _require_attr(scale, "volume", context="volumetric mode")
+        value = Q(scale, new_units["volume"])
         to_unit_specific = Q(1.0, new_units["specific_volumetric"])
 
     elif mode == "absolute":
@@ -203,37 +283,93 @@ def get_converter_to_specific(
 
 
 def nominal_capacity_as_absolute(
-    data: Data,
+    data: Any = None,
     value: Optional[float] = None,
     specific: Optional[float] = None,
     nom_cap_specifics: Optional[str] = None,
     convert_charge_units: bool = False,
+    *,
+    cell_meta: Optional[CellMeta] = None,
+    raw_units: Optional[CellpyUnits] = None,
 ) -> float:
-    """Get the nominal capacity as absolute value."""
+    """Get the nominal capacity as absolute value.
+
+    Args:
+        data: Optional data instance (cellpy's richer object may supply attrs).
+        value: Nominal capacity in specific units (e.g. mAh/g).
+        specific: Scale factor (mass, area, …) matching ``nom_cap_specifics``.
+        nom_cap_specifics: How ``value`` is specified (gravimetric, areal, …).
+        convert_charge_units: Whether to convert between raw and cellpy charge units.
+        cell_meta: Optional cell metadata supplying ``nom_cap``, ``nom_cap_specifics``,
+            ``mass``, and ``active_electrode_area``.
+        raw_units: Raw charge units for ``convert_charge_units``; defaults to
+            ``data.raw_units`` or ``CellpyUnits()`` when unset.
+
+    Returns:
+        Absolute nominal capacity in Ah.
+
+    Raises:
+        ValueError: When required inputs cannot be resolved.
+        NotImplementedError: For volumetric mode.
+    """
 
     cellpy_units = get_cellpy_units()
 
     if nom_cap_specifics is None:
-        nom_cap_specifics = data.nom_cap_specifics
+        nom_cap_specifics = _resolve_optional_attr(
+            explicit=None,
+            cell_meta=cell_meta,
+            meta_attr="nom_cap_specifics",
+            data=data,
+            data_attr="nom_cap_specifics",
+        )
 
     if specific is None:
         if nom_cap_specifics == "gravimetric":
-            specific = data.mass
+            specific = _resolve_optional_attr(
+                explicit=None,
+                cell_meta=cell_meta,
+                meta_attr="mass",
+                data=data,
+                data_attr="mass",
+            )
         elif nom_cap_specifics == "areal":
-            specific = data.active_electrode_area
+            specific = _resolve_optional_attr(
+                explicit=None,
+                cell_meta=cell_meta,
+                meta_attr="active_electrode_area",
+                data=data,
+                data_attr="active_electrode_area",
+            )
 
         # TODO: implement volumetric
         elif nom_cap_specifics == "volumetric":
             raise NotImplementedError("volumetric not implemented yet")
 
     if value is None:
-        value = data.nom_cap
+        value = _resolve_optional_attr(
+            explicit=None,
+            cell_meta=cell_meta,
+            meta_attr="nom_cap",
+            data=data,
+            data_attr="nom_cap",
+        )
+
+    if value is None:
+        raise ValueError(
+            "nom_cap is required; pass value=, supply cell_meta, "
+            "or use a data object with .nom_cap"
+        )
 
     value = Q(value, cellpy_units["nominal_capacity"])
 
     if nom_cap_specifics == "gravimetric":
+        specific = _require_attr(specific, "mass", context="gravimetric nom_cap")
         specific = Q(specific, cellpy_units["mass"])
     elif nom_cap_specifics == "areal":
+        specific = _require_attr(
+            specific, "active_electrode_area", context="areal nom_cap"
+        )
         specific = Q(specific, cellpy_units["area"])
     elif nom_cap_specifics == "absolute":
         specific = 1
@@ -243,17 +379,15 @@ def nominal_capacity_as_absolute(
         raise NotImplementedError("volumetric not implemented yet")
 
     if convert_charge_units:
+        resolved_raw_units = _resolve_raw_units(raw_units, data)
         conversion_factor_charge = Q(1, cellpy_units["charge"]) / Q(
-            1, data.raw_units["charge"]
+            1, resolved_raw_units["charge"]
         )
     else:
         conversion_factor_charge = 1.0
 
-    try:
-        absolute_value = (
-            (value * conversion_factor_charge * specific).to_reduced_units().to("Ah")
-        )
-    except Exception as e:
-        raise e
+    absolute_value = (
+        (value * conversion_factor_charge * specific).to_reduced_units().to("Ah")
+    )
 
     return absolute_value.m

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -533,6 +533,33 @@ def test_native_add_scaled_summary_columns_end_to_end():
         assert g == pytest.approx(10.0 * b)
 
 
+def test_native_add_scaled_summary_columns_with_cell_meta():
+    """Units fallback via ``cell_meta`` works without ``specific_converters``."""
+    pytest.importorskip("pint")
+
+    from cellpycore.metadata.models import CellMeta
+
+    cell = CellpyCellCore(initialize=False)
+    nhdr = cell.schema.raw
+    chdr = cell.schema.cycle
+
+    data = _data_with_raw(nhdr)
+    cell.make_core_step_table(data, nom_cap=1.0)
+    cell.make_core_summary(data)
+    cell.add_scaled_summary_columns(
+        data,
+        nom_cap_abs=1.0,
+        normalization_cycles=None,
+        specifics=["gravimetric"],
+        cell_meta=CellMeta(mass=2.0),
+    )
+
+    base = data.summary[chdr.charge_capacity].to_list()
+    grav = data.summary[f"{chdr.charge_capacity}_gravimetric"].to_list()
+    for b, g in zip(base, grav):
+        assert g == pytest.approx(500.0 * b)
+
+
 # --- issue #41: per-test key + composite group keys -------------------------
 def _build_merged_raw(nhdr: RawCols) -> pd.DataFrame:
     """Two tests (test_id 0 and 1) with **overlapping** cycle_num/step_num.

--- a/tests/test_units_converters.py
+++ b/tests/test_units_converters.py
@@ -17,6 +17,8 @@ import pytest
 pytest.importorskip("pint")
 
 from cellpycore import units
+from cellpycore.cell_core import Data
+from cellpycore.metadata.models import CellMeta
 from cellpycore.units import CellpyUnits
 
 
@@ -69,12 +71,38 @@ def test_get_converter_to_specific_charge_unit_mismatch():
     ) == pytest.approx(500_000.0)
 
 
+def test_get_converter_to_specific_via_cell_meta():
+    meta = CellMeta(mass=2.0, active_electrode_area=2.0)
+    assert units.get_converter_to_specific(
+        data=None, cell_meta=meta, mode="gravimetric"
+    ) == pytest.approx(500.0)
+    assert units.get_converter_to_specific(
+        data=None, cell_meta=meta, mode="areal"
+    ) == pytest.approx(0.5)
+
+
+def test_get_converter_to_specific_bare_data_raises_value_error():
+    with pytest.raises(ValueError, match="mass"):
+        units.get_converter_to_specific(Data(), mode="gravimetric")
+
+
 # --- nominal_capacity_as_absolute ---------------------------------------------
 # Gravimetric, default units: (nom_cap mAh/g * mass mg).to("Ah")
 #   = nom_cap * mass * 1e-6 Ah. With nom_cap=3000, mass=2.0 -> 0.006 Ah.
 def test_nominal_capacity_as_absolute_gravimetric():
     assert units.nominal_capacity_as_absolute(
         _stub(), nom_cap_specifics="gravimetric"
+    ) == pytest.approx(0.006)
+
+
+def test_nominal_capacity_as_absolute_via_cell_meta():
+    meta = CellMeta(
+        mass=2.0,
+        nom_cap=3000.0,
+        nom_cap_specifics="gravimetric",
+    )
+    assert units.nominal_capacity_as_absolute(
+        data=None, cell_meta=meta, nom_cap_specifics="gravimetric"
     ) == pytest.approx(0.006)
 
 


### PR DESCRIPTION
## Summary

- `get_converter_to_specific` and `nominal_capacity_as_absolute` resolve scale values from explicit kwargs, optional `CellMeta`, or duck-typed cellpy data objects (precedence in that order), and raise clear `ValueError`s when required geometry is missing.
- Optional `cell_meta` on `add_scaled_summary_columns` (native + legacy bridge) threads through the pint fallback when `specific_converters` is omitted.
- Removes the pointless `try/except` re-raise in `nominal_capacity_as_absolute`.

Closes #68

## Test plan

- [x] `uv run pytest tests/test_units_converters.py tests/test_units_optional.py -q`
- [x] `uv run pytest` — 127 passed (+ 3 deselected)
- [x] New: `CellMeta` path, bare `Data` → `ValueError`, `add_scaled_summary_columns` with `cell_meta` end-to-end


Made with [Cursor](https://cursor.com)