### PR TITLE
Add pre-commit hooks for ruff lint and format

### DIFF
--- a/.issueflows/03-solved-issues/issue84_original.md
+++ b/.issueflows/03-solved-issues/issue84_original.md
@@ -1,0 +1,7 @@
+# Issue #84: add auto precommit
+
+Source: https://github.com/cellpy/cellpy-core/issues/84
+
+## Original issue text
+
+we should use precommit hook for ruff check --fix.

--- a/.issueflows/03-solved-issues/issue84_plan.md
+++ b/.issueflows/03-solved-issues/issue84_plan.md
@@ -1,0 +1,71 @@
+# Issue #84 plan — add auto precommit
+
+## Goal
+
+Configure in-repo [pre-commit](https://pre-commit.com/) so commits auto-run
+`ruff check --fix` and `ruff format`, matching local dev guidance and CI lint
+steps in [`.github/workflows/simpletest.yml`](../../.github/workflows/simpletest.yml).
+
+## Constraints
+
+- No CI/workflow changes — pre-commit is a **local** guard only.
+- Keep scope minimal: config + dev dep + doc updates; no new test modules.
+- Use project's existing ruff config in [`pyproject.toml`](../../pyproject.toml)
+  (`[tool.ruff]`, dev dep `ruff>=0.11.8`).
+- Run/install via `uv` per
+  [this-project.md](../04-designs-and-guides/this-project.md).
+
+### Prior art
+
+- **CI lint commands** — [`.github/workflows/simpletest.yml`](../../.github/workflows/simpletest.yml)
+  lines 31–34: `uv run ruff check` + `uv run ruff format --check` (no `--fix` in CI).
+- **Local lint guidance** — [this-project.md](../04-designs-and-guides/this-project.md):
+  autofix with `uv run ruff check --fix && uv run ruff format`; notes pre-commit
+  "not configured in-repo yet".
+- **Issue #66** — added ruff to CI and `[tool.ruff]` config; this issue completes
+  the local hook story.
+- **Toolbox** — [`.issueflows/00-tools/`](../00-tools/) empty (no helpers).
+- **Sibling repos** — no `.pre-commit-config.yaml` in cellpy or batbase.
+- **Graph** — no relevant hits in `GRAPH_REPORT.md`.
+
+## Approach
+
+Use **local pre-commit hooks** (`language: system`) that invoke `uv run ruff …`
+so hook runs use the same ruff version as [`uv.lock`](../../uv.lock), not a
+separate pin in `ruff-pre-commit`.
+
+1. Add `pre-commit` to `[dependency-groups] dev` via `uv add --group dev pre-commit`.
+2. Add [`.pre-commit-config.yaml`](../../.pre-commit-config.yaml) at repo root.
+3. Update docs (see Files to touch).
+4. Verify: `uv run pre-commit run --all-files`; then
+   `uv run ruff check && uv run ruff format --check` and `uv run pytest`.
+
+**Confirmed scope:** both `ruff check --fix` and `ruff format` hooks.
+
+## Files to touch
+
+| File | Change |
+|------|--------|
+| [`.pre-commit-config.yaml`](../../.pre-commit-config.yaml) | **New** — local hooks |
+| [`pyproject.toml`](../../pyproject.toml) + [`uv.lock`](../../uv.lock) | Add `pre-commit` dev dep |
+| [`docs/development.md`](../../docs/development.md) | Replace step 3 placeholder with install command |
+| [`.issueflows/04-designs-and-guides/this-project.md`](../04-designs-and-guides/this-project.md) | Point at in-repo config + install command |
+
+**Not touched:** CI workflows, source code, tests.
+
+## Test strategy
+
+No new pytest modules — config-only change.
+
+Verification commands:
+
+```bash
+uv sync --group dev
+uv run pre-commit run --all-files
+uv run ruff check && uv run ruff format --check
+uv run pytest
+```
+
+## Open questions
+
+None — format hook scope confirmed (both hooks).

--- a/.issueflows/03-solved-issues/issue84_status.md
+++ b/.issueflows/03-solved-issues/issue84_status.md
@@ -1,0 +1,17 @@
+# Issue #84 status
+
+## Done
+
+- [x] Done
+
+## Summary
+
+Added `.pre-commit-config.yaml` with local `uv run ruff` hooks (`check --fix`,
+`format`); `pre-commit` dev dependency; updated `docs/development.md` and
+`this-project.md` with install instructions.
+
+## Verification
+
+- `uv run pre-commit run --all-files` — passed
+- `uv run ruff check && uv run ruff format --check` — passed
+- `uv run pytest` — 131 passed

--- a/.issueflows/04-designs-and-guides/this-project.md
+++ b/.issueflows/04-designs-and-guides/this-project.md
@@ -36,9 +36,12 @@ Run **both** check and format before opening a PR. CI runs `ruff check` and
 `ruff format --check` with no `--fix`; autofix locally, then re-run the check
 commands to confirm green.
 
-Optional: install [pre-commit](https://pre-commit.com/) and add a local hook that
-runs the same ruff commands — not configured in-repo yet, but a good guard if
-you commit often without running CI locally.
+Pre-commit hooks (`.pre-commit-config.yaml`) run the same ruff autofix locally
+before each commit. One-time setup after `uv sync --group dev`:
+
+```bash
+uv run pre-commit install
+```
 
 ## Conventions
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: local
+    hooks:
+      - id: ruff-check
+        name: ruff check --fix
+        entry: uv run ruff check --fix
+        language: system
+        types: [python]
+      - id: ruff-format
+        name: ruff format
+        entry: uv run ruff format
+        language: system
+        types: [python]

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Add in-repo pre-commit hooks (`ruff check --fix`, `ruff format`) via
+  `.pre-commit-config.yaml` and document one-time `uv run pre-commit install`
+  setup. (#84)
 - Move `CellpyError` / `NoDataFound` from `legacy/` to top-level
   `cellpycore.exceptions` (legacy re-export kept); expand the `CellpyCellCore`
   class docstring; add `ROADMAP.md` for planned features and open design

--- a/docs/development.md
+++ b/docs/development.md
@@ -320,7 +320,15 @@ from .config import Headers
 
 1. **Clone the repository**
 2. **Install dependencies**: `uv sync --group dev`
-3. **Install pre-commit hooks** (if available)
+3. **Install pre-commit hooks** (one-time, after step 2):
+
+   ```bash
+   uv run pre-commit install
+   ```
+
+   Hooks run `ruff check --fix` and `ruff format` on staged Python files before
+   each commit (see `.pre-commit-config.yaml`).
+
 4. **Run tests** to ensure everything works
 
 It is recommended to use the `uv` project management solution for

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ dev = [
     "marimo>=0.23.10",
     "pytest-benchmark>=5.2.3",
     "pytest-cov>=7.1.0",
+    "pre-commit>=4.6.0",
 ]
 
 [tool.pytest.ini_options]

--- a/uv.lock
+++ b/uv.lock
@@ -34,6 +34,7 @@ dev = [
     { name = "marimo" },
     { name = "matplotlib" },
     { name = "pint" },
+    { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-benchmark" },
     { name = "pytest-cov" },
@@ -54,6 +55,7 @@ dev = [
     { name = "marimo", specifier = ">=0.23.10" },
     { name = "matplotlib", specifier = ">=3.10.6" },
     { name = "pint", specifier = ">=0.25" },
+    { name = "pre-commit", specifier = ">=4.6.0" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-benchmark", specifier = ">=5.2.3" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
@@ -103,6 +105,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
     { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
     { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
+name = "cfgv"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
 ]
 
 [[package]]
@@ -245,12 +256,30 @@ wheels = [
 ]
 
 [[package]]
+name = "distlib"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/02/bd72be9134d25ed783ecbbc38a539ffaefbf90c78418c7fb7229600dbac7/distlib-0.4.3.tar.gz", hash = "sha256:f152097224a0ae24be5a0f6bae1b9359af82133bce63f98a95f86cae1aede9ed", size = 615141, upload-time = "2026-06-12T08:04:52.847Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/08/9c41fb51ab5b43eb21674aff13df270e8ba6c4b29c8624e328dc7a9482af/distlib-0.4.3-py2.py3-none-any.whl", hash = "sha256:4b0ce306c966eb73bc3a7b6abad017c556dadd92c44701562cd528ac7fde4d5b", size = 470628, upload-time = "2026-06-12T08:04:50.506Z" },
+]
+
+[[package]]
 name = "docutils"
 version = "0.23"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/39/a4/5180d9afc57e8fca05601dd652bdff19604c218814037fe90ffc7625a50a/docutils-0.23.tar.gz", hash = "sha256:746f5060322511280a1e50eb76846ed6bf2342984b2ac04dc42caa1a8d78799e", size = 2303823, upload-time = "2026-05-27T17:41:06.934Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/91/30151a39f7570f448ed84529390628a651d7f27c87d73c9b887f8189695e/docutils-0.23-py3-none-any.whl", hash = "sha256:25d013af9bf23bc1c7b2b093dff4208166c53a94786c9e447808335ef1185fea", size = 634701, upload-time = "2026-05-27T17:40:58.442Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.29.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/ee/29c668c50888588c432a702f7c2e8ee8a0c9e5286028d91f170308d6b2e9/filelock-3.29.5.tar.gz", hash = "sha256:6e6034c57a00a020e767f2614a5539863f056de7e7991d6d1473aef7ff73f156", size = 68927, upload-time = "2026-07-03T03:50:31.818Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/e3/f1fae3647d170919c2cf2a898e77e7d1a4e5c7cae0aed7bb4bd3f5ebff6f/filelock-3.29.5-py3-none-any.whl", hash = "sha256:8af830889ba3a0ffcefbd6c7d2af8a54012058103771f2e10848222f476a1693", size = 45073, upload-time = "2026-07-03T03:50:30.445Z" },
 ]
 
 [[package]]
@@ -317,6 +346,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "identify"
+version = "2.6.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
 ]
 
 [[package]]
@@ -591,6 +629,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
 name = "numpy"
 version = "2.2.5"
 source = { registry = "https://pypi.org/simple" }
@@ -769,6 +816,22 @@ wheels = [
 ]
 
 [[package]]
+name = "pre-commit"
+version = "4.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
+]
+
+[[package]]
 name = "psutil"
 version = "7.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -934,6 +997,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-discovery"
+version = "1.4.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/26/8b004cc36f430345136f6f00fa1aa9ed596c8ed1e8504625fa79522ff39c/python_discovery-1.4.3.tar.gz", hash = "sha256:ad57d7045a862460d4a235986c33f13ed707d3aeb9153fa47eb7dfd0d4673289", size = 70438, upload-time = "2026-07-03T13:21:51.621Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/78/9b77ecb4644d1bbea94d29abf78f21c47eca6eb79e9745b702ec0bed2e19/python_discovery-1.4.3-py3-none-any.whl", hash = "sha256:b6e1e4a7d9e3f6948c39746ffe8218225162d738ba39d05ab1d2f6c1cac4878c", size = 33885, upload-time = "2026-07-03T13:21:50.174Z" },
 ]
 
 [[package]]
@@ -1117,6 +1193,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c4/1f/fa18009dea8469069cca78a4e877a008ab78f08b064bfc9ab891579077ff/uvicorn-0.49.0.tar.gz", hash = "sha256:ebf4271aa580d9de97f93192d4595176df6e91f9aae919ca73e4fc07df1e66a3", size = 91284, upload-time = "2026-06-03T22:01:30.448Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/fa/e1388bbcf24ef3274f45c0c1c7b501fd14971037c1b6ee23610553307497/uvicorn-0.49.0-py3-none-any.whl", hash = "sha256:ba3d14c3ee7e41c6c654c46c9eb489d33213cdd30aa1696eab1374337c13f68f", size = 71376, upload-time = "2026-06-03T22:01:29.037Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "21.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/a5/81f987504738e6defeed61ec1c47e2aefab3c35d8eeb87e1b3f38cf28254/virtualenv-21.5.1.tar.gz", hash = "sha256:dca3bf98275a59c652b69d68e73433e597d977c2da9198882479d1a7188009c8", size = 4578798, upload-time = "2026-06-16T16:23:58.603Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl", hash = "sha256:55aa670b67bbfb991b03fda39bd3276d92c419d702376e98c5df1c9989a26783", size = 4558820, upload-time = "2026-06-16T16:23:56.963Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add `.pre-commit-config.yaml` with local hooks running `uv run ruff check --fix` and `uv run ruff format` on staged Python files.
- Add `pre-commit` to the dev dependency group.
- Document one-time setup (`uv run pre-commit install`) in `docs/development.md` and `this-project.md`.

Closes #84

## Test plan

- [x] `uv run pre-commit run --all-files`
- [x] `uv run ruff check && uv run ruff format --check`
- [x] `uv run pytest` (131 passed)

Made with [Cursor](https://cursor.com)