### PR TITLE
Document step stat contract and align cycle_mode default (B1/B2)

### DIFF
--- a/.issueflows/03-solved-issues/issue70_original.md
+++ b/.issueflows/03-solved-issues/issue70_original.md
@@ -1,0 +1,15 @@
+# Issue #70: Design pass: schema-agnostic step-stat columns (B1) and cycle_mode default polarity (B2)
+
+Source: https://github.com/cellpy/cellpy-core/issues/70
+
+## Original issue text
+
+Deferred from #66 (code review 2026-07, items B1 + B2).
+
+**B1 — schema-agnosticism is only partial in the step engine.** Per-step statistic columns are hardcoded as `f"{base}_{stat}"` and the classifier reads `pl.col("current_mean")` etc.; injected `StepCols` values apply only to group keys, `step_type` and `c_rate`. Either derive stat column names from the schema, or (cheaper, recommended by the review) document the `<signal>_<stat>` names as a fixed engine contract.
+
+**B2 — default-polarity inconsistency in `cycle_mode`.** `MockMetaTestDependent.cycle_mode = "anode"` means an initialized `Data` defaults to INVERTED mode, while an uninitialized cell (`_cycle_mode = None`) resolves to NORMAL — the exact "default-polarity trap" the `config.TestMode` docstring warns about.
+
+Decide document-vs-fix for each and implement.
+
+See `.issueflows/04-designs-and-guides/code-review-2026-07.md` (B1, B2).

--- a/.issueflows/03-solved-issues/issue70_plan.md
+++ b/.issueflows/03-solved-issues/issue70_plan.md
@@ -1,0 +1,127 @@
+# Issue #70 — plan
+
+## Goal
+
+Close code-review items **B1** and **B2**: make the step-engine stat-column naming
+contract explicit, and remove the `cycle_mode` default-polarity trap inside
+cellpy-core so an initialized vs uninitialized `CellpyCellCore` behaves the same
+unless the caller sets `cycle_mode` explicitly.
+
+## Constraints
+
+- **B1: document, not refactor.** The 2026-07 review recommends documenting
+  `<signal>_<stat>` as a fixed engine contract rather than deriving names from
+  injected `StepCols`. Issue #43 already followed that pattern for
+  `ref_potential`. No change to aggregation or classifier logic.
+- **B2: fix the inconsistency, keep cellpy bridge path explicit.** Changing the
+  core default to “unset → NORMAL” is intentional: it matches `TestMode` /
+  batbase and the uninitialized `_cycle_mode = None` path. Legacy cellpy’s
+  historical `"anode"` default remains the bridge’s job when loading real cells
+  (document, do not silently reintroduce `"anode"` in core).
+- **Parity:** golden / legacy-bridge tests must stay green. Native API tests may
+  need CE-direction updates only if they implicitly relied on the old anode
+  default (grep shows none beyond round-trip self-consistency).
+- **Scope:** docs + small defaults/helper only. No schema-derived stat rename,
+  no metadata wiring, no `make_step_table` refactor.
+
+### Prior art
+
+- [`code-review-2026-07.md`](../04-designs-and-guides/code-review-2026-07.md) §B1, §B2 — source findings; review recommends document for B1.
+- [`issue43_plan.md`](../03-solved-issues/issue43_plan.md) — “Engine stat-column contract: hardcoded `f"{base}_{stat}"`”; mirror that decision.
+- [`this-project.md`](../04-designs-and-guides/this-project.md) — already notes stat columns as fixed contract (issue #70); line 48 still overclaims full schema injection — update in same PR.
+- [`docs/standalone-use.md`](../../docs/standalone-use.md) — “cycle-mode trap” section documents old `"anode"` default; must be updated if B2 fix lands.
+- `summarizers.make_step_table` — aggregation at `f"{base}_{stat}"` (lines 454–457); classifier hardcodes `pl.col("current_mean")` etc. (lines 273–279); only group keys + `step_type` / `c_rate` use injected `StepCols` (lines 498–506).
+- `header_mapping.STAT_SUFFIXES` + `OldCellpyCellCore._legacy_step_column_order` — legacy rename path; unchanged by B1 docs.
+- `config.TestMode` docstring — already warns about batbase NORMAL vs cellpy `"anode"`; extend cross-link to `MockMetaTestDependent`.
+- `tests/test_schema.py::test_make_summary_anode_flips_coulombic_columns` — explicit `TestMode` test; reuse pattern for default-mode test.
+- Graph communities 0 / engine hub (`summarizers.py`, `config.py`, `cell_core.py`) — confirms touch surface.
+- `.issueflows/00-tools/` — nothing relevant.
+
+## Approach
+
+### B1 — document the stat-column engine contract
+
+1. **`config.StepCols` docstring** — add a `Note:` block: attributes name the
+   **native output columns** for the default contract; the step engine builds
+   intermediate aggregates as `<base>_<stat>` where `<base>` comes from
+   `_SIGNAL_BASES` / raw column stems (`current`, `potential`, …) and `<stat>`
+   is one of `mean|std|min|max|first|last|delta`. Custom `StepCols.current_mean`
+   (etc.) does **not** retarget aggregation or classification today; only group
+   keys, `step_type`, and `c_rate` honour injected renames. Legacy bridge renames
+   via `header_mapping.native_to_legacy_step()` after the engine runs.
+2. **`summarizers.make_step_table` docstring** — same `Note:` (shorter); point
+   readers to `StepCols`.
+3. **`summarizers.py` module comment** (lines 20–23) — nuance “schema-agnostic”:
+   raw/cycle/step *keys* and summary column aliases are injected; per-step stat
+   column stems are a fixed contract.
+4. **`this-project.md`** — tighten conventions bullet: group keys and summary
+   headers are schema-injected; per-step stat stems are not.
+5. **`code-review-2026-07.md`** — mark B1 resolved (documented, 2026-07-03).
+
+**Optional guard test** (recommended, ~15 lines): after `make_step_table` on
+synthetic raw data, assert every `StepCols` `*_mean|*_delta|…` default name that
+corresponds to a present signal exists as a column. Documents the contract in
+tests without custom-schema rename coverage.
+
+### B2 — align default polarity to NORMAL (unset)
+
+**Decision:** `None` / unset → `TestMode.NORMAL`; only explicit `"anode"` →
+`TestMode.INVERTED`. Fixes the initialize=True vs initialize=False split.
+
+1. **`legacy.MockMetaTestDependent`**
+   - Change `cycle_mode: str = "anode"` → `cycle_mode: Optional[str] = None`.
+   - Docstring: placeholder for graceful degradation; `None` means normal
+     convention; cellpy bridge / caller must set `"anode"` for half-cells.
+2. **`cell_core.py`**
+   - Add small helper `_cycle_mode_to_test_mode(cycle_mode: str | None) -> TestMode`
+     (or method on `CellpyCellCore`): `"anode"` → `INVERTED`, else `NORMAL`
+     (including `None`).
+   - Use it in `make_core_summary` (and anywhere else the same
+     `if self.cycle_mode == "anode"` pattern appears: `add_scaled_summary_columns`,
+     `OldCellpyCellCore.add_scaled_summary_columns`) so logic is single-sourced.
+   - Annotate `cycle_mode` property return as `Optional[str]`; no behaviour change
+     to getter/setter beyond the new default on fresh `Data`.
+3. **Docs**
+   - Update [`docs/standalone-use.md`](../../docs/standalone-use.md) trap section:
+     fresh `Data` now defaults to normal convention; set `core.cycle_mode = "anode"`
+     for half-cells. Keep explicit mapping table.
+   - Cross-link from `config.TestMode` docstring to `MockMetaTestDependent`.
+4. **`code-review-2026-07.md`** — mark B2 resolved.
+
+## Files to touch
+
+| File | Change |
+| --- | --- |
+| [`src/cellpycore/config.py`](../../src/cellpycore/config.py) | `StepCols` contract `Note:`; optional `TestMode` cross-link |
+| [`src/cellpycore/summarizers.py`](../../src/cellpycore/summarizers.py) | Module comment + `make_step_table` `Note:` |
+| [`src/cellpycore/legacy.py`](../../src/cellpycore/legacy.py) | `MockMetaTestDependent.cycle_mode = None` + docstring |
+| [`src/cellpycore/cell_core.py`](../../src/cellpycore/cell_core.py) | `_cycle_mode_to_test_mode` helper; replace inline `"anode"` checks |
+| [`docs/standalone-use.md`](../../docs/standalone-use.md) | Updated default-polarity guidance |
+| [`.issueflows/04-designs-and-guides/this-project.md`](../04-designs-and-guides/this-project.md) | Nuance schema-injection convention |
+| [`.issueflows/04-designs-and-guides/code-review-2026-07.md`](../04-designs-and-guides/code-review-2026-07.md) | Mark B1 + B2 resolved |
+| [`tests/test_schema.py`](../../tests/test_schema.py) or new small test file | Contract column test (B1); default `cycle_mode` → NORMAL summary test (B2) |
+
+## Test strategy
+
+```bash
+uv run pytest tests/test_schema.py tests/test_creation.py -q
+uv run pytest -q   # full suite before close
+uv run ruff check && uv run ruff format --check
+```
+
+**New tests**
+
+- **B1:** `test_step_table_stat_columns_match_stepcols_defaults` — default schema,
+  synthetic raw with core signals → step columns include expected stat names.
+- **B2:** `test_default_cycle_mode_is_normal_convention` — fresh `Data()` +
+  `CellpyCellCore.make_core_summary` CE direction matches
+  `TestMode.NORMAL`; separate assert that `cycle_mode="anode"` still flips
+  (can extend existing anode test or add integration via `CellpyCellCore`).
+
+## Open questions
+
+1. **Breaking-change notice:** default CE direction changes for callers who never
+   set `cycle_mode` on native `Data()` / `CellpyCellCore`. Acceptable for
+   pre-release core? (Recommend yes — fixes the documented trap; note in PR body.)
+2. **B1 guard test:** include the optional contract assertion test, or docs-only?
+   (Recommend include — cheap, prevents doc drift.)

--- a/.issueflows/03-solved-issues/issue70_status.md
+++ b/.issueflows/03-solved-issues/issue70_status.md
@@ -1,0 +1,15 @@
+# Issue #70 — status
+
+- [x] Done
+
+## What's done
+
+- **B1:** Documented `<signal>_<stat>` engine contract in `StepCols`, `make_step_table`, `summarizers` module comment, `this-project.md`; marked resolved in code-review doc.
+- **B2:** `MockMetaTestDependent.cycle_mode = None`; `_cycle_mode_to_test_mode` in `cell_core.py`; updated `standalone-use.md` and `TestMode` docstring.
+- **Tests:** `test_step_table_stat_columns_match_stepcols_defaults`, default/anode `CellpyCellCore` CE tests, initialize consistency test.
+- **Verification:** `uv run pytest` — 131 passed; ruff check/format clean on touched source files.
+- **Land:** HISTORY.md, commit, PR opened.
+
+## Remaining work
+
+- None.

--- a/.issueflows/04-designs-and-guides/code-review-2026-07.md
+++ b/.issueflows/04-designs-and-guides/code-review-2026-07.md
@@ -107,6 +107,10 @@ properties over `steps` / `summary`.
 
 ### B1. Schema-agnosticism is only partial in the step engine
 
+> **Resolved (#70, 2026-07-03):** documented ``<signal>_<stat>`` as a fixed engine
+> contract in ``StepCols``, ``make_step_table``, and ``this-project.md``; no
+> schema-derived stat rename.
+
 The per-step statistic columns are hardcoded as `f"{base}_{stat}"` (and the
 classifier reads `pl.col("current_mean")` etc.). The injected `StepCols`
 values are applied only to the group keys, `step_type` and `c_rate`. A custom
@@ -115,6 +119,10 @@ names from the schema, or (cheaper, recommended) document that the
 `<signal>_<stat>` names are a fixed engine contract.
 
 ### B2. Default-polarity inconsistency in `cycle_mode`
+
+> **Resolved (#70, 2026-07-03):** ``MockMetaTestDependent.cycle_mode`` defaults to
+> ``None`` (``NORMAL``); ``CellpyCellCore`` maps via ``_cycle_mode_to_test_mode``.
+> Legacy cellpy ``"anode"`` remains the bridge's explicit job.
 
 `MockMetaTestDependent.cycle_mode = "anode"` means an **initialized** `Data`
 defaults to INVERTED mode, while an uninitialized cell

--- a/.issueflows/04-designs-and-guides/this-project.md
+++ b/.issueflows/04-designs-and-guides/this-project.md
@@ -45,9 +45,10 @@ you commit often without running CI locally.
 - Issue work on `<N>-<short-slug>` branches; Conventional Commits; squash
   merges on GitHub. Issue tracking lives under `.issueflows/`.
 - Google-style docstrings everywhere.
-- Column names are never hardcoded in the engine: they come from an injected
-  `config.Schema` (native `RawCols`/`StepCols`/`CycleCols`, or the legacy
-  headers via the bridge).
+- Column names for raw / cycle / step **group keys** and summary aliases come
+  from an injected ``config.Schema``. Per-step stat column stems
+  (``<signal>_<stat>``) are a **fixed engine contract**, not schema-injected
+  (see issue #70 / ``StepCols`` docstring).
 - Parity with legacy cellpy is enforced by tests (golden parquet fixtures in
   `tests/data/`, see `tests/data/README.md`), not by vigilance.
 - Metadata boundary: core ships metadata *scaffolding* (`cellpycore.metadata`)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Document the per-step `<signal>_<stat>` engine contract (B1) and default unset
+  `cycle_mode` to NORMAL via `_cycle_mode_to_test_mode`, so initialized and
+  uninitialized `CellpyCellCore` share the same polarity unless `"anode"` is set
+  explicitly. (#70)
 - Fix units fallback so `get_converter_to_specific` and
   `nominal_capacity_as_absolute` accept explicit values or `CellMeta` instead of
   crashing on bare `Data`; thread optional `cell_meta` through

--- a/docs/standalone-use.md
+++ b/docs/standalone-use.md
@@ -23,7 +23,7 @@ from cellpycore.cell_core import CellpyCellCore, Data
 
 core = CellpyCellCore()
 core.data = Data.from_raw_frame(my_polars_frame)  # validates against config.RawCols
-core.cycle_mode = "standard"                      # see the cycle-mode trap below
+core.cycle_mode = "anode"                          # half-cells only; unset = normal
 
 data = core.make_core_step_table(
     core.data,
@@ -50,16 +50,19 @@ a polars `DataFrame` carrying the load-bearing `RawCols` columns with sane
 dtypes and reports every problem in a single error. Pass `validate=False` to
 skip the checks (e.g. in a hot loop after the shape is known-good).
 
-### The cycle-mode trap
+### The cycle-mode default
 
 `cycle_mode` decides the coulombic-efficiency direction (and which capacity
-column "comes first"). For historical cellpy reasons the metadata placeholder
-on a fresh `Data` defaults to `"anode"` (anode half-cell, inverted convention)
-— **not** `"standard"`. Set it explicitly:
+column "comes first"). A fresh ``Data`` leaves ``cycle_mode`` unset
+(``None``), which the engine treats as **normal** convention — set it
+explicitly for half-cells:
 
+- unset / `"standard"` / `"cathode"` / `"full_cell"` / … — normal convention
+  (`CE = 100 * discharge / charge`).
 - `"anode"` — anode half-cell (inverted; `CE = 100 * charge / discharge`).
-- anything else (`"standard"`, `"cathode"`, `"full_cell"`, …) — normal
-  convention (`CE = 100 * discharge / charge`).
+
+Legacy cellpy historically defaulted to `"anode"`; the cellpy bridge must set
+that when loading real cells. Do not rely on implicit defaults across layers.
 
 ### Useful knobs
 
@@ -99,8 +102,9 @@ handling done for you, and the IR / C-rate orchestration
 - **Order matters.** Step table before summary — `make_summary` reads
   `data.steps`.
 - **No metadata required.** `Data()` ships a `MockMetaTestDependent`
-  placeholder; the engine never needs populated cell metadata. Only
-  `cycle_mode` changes the math (CE direction — see the trap above).
+  placeholder; the engine never needs populated cell metadata. Only an
+  explicit `cycle_mode` (e.g. `"anode"`) changes the math (CE direction — see
+  above).
 - **Units by value.** The core never sees unit objects. The caller precomputes
   plain floats: `nom_cap` / `nom_cap_abs`, `current_conversion_factor`, and the
   `specific_converters` mapping. The pint-backed helpers in `cellpycore.units`

--- a/src/cellpycore/cell_core.py
+++ b/src/cellpycore/cell_core.py
@@ -15,6 +15,21 @@ DataFrame = TypeVar("DataFrame")
 logger = logging.getLogger(__name__)
 
 
+def _cycle_mode_to_test_mode(cycle_mode: Optional[str]) -> config.TestMode:
+    """Map legacy ``cycle_mode`` string to ``TestMode``.
+
+    Args:
+        cycle_mode: Legacy mode string (``"anode"`` selects inverted convention).
+            ``None`` and all other values map to ``TestMode.NORMAL``.
+
+    Returns:
+        The corresponding ``TestMode`` for summary sign conventions.
+    """
+    if cycle_mode == "anode":
+        return config.TestMode.INVERTED
+    return config.TestMode.NORMAL
+
+
 def validate_raw_frame(raw, raw_cols: Optional[config.Cols] = None) -> None:
     """Validate a native-schema raw frame against ``config.RawCols``.
 
@@ -212,7 +227,7 @@ class CellpyCellCore:  # Rename to CellpyCell when cellpy core is ready
         self._data = new_data
 
     @property
-    def cycle_mode(self) -> str:
+    def cycle_mode(self) -> Optional[str]:
         # TODO: v2.0 edit this from scalar to list
         try:
             data = self.data
@@ -300,11 +315,7 @@ class CellpyCellCore:  # Rename to CellpyCell when cellpy core is ready
         # added only on the legacy bridge (``OldCellpyCellCore.make_core_summary``).
         time_00 = time.time()
         logger.debug("start making summary (native polars engine)")
-        test_mode = (
-            config.TestMode.INVERTED
-            if self.cycle_mode == "anode"
-            else config.TestMode.NORMAL
-        )
+        test_mode = _cycle_mode_to_test_mode(self.cycle_mode)
         data = summarizers.make_summary(
             data,
             self.schema,
@@ -360,10 +371,11 @@ class CellpyCellCore:  # Rename to CellpyCell when cellpy core is ready
             specifics = ["gravimetric", "areal", "absolute"]
 
         if step_txt is None:
-            if self.cycle_mode == "anode":
-                step_txt = schema.cycle.discharge_capacity
-            else:
-                step_txt = schema.cycle.charge_capacity
+            step_txt = (
+                schema.cycle.discharge_capacity
+                if _cycle_mode_to_test_mode(self.cycle_mode) == config.TestMode.INVERTED
+                else schema.cycle.charge_capacity
+            )
 
         data = summarizers.equivalent_cycles_to_summary(
             data, schema, nom_cap_abs, normalization_cycles, step_txt
@@ -815,7 +827,7 @@ class OldCellpyCellCore(CellpyCellCore):
         if step_txt is None:
             step_txt = (
                 native_schema.cycle.discharge_capacity
-                if self.cycle_mode == "anode"
+                if _cycle_mode_to_test_mode(self.cycle_mode) == config.TestMode.INVERTED
                 else native_schema.cycle.charge_capacity
             )
 

--- a/src/cellpycore/config.py
+++ b/src/cellpycore/config.py
@@ -68,7 +68,9 @@ class TestMode(StrEnum):
         - Default-polarity trap: batbase defaults to ``NORMAL``, but cellpy
           historically defaulted ``cycle_mode="anode"`` (i.e. ``INVERTED``).
           When bridging metadata into the engine, map the mode explicitly and
-          do not rely on either side's implicit default.
+          do not rely on either side's implicit default. The core
+          ``legacy.MockMetaTestDependent`` placeholder defaults to ``None``
+          (``NORMAL``); only an explicit ``"anode"`` selects ``INVERTED``.
     """
 
     NORMAL = "normal"
@@ -452,6 +454,18 @@ class StepCols(Cols):
     per-step summary (per-step statistics such as mean/std/min/max/first/last/
     delta for time, current, potential, capacity, energy, power and internal
     resistance, plus the per-step C-rate estimate).
+
+    Note:
+        Attributes name the **native output columns** for the default contract.
+        The step engine builds aggregates as ``<base>_<stat>`` where ``<base>``
+        comes from the raw signal stems in ``summarizers._SIGNAL_BASES``
+        (``current``, ``potential``, ``charge_capacity``, …) and ``<stat>`` is
+        one of ``mean``, ``std``, ``min``, ``max``, ``first``, ``last``, or
+        ``delta``. Custom ``StepCols.current_mean`` (etc.) does **not** retarget
+        aggregation or step-type classification today; only group keys,
+        ``step_type``, and ``c_rate`` honour injected renames. The legacy bridge
+        renames via ``header_mapping.native_to_legacy_step()`` after the engine
+        runs.
     """
 
     # Compact per-test key (mirrors ``RawCols.test_id``); the leading component of

--- a/src/cellpycore/legacy.py
+++ b/src/cellpycore/legacy.py
@@ -3,7 +3,7 @@
 import logging
 import numbers
 from dataclasses import dataclass
-from typing import List
+from typing import List, Optional
 
 from cellpycore.config import STEP_TYPES  # noqa: F401  (re-exported; see note below)
 
@@ -75,7 +75,16 @@ class Meta:
 
 
 class MockMetaTestDependent(Meta):
-    cycle_mode: str = "anode"
+    """Graceful-degradation metadata placeholder on ``Data``.
+
+    ``cycle_mode`` is optional. ``None`` (the default) means normal full-cell /
+    cathode convention at the engine boundary; set ``"anode"`` explicitly for
+    half-cell (inverted) tests. Legacy cellpy historically defaulted to
+    ``"anode"`` — the cellpy bridge must set that when loading real cells, not
+    rely on this placeholder default.
+    """
+
+    cycle_mode: Optional[str] = None
 
 
 # -----------------------------------------------------------------------------

--- a/src/cellpycore/summarizers.py
+++ b/src/cellpycore/summarizers.py
@@ -18,9 +18,10 @@ Array = TypeVar("Array")
 
 
 # The summarizer bodies read their column names from an injected ``Schema`` (see
-# config.Schema) instead of module-level header globals. This keeps the engine
-# schema-agnostic and thread-safe; the legacy bridge (OldCellpyCellCore) injects
-# the legacy-named schema, a native CellpyCellCore injects the native one.
+# config.Schema) instead of module-level header globals. Raw / cycle / step group
+# keys and summary column aliases are schema-injected and thread-safe; per-step
+# stat column stems (``<base>_<stat>``) are a fixed engine contract — see
+# ``StepCols`` and ``make_step_table``.
 
 
 # Standalone default step-detection limits, derived from the CellpyLimits
@@ -367,6 +368,11 @@ def make_step_table(
         from_data_point (int): first data point to use.
         raw_limits (dict): the raw limits (resolution) for the instrument.
             Defaults to a fresh copy of ``DEFAULT_RAW_LIMITS``.
+
+    Note:
+        Per-step statistic columns are emitted as ``<base>_<stat>`` (fixed engine
+        contract). Only group keys, ``step_type``, and ``c_rate`` honour injected
+        ``StepCols`` renames. See ``config.StepCols`` for the full contract.
 
     Returns:
         core.Data: The data object with the step table added if from_data_point is None,

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -384,6 +384,94 @@ def test_make_summary_anode_flips_coulombic_columns():
         assert cd_anode[i] == pytest.approx(dc[i] - cc[i])
 
 
+# --- issue #70: stat-column contract + cycle_mode default --------------------
+_STAT_SUFFIXES = ("mean", "std", "min", "max", "first", "last", "delta")
+
+_STEP_TABLE_BASES = (
+    "datapoint_num",
+    "test_time",
+    "step_time",
+    "current",
+    "potential",
+    "charge_capacity",
+    "discharge_capacity",
+    "internal_resistance",
+)
+
+
+def test_step_table_stat_columns_match_stepcols_defaults():
+    """Per-step stat columns follow the fixed ``<base>_<stat>`` engine contract."""
+    schema = default_schema()
+    shdr = schema.step
+    data = Data()
+    data.raw = _build_raw(RawCols())
+
+    summarizers.make_step_table(data, schema=schema, nom_cap=1.0)
+    steps = data.steps
+
+    for base in _STEP_TABLE_BASES:
+        for stat in _STAT_SUFFIXES:
+            col = f"{base}_{stat}"
+            assert col in steps.columns
+            attr = f"{base}_{stat}"
+            if hasattr(shdr, attr):
+                assert getattr(shdr, attr) == col
+
+
+def test_default_cycle_mode_is_normal_convention():
+    """Fresh Data() with unset cycle_mode uses NORMAL CE via CellpyCellCore."""
+    nhdr = RawCols()
+    chdr = default_schema().cycle
+    data = Data()
+    data.raw = _build_cumulative_raw(nhdr)
+
+    core = CellpyCellCore()
+    core.data = data
+    assert core.cycle_mode is None
+
+    data = core.make_core_step_table(data, nom_cap=1.0)
+    data = core.make_core_summary(data)
+    s = data.summary
+
+    cc = s[chdr.charge_capacity].to_list()
+    dc = s[chdr.discharge_capacity].to_list()
+    ce = s[chdr.coulombic_efficiency].to_list()
+    cd = s[chdr.coulombic_difference].to_list()
+    for i in range(len(cc)):
+        assert ce[i] == pytest.approx(100.0 * dc[i] / cc[i])
+        assert cd[i] == pytest.approx(cc[i] - dc[i])
+
+
+def test_cycle_mode_anode_via_cellpy_cell_core():
+    """Explicit cycle_mode='anode' still selects INVERTED CE direction."""
+    nhdr = RawCols()
+    chdr = default_schema().cycle
+    data = Data()
+    data.raw = _build_cumulative_raw(nhdr)
+
+    core = CellpyCellCore()
+    core.data = data
+    core.cycle_mode = "anode"
+
+    data = core.make_core_step_table(data, nom_cap=1.0)
+    data = core.make_core_summary(data)
+    s = data.summary
+
+    cc = s[chdr.charge_capacity].to_list()
+    dc = s[chdr.discharge_capacity].to_list()
+    ce = s[chdr.coulombic_efficiency].to_list()
+    cd = s[chdr.coulombic_difference].to_list()
+    for i in range(len(cc)):
+        assert ce[i] == pytest.approx(100.0 * cc[i] / dc[i])
+        assert cd[i] == pytest.approx(dc[i] - cc[i])
+
+
+def test_initialized_and_uninitialized_core_share_cycle_mode_default():
+    """initialize=True vs False must not diverge on default polarity."""
+    assert CellpyCellCore(initialize=False).cycle_mode is None
+    assert CellpyCellCore(initialize=True).cycle_mode is None
+
+
 def test_c_rates_to_summary_native():
     """c_rates_to_summary joins per-cycle first charge/discharge C-rates (native)."""
     nhdr = RawCols()


### PR DESCRIPTION
## Summary

- **B1:** Document per-step stat columns as a fixed `<signal>_<stat>` engine contract in `StepCols`, `make_step_table`, and project docs (no schema-derived rename refactor).
- **B2:** Default unset `cycle_mode` to NORMAL: `MockMetaTestDependent.cycle_mode = None`, centralised mapping via `_cycle_mode_to_test_mode()` in `cell_core.py`. Explicit `"anode"` still selects INVERTED.

## Breaking change

Fresh `Data()` / unset `cycle_mode` now uses normal CE convention (was implicit INVERTED via `"anode"` placeholder). Legacy cellpy bridge must set `"anode"` explicitly when loading half-cell data.

## Test plan

- [x] `uv run pytest` — 131 passed
- [x] `uv run ruff check && uv run ruff format --check`
- [x] New tests: stat-column contract, default NORMAL CE, explicit anode flip, initialize consistency

Closes #70

Made with [Cursor](https://cursor.com)