### PR TITLE
feat: merge and incremental update APIs for Data (#86)

### DIFF
--- a/.issueflows/03-solved-issues/issue86_original.md
+++ b/.issueflows/03-solved-issues/issue86_original.md
@@ -1,0 +1,60 @@
+# Issue #86: update data and merge tests
+
+Source: https://github.com/cellpy/cellpy-core/issues/86
+
+## Original issue text
+
+We should add method for incremental updating as well as merging data as stated in the roadmap:
+
+```markdown
+
+## Merging cell tests
+
+- **Merge many test files into one `Data` object** — Legacy cellpy exposes a method for
+  merging cell tests (vertical concat of raw frames, aligned metadata, isolated per-test
+  grouping via `test_id`). This can be compute-intensive at scale; cellpy-core should
+  own the operation rather than leaving it to callers or the full cellpy package.
+  Scaffolding exists (`raw.test_id`, composite group keys in the engine,
+  `metadata.merge_test_meta`); a first-class **raw + metadata merge API** on `Data` /
+  `CellpyCellCore` is still missing. See
+  `.issueflows/04-designs-and-guides/test-metadata-and-merging.md`.
+
+## Incremental summarization
+
+- **Update step/summary tables from new raw rows only** — Summarizers today reprocess the
+  entire `data.raw` frame on every call. For live or in-progress tests (e.g. polling
+  cycler status), callers should be able to append new raw data and refresh steps /
+  summary incrementally instead of recomputing from scratch. Likely needs defined
+  merge/append semantics on `Data`, stable row keys (`test_id`, cycle/step boundaries),
+  and incremental paths in `make_step_table` / `make_summary` (or companion helpers).
+
+```
+
+
+## Algorithms to use
+
+### Merging
+
+For merging two tests, we focus on merging the two data objects (the raw, steps summary, cycle summary frames)
+for now. Lets label the two data objects D1 and D2. Then during merging we must do the following:
+
+1. check that test-id for D1 is not the same as for D2. If it is - we raise an exception. We allow the user to override this by supplying a key-word argument.
+2. the cycle numbers in D2 should be updtated (c2,i -> c2,i + c1,last). User can upt out.
+3. the data point number in D2 should be updated (n2,i -> n2,i + n1,last). User can not opt out.
+
+When merging the cycle summary, we need to make sure that the cummulative values in D2 continues from where the values stopped in D1.
+
+### Updating a test with new data
+
+Assume D1 is the data we already have processed. R2 contains new raw data (will probably overlap with one row, but could overlap with more). As default we use the source_datapoint_num (lets label them as r, i.e. for D1 they are r1(0), r1(1), etc.) as our key for partitioning. R1 denotes the raw data for D1. R1 contains the steps s1(0), s1(1), s1(2), ..., s1(last1). R2 the steps s2(0) .... s2(last2).
+
+If r2(0) >= r1(last): find what step r2(0) is in. That step and all the ones after will then belong to R2. The steps before will belong to D1.
+
+Then we have to calculate the step summary for D2. We already have for D1 (remember to not include the "overlapped" ones).
+We pick the last cycle in D1 as reference cycle (used for calculating cummulative values) and calculates cycle summary. Then we append the new raw, steps summary, and cycle summary rows to D1 frames and return it.
+
+## Structure
+
+Open for suggestions. But should honour our principles.
+
+<!-- Edit the body of your new issue then click the ✓ "Create Issue" button in the top right of the editor. The first line will be the issue title. Assignees and Labels follow after a blank line. Leave an empty line before beginning the body of the issue. -->

--- a/.issueflows/03-solved-issues/issue86_plan.md
+++ b/.issueflows/03-solved-issues/issue86_plan.md
@@ -1,0 +1,169 @@
+# Issue #86 plan — update data and merge tests
+
+## Goal
+
+Add first-class APIs on `Data` / `CellpyCellCore` to (1) **merge** two processed `Data` objects and (2) **incrementally update** one processed `Data` with new raw rows — without full re-summarization where the issue algorithm allows.
+
+**Phase A (`merge_data`) — shipped** on branch `86-update-data-merge-tests` (pending `/iflow-close`).
+
+**Phase B (`update_data`) — this plan** is the next PR on the same branch (or a follow-up branch after Phase A merges).
+
+---
+
+## Phase A recap (done)
+
+Implemented in [`src/cellpycore/merge.py`](../../src/cellpycore/merge.py): `merge_data`, `CellpyCellCore.merge_core_data`, 11 tests. Defaults: `renumber_cycles=True`, `allow_duplicate_test_id` renumbers right.
+
+---
+
+## Phase B — `update_data`
+
+### Goal
+
+Append new raw rows to an **already processed** single-test `Data` object, trimming the overlap at the partition boundary and refreshing only the affected steps / cycle-summary tail.
+
+### Constraints
+
+- Same as Phase A (polars-native, schema-injected, inputs untouched, return new `Data`).
+- **Single-test v1:** one `test_id` in existing data; `new_raw` must belong to the same test. Multi-test update → follow-up.
+- Partition on **`source_datapoint_num`** (instrument-stable key per issue). Fallback to `datapoint_num` with `logger.warning` when absent.
+- Reuse Phase A cumulative carry-forward (`_carry_forward_cumulative_summary`) for summary stitch.
+- `ir_to_summary` / `c_rates_to_summary` **not** inside `update_data` — caller (or `update_core_data`) re-runs them if needed, mirroring `make_core_summary` split.
+
+### Prior art
+
+| Hit | Module | Notes |
+|-----|--------|-------|
+| `merge_data`, `_carry_forward_cumulative_summary` | `merge.py` | Cumulative stitch; frame copy helpers — **reuse** |
+| `make_step_table(..., from_data_point=…)` | `summarizers.py` | Filters raw `>= from_data_point`, returns steps `DataFrame` without mutating `data` — **primary incremental step path** |
+| `_dev_update_merge`, `_dev_update_make_steps`, `_dev_update_make_summary` | `cellpy/readers/cellreader.py` | Legacy WIP: drop last raw row, steps `[:-1]`, `from_data_point=last_step.point_first`; summary uses `from_cycle` but still full-recomputes today |
+| `source_datapoint_num` | `config.RawCols`, `mock_data.py` | Partition key; mock data sets `source_datapoint_num == datapoint_num` |
+| `make_summary` | `summarizers.py` | **No `from_cycle` yet** — needs new param or helper for tail-only summary |
+| Toolbox / graph | — | No new tools; graphify confirms `make_step_table` ↔ `from_data_point` link |
+
+### Approach
+
+Add to [`src/cellpycore/merge.py`](../../src/cellpycore/merge.py) (or rename module to `data_ops.py` only if merge+update makes the name misleading — **keep `merge.py` for now**, KISS):
+
+```python
+def update_data(
+    data: Data,
+    new_raw: pl.DataFrame,
+    *,
+    schema: Schema | None = None,
+    nom_cap: float = 1.0,
+    partition_col: str | None = None,
+    test_mode: TestMode = TestMode.NORMAL,
+    **step_table_kwargs,
+) -> Data:
+    ...
+```
+
+Thin wrapper: `CellpyCellCore.update_core_data(...)`. Export from `__init__.py`.
+
+#### Data flow
+
+```mermaid
+flowchart TD
+    A[Input: processed D1 + new_raw R2] --> B{Validate}
+    B --> C[Resolve partition_col]
+    C --> D["r2_start = min(R2[partition])"]
+    D --> E["Trim R1: partition < r2_start"]
+    E --> F["Find overlap step in D1.steps"]
+    F --> G["Keep steps before overlap step"]
+    G --> H["Offset R2 datapoint_num by max kept"]
+    H --> I["Concat trimmed raw + R2"]
+    I --> J["make_step_table from overlap step datapoint_num_first"]
+    J --> K["Concat kept steps + new steps"]
+    K --> L["make_summary from_cycle = last kept cycle"]
+    L --> M["Concat kept summary + new tail"]
+    M --> N["Carry cumulative cols forward"]
+    N --> O[Return new Data]
+```
+
+**Step-by-step**
+
+1. **Validate:** `data.raw`, `data.steps`, `data.summary` populated; `new_raw` non-empty; required schema columns present; single `test_id` in existing frames.
+2. **Partition column:** default `schema.raw.source_datapoint_num`; if missing from both frames, fall back to `datapoint_num` + warning.
+3. **Overlap boundary:** `r2_start = new_raw[partition_col].min()`. If `r2_start < max(data.raw[partition_col])`, treat as in-progress overlap (issue default). If `r2_start` is strictly greater than max kept (gap), append without trim (no step truncation).
+4. **Trim raw:** keep rows with `partition_col < r2_start`; drop rows `>= r2_start` from D1.
+5. **Trim steps:** locate the step whose `[datapoint_num_first, datapoint_num_last]` bracket contains the first raw row at/after `r2_start` (match on `datapoint_num` after sorting raw). Drop that step and all later steps from kept steps. *(Mirrors issue: "that step and all after belong to R2".)*
+6. **Align `datapoint_num` on `new_raw`:** offset by `max(kept.datapoint_num)` (same boundary rule as `merge_data` — first new row may share the boundary index).
+7. **Append raw:** `pl.concat([kept_raw, new_raw])`.
+8. **Incremental steps:** call `make_step_table(slice_data, from_data_point=overlap_step.datapoint_num_first, …)` on a temporary `Data` holding the **combined** raw; returns new-step rows only. Concat with kept steps.
+9. **Incremental summary:** add `from_cycle: int | None = None` to `make_summary` (or private `_make_summary_from_cycle`):
+   - Build summary rows only for cycles `>= from_cycle` using combined raw + combined steps.
+   - Keep summary rows with `cycle_num < from_cycle` from D1 unchanged.
+   - Apply `_carry_forward_cumulative_summary(kept_summary, new_tail, chdr)` so `test_cumulated_*` continues from the last kept row (reference cycle = last kept cycle, per issue).
+10. **Return** fresh `Data`; do not mutate input.
+
+#### Summarizer change (minimal)
+
+Add to `make_summary`:
+
+```python
+def make_summary(..., from_cycle: int | None = None) -> Data:
+```
+
+When `from_cycle` is set, filter `steps` (and raw cycle-end selection) to `cycle_num >= from_cycle` before aggregation; return only the tail rows. `update_data` concatenates `kept_summary` + tail. Document that `from_cycle` is an incremental-update hook, not a public cellpy parity feature yet.
+
+**Not** adding `from_data_point` changes — already sufficient.
+
+#### Edge cases
+
+| Case | Behavior |
+|------|----------|
+| `new_raw` empty | Return `_copy_data(data)` |
+| No overlap (`r2_start > max kept partition`) | Append raw; full step/summary recompute from `from_cycle = last_cycle + 1` or last kept cycle |
+| `r2_start` before any kept row | Replace entire dataset (equivalent to re-process from scratch) — warn |
+| Missing steps/summary on input | `ValueError` with clear message |
+| Multiple `test_id` in D1 | `ValueError` (v1) |
+
+### Files to touch
+
+| File | Change |
+|------|--------|
+| [`src/cellpycore/merge.py`](../../src/cellpycore/merge.py) | `update_data` + private overlap/trim helpers |
+| [`src/cellpycore/summarizers.py`](../../src/cellpycore/summarizers.py) | `make_summary(..., from_cycle=None)` tail path |
+| [`src/cellpycore/cell_core.py`](../../src/cellpycore/cell_core.py) | `update_core_data` delegate |
+| [`src/cellpycore/__init__.py`](../../src/cellpycore/__init__.py) | Export `update_data` |
+| [`tests/test_merge.py`](../../tests/test_merge.py) or `tests/test_update.py` | Phase B tests (prefer extend `test_merge.py` or split if >~200 lines) |
+
+### Test strategy
+
+```bash
+uv run pytest tests/test_merge.py tests/test_update.py -v   # if split
+uv run pytest                                              # full suite
+```
+
+**Oracle pattern:** for synthetic fixture, `full = process(concat(trim(R1), R2))` vs `update(process(R1), R2)` — steps and summary must match (within float tolerance).
+
+**Cases**
+
+- Single-row overlap at boundary (`source_datapoint_num` shared).
+- Multi-row overlap (several raw rows re-sent).
+- Gap append (no overlap — new partition values all greater than max kept).
+- Fallback when `source_datapoint_num` absent (uses `datapoint_num`, warning logged).
+- Input immutability.
+- `update_core_data` on `CellpyCellCore`.
+- Missing steps/summary → `ValueError`.
+
+### Scope check
+
+Phase B is one focused PR (~200–350 lines). No refactor of `merge.py` module rename. No multi-test update. No metadata / `TestMetaCollection` wiring.
+
+---
+
+## Resolved (Phase A)
+
+1. Phase A first — **yes, done**.
+2. `renumber_cycles` default — **`True`**.
+3. `allow_duplicate_test_id` — **auto-renumber right**.
+4. Branch — **`86-update-data-merge-tests`**.
+
+## Open questions (Phase B — confirm before `/iflow-start`)
+
+1. **Same branch vs new:** Continue on `86-update-data-merge-tests` after Phase A closes, or new branch `86-update-data`? *(Recommend: same branch if Phase A not merged yet; else `86-update-data` off main.)*
+2. **Gap append:** When `r2_start > max(partition)`, recompute steps for **all** new raw only, or from last cycle? *(Recommend: steps from overlap `from_data_point` = first new row's `datapoint_num`; summary `from_cycle = max kept cycle`.)*
+3. **Full replace:** When `r2_start <= min(partition)`, raise vs silently replace? *(Recommend: raise `ValueError` — caller should use fresh `from_raw_frame`.)*
+4. **`update_core_data` extras:** Should wrapper optionally re-run `ir_to_summary` + `c_rates_to_summary` like `make_core_summary`? *(Recommend: yes, behind `refresh_derived: bool = True` default.)*

--- a/.issueflows/03-solved-issues/issue86_status.md
+++ b/.issueflows/03-solved-issues/issue86_status.md
@@ -1,0 +1,22 @@
+# Issue #86 status
+
+- [x] Done
+
+## What's done
+
+### Phase A
+- `merge_data` in `src/cellpycore/merge.py`
+- `CellpyCellCore.merge_core_data` wrapper
+- Exported `merge_data` from `cellpycore`
+- 11 merge tests
+
+### Phase B
+- `update_data` — partition trim, incremental steps (`from_data_point`), full summary rebuild
+- `CellpyCellCore.update_core_data(refresh_derived=True)` — IR + C-rates
+- Exported `update_data`
+- 6 update tests (overlap, gap, full-replace error, immutability, validation, refresh_derived)
+- Full suite green (148 passed)
+
+## Remaining work
+
+- None

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 - Add in-repo pre-commit hooks (`ruff check --fix`, `ruff format`) via
   `.pre-commit-config.yaml` and document one-time `uv run pre-commit install`
   setup. (#84)
+- Add `merge_data` and `update_data` for combining processed `Data` objects and
+  incrementally appending new raw rows (with `CellpyCellCore` wrappers and tests).
+  (#86)
 - Move `CellpyError` / `NoDataFound` from `legacy/` to top-level
   `cellpycore.exceptions` (legacy re-export kept); expand the `CellpyCellCore`
   class docstring; add `ROADMAP.md` for planned features and open design

--- a/src/cellpycore/__init__.py
+++ b/src/cellpycore/__init__.py
@@ -20,6 +20,7 @@ from cellpycore.config import (
     default_schema,
 )
 from cellpycore.exceptions import CellpyError, NoDataFound
+from cellpycore.merge import merge_data, update_data
 from cellpycore.summarizers import make_step_table, make_summary
 
 try:
@@ -41,4 +42,6 @@ __all__ = [
     "default_schema",
     "make_step_table",
     "make_summary",
+    "merge_data",
+    "update_data",
 ]

--- a/src/cellpycore/cell_core.py
+++ b/src/cellpycore/cell_core.py
@@ -393,6 +393,94 @@ class CellpyCellCore:
         logger.debug(f"(dt: {(time.time() - time_00):4.2f}s)")
         return data
 
+    def merge_core_data(
+        self,
+        left: Data,
+        right: Data,
+        *,
+        renumber_cycles: bool = True,
+        allow_duplicate_test_id: bool = False,
+    ) -> Data:
+        """Merge two ``Data`` objects via ``merge_data`` using this cell's schema.
+
+        Args:
+            left: First dataset.
+            right: Second dataset, appended after ``left``.
+            renumber_cycles: Offset right-side cycle numbers and carry cumulative
+                summary values forward when True (default).
+            allow_duplicate_test_id: Reassign colliding right-side ``test_id``
+                values when True.
+
+        Returns:
+            A new merged ``Data`` object. Inputs are not modified.
+        """
+        from cellpycore.merge import merge_data
+
+        return merge_data(
+            left,
+            right,
+            schema=self.schema,
+            renumber_cycles=renumber_cycles,
+            allow_duplicate_test_id=allow_duplicate_test_id,
+        )
+
+    def update_core_data(
+        self,
+        data: Data,
+        new_raw,
+        *,
+        nom_cap: float = 1.0,
+        refresh_derived: bool = True,
+        find_ir: bool = True,
+        current_conversion_factor: float = 1.0,
+        **kwargs,
+    ) -> Data:
+        """Incrementally update ``Data`` via ``update_data`` using this cell's schema.
+
+        Args:
+            data: Processed data to update.
+            new_raw: New raw rows to append.
+            nom_cap: Nominal capacity for per-step C-rate.
+            refresh_derived: When True (default), run ``c_rates_to_summary`` and
+                ``ir_to_summary`` after rebuilding the summary (mirrors
+                ``make_core_summary`` extras).
+            find_ir: Whether to add IR columns when ``refresh_derived`` is True.
+            current_conversion_factor: Current-unit factor for C-rate columns.
+            **kwargs: Forwarded to ``update_data`` / ``make_step_table``.
+
+        Returns:
+            A new updated ``Data`` object. The input is not modified.
+        """
+        import polars as pl
+
+        from cellpycore.merge import update_data
+
+        if not isinstance(new_raw, pl.DataFrame):
+            new_raw = pl.from_pandas(new_raw)
+
+        test_mode = _cycle_mode_to_test_mode(self.cycle_mode)
+        out = update_data(
+            data,
+            new_raw,
+            schema=self.schema,
+            nom_cap=nom_cap,
+            test_mode=test_mode,
+            **kwargs,
+        )
+
+        if refresh_derived:
+            from cellpycore import summarizers
+
+            out = summarizers.c_rates_to_summary(
+                out, self.schema, current_conversion_factor=current_conversion_factor
+            )
+            if find_ir:
+                raw_cols = out.raw.columns if hasattr(out.raw, "columns") else []
+                if self.schema.raw.internal_resistance in raw_cols:
+                    out = summarizers.ir_to_summary(out, self.schema)
+
+        return out
+
     def add_scaled_summary_columns(
         self,
         data: Data,

--- a/src/cellpycore/merge.py
+++ b/src/cellpycore/merge.py
@@ -1,0 +1,459 @@
+"""Merge and incremental-update helpers for ``Data`` objects."""
+
+from __future__ import annotations
+
+import logging
+from copy import copy
+from typing import TYPE_CHECKING, Any, Optional
+
+import polars as pl
+
+from cellpycore import config
+from cellpycore.cell_core import Data
+from cellpycore.summarizers import _ensure_test_id, make_step_table, make_summary
+
+if TYPE_CHECKING:
+    from cellpycore.config import Schema
+
+logger = logging.getLogger(__name__)
+
+_CUMULATIVE_SUMMARY_ATTRS = (
+    "test_cumulated_charge_capacity",
+    "test_cumulated_discharge_capacity",
+    "test_cumulated_coulombic_difference",
+    "test_cumulated_charge_capacity_loss",
+    "test_cumulated_discharge_capacity_loss",
+    "test_cumulated_charge_energy",
+    "test_cumulated_discharge_energy",
+    "test_net_capacity",
+    "test_net_energy",
+)
+
+
+def merge_data(
+    left: Data,
+    right: Data,
+    *,
+    schema: Optional["Schema"] = None,
+    renumber_cycles: bool = True,
+    allow_duplicate_test_id: bool = False,
+) -> Data:
+    """Merge two processed ``Data`` objects into a new one.
+
+    Vertically concatenates ``raw`` and, when present on both sides, ``steps`` and
+    ``summary``. Offsets ``datapoint_num`` on the right side by the last left
+    datapoint (always). When ``renumber_cycles`` is True, also offsets cycle
+    numbers on the right and carries cumulative summary columns forward from the
+    last left summary row.
+
+    Args:
+        left: First dataset (D1).
+        right: Second dataset (D2), appended after ``left``.
+        schema: Column-header schema. Defaults to ``config.default_schema()``.
+        renumber_cycles: If True (default), offset right ``cycle_num`` values by
+            ``max(left.cycle_num)`` and shift cumulative summary columns. If False,
+            cycle numbers are kept as-is (multi-test isolation via ``test_id``).
+        allow_duplicate_test_id: If False (default), raise when both sides share
+            a ``test_id``. If True, reassign colliding right-side ``test_id``
+            values to the next free ids.
+
+    Returns:
+        A new ``Data`` with merged frames. Inputs are not modified.
+
+    Raises:
+        ValueError: If either side lacks ``raw``, or ``test_id`` values collide
+            and ``allow_duplicate_test_id`` is False.
+    """
+    if schema is None:
+        schema = config.default_schema()
+    nhdr, shdr, chdr = schema.raw, schema.step, schema.cycle
+
+    left_raw = left.raw
+    right_raw = right.raw
+    if left_raw is None or right_raw is None:
+        raise ValueError("merge_data requires both Data objects to have raw frames")
+
+    if _frame_is_empty(left_raw):
+        return _copy_data(right)
+    if _frame_is_empty(right_raw):
+        return _copy_data(left)
+
+    left_pl = _as_polars(left_raw)
+    right_pl = _as_polars(right_raw)
+    left_pl = _ensure_test_id(left_pl, nhdr.test_id)
+    right_pl = _ensure_test_id(right_pl, nhdr.test_id)
+
+    right_pl, test_id_map = _resolve_test_id_collisions(
+        right_pl,
+        left_pl,
+        nhdr.test_id,
+        allow_duplicate_test_id=allow_duplicate_test_id,
+    )
+
+    dp_offset = _max_column(left_pl, nhdr.datapoint_num)
+    right_pl = _offset_int_column(right_pl, nhdr.datapoint_num, dp_offset)
+
+    cycle_offset = 0
+    if renumber_cycles:
+        cycle_offset = _max_column(left_pl, nhdr.cycle_num)
+        right_pl = _offset_int_column(right_pl, nhdr.cycle_num, cycle_offset)
+
+    merged_raw = pl.concat([left_pl, right_pl], how="vertical")
+
+    out = Data()
+    out.raw = _restore_frame_type(merged_raw, left_raw)
+
+    if left.steps is not None and right.steps is not None:
+        left_steps = _as_polars(left.steps)
+        right_steps = _as_polars(right.steps)
+        right_steps = _remap_test_id(right_steps, shdr.test_id, test_id_map)
+        right_steps = _offset_int_column(
+            right_steps, shdr.datapoint_num_first, dp_offset
+        )
+        right_steps = _offset_int_column(
+            right_steps, shdr.datapoint_num_last, dp_offset
+        )
+        if renumber_cycles:
+            right_steps = _offset_int_column(right_steps, shdr.cycle_num, cycle_offset)
+        merged_steps = pl.concat([left_steps, right_steps], how="vertical")
+        out.steps = _restore_frame_type(merged_steps, left.steps)
+
+    if left.summary is not None and right.summary is not None:
+        left_summary = _as_polars(left.summary)
+        right_summary = _as_polars(right.summary)
+        right_summary = _remap_test_id(right_summary, chdr.test_id, test_id_map)
+        right_summary = _offset_int_column(
+            right_summary, chdr.datapoint_num_last, dp_offset
+        )
+        if renumber_cycles:
+            right_summary = _offset_int_column(
+                right_summary, chdr.cycle_num, cycle_offset
+            )
+            right_summary = _carry_forward_cumulative_summary(
+                left_summary, right_summary, chdr
+            )
+        merged_summary = pl.concat([left_summary, right_summary], how="vertical")
+        out.summary = _restore_frame_type(merged_summary, left.summary)
+
+    return out
+
+
+def update_data(
+    data: Data,
+    new_raw: pl.DataFrame,
+    *,
+    schema: Optional["Schema"] = None,
+    nom_cap: float = 1.0,
+    partition_col: str | None = None,
+    test_mode: config.TestMode = config.TestMode.NORMAL,
+    **step_table_kwargs: Any,
+) -> Data:
+    """Incrementally update processed ``Data`` with new raw rows.
+
+    Trims the overlap at ``source_datapoint_num`` (or ``datapoint_num`` when
+    absent), refreshes affected step rows via ``make_step_table(from_data_point=…)``,
+    and rebuilds the per-cycle summary on the combined frames.
+
+    Args:
+        data: Processed ``Data`` with ``raw``, ``steps``, and ``summary``.
+        new_raw: New raw rows to append (may overlap the tail of ``data.raw``).
+        schema: Column-header schema. Defaults to ``config.default_schema()``.
+        nom_cap: Nominal capacity for per-step C-rate (forwarded to
+            ``make_step_table``).
+        partition_col: Column used to detect overlap. Defaults to
+            ``source_datapoint_num``, falling back to ``datapoint_num``.
+        test_mode: Cell convention forwarded to ``make_summary``.
+        **step_table_kwargs: Extra keyword arguments forwarded to
+            ``make_step_table`` (except ``schema``, ``nom_cap``, ``from_data_point``).
+
+    Returns:
+        A new ``Data`` object. The input is not modified.
+
+    Raises:
+        ValueError: If ``data`` is not fully processed, ``new_raw`` is invalid,
+            more than one ``test_id`` is present, or ``new_raw`` starts at or
+            before the beginning of the existing partition range (full reload).
+    """
+    if schema is None:
+        schema = config.default_schema()
+    nhdr, shdr = schema.raw, schema.step
+
+    if data.raw is None or data.steps is None or data.summary is None:
+        raise ValueError("update_data requires data.raw, data.steps, and data.summary")
+    if new_raw is None or _frame_is_empty(new_raw):
+        return _copy_data(data)
+
+    raw_pl = _as_polars(data.raw)
+    steps_pl = _as_polars(data.steps)
+    new_pl = _as_polars(new_raw)
+    raw_pl = _ensure_test_id(raw_pl, nhdr.test_id)
+    new_pl = _ensure_test_id(new_pl, nhdr.test_id)
+
+    _require_single_test_id(raw_pl, nhdr.test_id)
+    _require_single_test_id(steps_pl, shdr.test_id)
+    _require_single_test_id(new_pl, nhdr.test_id)
+
+    partition = _resolve_partition_col(
+        raw_pl, new_pl, nhdr, partition_col=partition_col
+    )
+    _require_columns(new_pl, {partition: partition}, "new_raw")
+
+    r2_start = int(new_pl[partition].min())  # type: ignore[arg-type]
+    r1_min = int(raw_pl[partition].min())  # type: ignore[arg-type]
+    r1_max = int(raw_pl[partition].max())  # type: ignore[arg-type]
+
+    if r2_start <= r1_min:
+        raise ValueError(
+            "new_raw starts at or before existing data; "
+            "use Data.from_raw_frame for a full reload"
+        )
+
+    gap_append = r2_start > r1_max
+
+    if gap_append:
+        kept_raw = raw_pl
+        kept_steps = steps_pl
+    else:
+        kept_raw = raw_pl.filter(pl.col(partition) < r2_start)
+        kept_steps, from_data_point = _trim_steps_for_overlap(
+            steps_pl,
+            raw_pl.filter(pl.col(partition) >= r2_start),
+            shdr,
+            nhdr,
+        )
+
+    dp_max_kept = _max_column(kept_raw, nhdr.datapoint_num)
+    new_dp_min = int(new_pl[nhdr.datapoint_num].min())  # type: ignore[arg-type]
+    if new_dp_min <= dp_max_kept:
+        new_pl = _offset_int_column(new_pl, nhdr.datapoint_num, dp_max_kept)
+
+    combined_raw = pl.concat([kept_raw, new_pl], how="vertical")
+
+    if gap_append:
+        from_data_point = int(new_pl[nhdr.datapoint_num].min())  # type: ignore[arg-type]
+
+    slice_data = Data()
+    slice_data.raw = combined_raw
+    new_steps = make_step_table(
+        slice_data,
+        schema=schema,
+        nom_cap=nom_cap,
+        from_data_point=from_data_point,
+        **step_table_kwargs,
+    )
+    if not isinstance(new_steps, pl.DataFrame):
+        new_steps = pl.from_pandas(new_steps)
+
+    combined_steps = pl.concat([kept_steps, new_steps], how="vertical")
+
+    out = Data()
+    out.raw = _restore_frame_type(combined_raw, data.raw)
+    out.steps = _restore_frame_type(combined_steps, data.steps)
+
+    summary_data = Data()
+    summary_data.raw = out.raw
+    summary_data.steps = out.steps
+    make_summary(summary_data, schema=schema, test_mode=test_mode)
+    out.summary = _restore_frame_type(_as_polars(summary_data.summary), data.summary)
+
+    return out
+
+
+def _resolve_partition_col(
+    raw: pl.DataFrame,
+    new_raw: pl.DataFrame,
+    nhdr: config.RawCols,
+    *,
+    partition_col: str | None,
+) -> str:
+    if partition_col is not None:
+        return partition_col
+    if (
+        nhdr.source_datapoint_num in raw.columns
+        and nhdr.source_datapoint_num in new_raw.columns
+    ):
+        return nhdr.source_datapoint_num
+    logger.warning(
+        "source_datapoint_num missing; falling back to datapoint_num for update partition"
+    )
+    return nhdr.datapoint_num
+
+
+def _require_columns(frame: pl.DataFrame, mapping: dict[str, str], label: str) -> None:
+    missing = [name for name in mapping if name not in frame.columns]
+    if missing:
+        raise ValueError(f"{label} missing required column(s): {', '.join(missing)}")
+
+
+def _require_single_test_id(frame: pl.DataFrame, test_id_col: str) -> None:
+    if test_id_col not in frame.columns:
+        return
+    if frame[test_id_col].n_unique() > 1:
+        raise ValueError(
+            "update_data v1 supports a single test_id only (multi-test update is not implemented)"
+        )
+
+
+def _trim_steps_for_overlap(
+    steps: pl.DataFrame,
+    overlap_raw: pl.DataFrame,
+    shdr: config.StepCols,
+    nhdr: config.RawCols,
+) -> tuple[pl.DataFrame, int]:
+    """Drop the overlap step and all later steps; return kept steps and ``from_data_point``."""
+    if overlap_raw.is_empty():
+        return steps, int(steps[shdr.datapoint_num_first].min())  # type: ignore[arg-type]
+
+    first_dp = int(
+        overlap_raw.sort(nhdr.datapoint_num)[nhdr.datapoint_num][0]  # type: ignore[index]
+    )
+    steps_sorted = steps.sort(shdr.datapoint_num_first)
+    overlap_idx = None
+    for idx, row in enumerate(steps_sorted.iter_rows(named=True)):
+        first = row[shdr.datapoint_num_first]
+        last = row[shdr.datapoint_num_last]
+        if first <= first_dp <= last:
+            overlap_idx = idx
+            from_data_point = int(first)
+            break
+
+    if overlap_idx is None:
+        from_data_point = first_dp
+        kept = steps_sorted.filter(pl.col(shdr.datapoint_num_last) < first_dp)
+        return kept, from_data_point
+
+    kept = steps_sorted.head(overlap_idx)
+    return kept, from_data_point
+
+
+def _copy_data(data: Data) -> Data:
+    """Return a shallow copy of ``data`` with frame references duplicated."""
+    out = Data()
+    out.raw = _clone_frame(data.raw)
+    out.steps = _clone_frame(data.steps)
+    out.summary = _clone_frame(data.summary)
+    if hasattr(data, "meta_test_dependent"):
+        out.meta_test_dependent = copy(data.meta_test_dependent)
+    return out
+
+
+def _clone_frame(frame):
+    if frame is None:
+        return None
+    if isinstance(frame, pl.DataFrame):
+        return frame.clone()
+    return frame.copy()
+
+
+def _frame_is_empty(frame) -> bool:
+    if isinstance(frame, pl.DataFrame):
+        return frame.is_empty()
+    return len(frame) == 0
+
+
+def _as_polars(frame) -> pl.DataFrame:
+    if isinstance(frame, pl.DataFrame):
+        return frame.clone()
+    return pl.from_pandas(frame)
+
+
+def _restore_frame_type(frame: pl.DataFrame, prototype):
+    import pandas as pd
+
+    if isinstance(prototype, pd.DataFrame):
+        return frame.to_pandas()
+    return frame
+
+
+def _max_column(frame: pl.DataFrame, col: str) -> int:
+    if col not in frame.columns or frame.is_empty():
+        return 0
+    value = frame[col].max()
+    if value is None:
+        return 0
+    return int(value)
+
+
+def _offset_int_column(frame: pl.DataFrame, col: str, offset: int) -> pl.DataFrame:
+    if offset == 0 or col not in frame.columns:
+        return frame
+    return frame.with_columns((pl.col(col) + pl.lit(offset)).alias(col))
+
+
+def _distinct_test_ids(frame: pl.DataFrame, col: str) -> set[int]:
+    if col not in frame.columns:
+        return {0}
+    return set(frame[col].unique().to_list())
+
+
+def _resolve_test_id_collisions(
+    right: pl.DataFrame,
+    left: pl.DataFrame,
+    test_id_col: str,
+    *,
+    allow_duplicate_test_id: bool,
+) -> tuple[pl.DataFrame, dict[int, int]]:
+    left_ids = _distinct_test_ids(left, test_id_col)
+    right_ids = _distinct_test_ids(right, test_id_col)
+    overlap = left_ids & right_ids
+    if not overlap:
+        return right, {}
+    if not allow_duplicate_test_id:
+        raise ValueError(
+            f"duplicate test_id {sorted(overlap)} while merging "
+            f"(pass allow_duplicate_test_id=True to reassign)"
+        )
+
+    used = set(left_ids)
+    id_map: dict[int, int] = {}
+    for tid in sorted(right_ids):
+        if tid not in used:
+            used.add(tid)
+            continue
+        next_id = 0
+        while next_id in used:
+            next_id += 1
+        id_map[tid] = next_id
+        used.add(next_id)
+
+    return _remap_test_id(right, test_id_col, id_map), id_map
+
+
+def _remap_test_id(
+    frame: pl.DataFrame, test_id_col: str, id_map: dict[int, int]
+) -> pl.DataFrame:
+    if not id_map or test_id_col not in frame.columns:
+        return frame
+    expr = pl.col(test_id_col)
+    for old_id, new_id in id_map.items():
+        expr = (
+            pl.when(pl.col(test_id_col) == old_id).then(pl.lit(new_id)).otherwise(expr)
+        )
+    return frame.with_columns(expr.alias(test_id_col))
+
+
+def _carry_forward_cumulative_summary(
+    left: pl.DataFrame,
+    right: pl.DataFrame,
+    chdr: config.CycleCols,
+) -> pl.DataFrame:
+    """Add last left cumulative summary values onto every right summary row."""
+    if left.is_empty() or right.is_empty():
+        return right
+
+    sort_cols = [c for c in (chdr.test_id, chdr.cycle_num) if c in left.columns]
+    last = left.sort(sort_cols).tail(1)
+
+    exprs = []
+    for attr in _CUMULATIVE_SUMMARY_ATTRS:
+        col = getattr(chdr, attr)
+        if col not in left.columns or col not in right.columns:
+            continue
+        base = last[col][0]
+        if base is None:
+            continue
+        exprs.append((pl.col(col) + pl.lit(base)).alias(col))
+
+    if not exprs:
+        return right
+    return right.with_columns(exprs)

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1,0 +1,345 @@
+"""Tests for ``cellpycore.merge`` (merge + update)."""
+
+import polars as pl
+import pytest
+
+from cellpycore import CellpyCellCore, Data, merge_data, summarizers, update_data
+from cellpycore.config import CycleCols, RawCols, Schema, StepCols
+
+
+def _schema() -> Schema:
+    return Schema(raw=RawCols(), cycle=CycleCols(), step=StepCols())
+
+
+def _single_test_raw(
+    nhdr: RawCols,
+    *,
+    test_id: int = 0,
+    cycle_start: int = 1,
+    n_cycles: int = 2,
+    dp_start: int = 0,
+    scale: float = 1.0,
+) -> pl.DataFrame:
+    records = []
+    dp = dp_start
+    for cyc in range(cycle_start, cycle_start + n_cycles):
+        for k in range(5):
+            records.append(
+                {
+                    nhdr.test_id: test_id,
+                    nhdr.datapoint_num: dp,
+                    nhdr.test_time: float(dp),
+                    nhdr.step_time: float(k),
+                    nhdr.step_num: 1,
+                    nhdr.cycle_num: cyc,
+                    nhdr.current: 1.0,
+                    nhdr.potential: 3.5 + 0.01 * k,
+                    nhdr.cumulative_charge_capacity: scale * 0.1 * (k + 1),
+                    nhdr.cumulative_discharge_capacity: 0.0,
+                    nhdr.internal_resistance: 0.0,
+                }
+            )
+            dp += 1
+        for k in range(5):
+            records.append(
+                {
+                    nhdr.test_id: test_id,
+                    nhdr.datapoint_num: dp,
+                    nhdr.test_time: float(dp),
+                    nhdr.step_time: float(k),
+                    nhdr.step_num: 2,
+                    nhdr.cycle_num: cyc,
+                    nhdr.current: -1.0,
+                    nhdr.potential: 3.9 - 0.01 * k,
+                    nhdr.cumulative_charge_capacity: scale * 0.5,
+                    nhdr.cumulative_discharge_capacity: scale * 0.08 * (k + 1),
+                    nhdr.internal_resistance: 0.0,
+                }
+            )
+            dp += 1
+    frame = pl.DataFrame(records)
+    if nhdr.source_datapoint_num not in frame.columns:
+        frame = frame.with_columns(
+            pl.col(nhdr.datapoint_num).alias(nhdr.source_datapoint_num)
+        )
+    return frame
+
+
+def _processed_data(
+    nhdr: RawCols,
+    schema: Schema,
+    *,
+    test_id: int = 0,
+    cycle_start: int = 1,
+    dp_start: int = 0,
+    scale: float = 1.0,
+) -> Data:
+    data = Data()
+    data.raw = _single_test_raw(
+        nhdr,
+        test_id=test_id,
+        cycle_start=cycle_start,
+        dp_start=dp_start,
+        scale=scale,
+    )
+    summarizers.make_step_table(data, schema=schema, nom_cap=1.0)
+    summarizers.make_summary(data, schema=schema)
+    return data
+
+
+def test_merge_offsets_datapoint_num():
+    nhdr = RawCols()
+    schema = _schema()
+    left = _processed_data(nhdr, schema, test_id=0, dp_start=0)
+    right = _processed_data(nhdr, schema, test_id=1, dp_start=0)
+
+    merged = merge_data(left, right, schema=schema)
+    left_max = left.raw[nhdr.datapoint_num].max()
+    assert left_max == 19
+    assert merged.raw.height == 40
+    # Issue spec: n2,i += n1,last — first right row shares the boundary index.
+    right_dps = merged.raw.filter(pl.col(nhdr.test_id) == 1)[
+        nhdr.datapoint_num
+    ].to_list()
+    assert right_dps[0] == left_max
+    assert right_dps[-1] == left_max + 19
+
+
+def test_merge_renumber_cycles_default():
+    nhdr = RawCols()
+    schema = _schema()
+    left = _processed_data(nhdr, schema, test_id=0)
+    right = _processed_data(nhdr, schema, test_id=1)
+
+    merged = merge_data(left, right, schema=schema)
+    right_cycles = (
+        merged.raw.filter(pl.col(nhdr.test_id) == 1)[nhdr.cycle_num].unique().sort()
+    )
+    assert right_cycles.to_list() == [3, 4]
+
+
+def test_merge_renumber_cycles_false_keeps_overlapping_cycles():
+    nhdr = RawCols()
+    schema = _schema()
+    shdr = schema.step
+    left = _processed_data(nhdr, schema, test_id=0)
+    right = _processed_data(nhdr, schema, test_id=1)
+
+    merged = merge_data(left, right, schema=schema, renumber_cycles=False)
+    assert merged.steps.height == 8
+    assert set(merged.steps[shdr.test_id].to_list()) == {0, 1}
+    key = merged.steps.select(shdr.test_id, shdr.cycle_num, shdr.step_num)
+    assert key.n_unique() == 8
+
+
+def test_merge_duplicate_test_id_raises():
+    nhdr = RawCols()
+    schema = _schema()
+    left = _processed_data(nhdr, schema, test_id=0)
+    right = _processed_data(nhdr, schema, test_id=0)
+
+    with pytest.raises(ValueError, match="duplicate test_id"):
+        merge_data(left, right, schema=schema)
+
+
+def test_merge_allow_duplicate_test_id_renumbers():
+    nhdr = RawCols()
+    schema = _schema()
+    left = _processed_data(nhdr, schema, test_id=0)
+    right = _processed_data(nhdr, schema, test_id=0)
+
+    merged = merge_data(left, right, schema=schema, allow_duplicate_test_id=True)
+    assert set(merged.raw[nhdr.test_id].unique().to_list()) == {0, 1}
+
+
+def test_merge_empty_left_returns_copy_of_right():
+    nhdr = RawCols()
+    schema = _schema()
+    left = Data()
+    left.raw = pl.DataFrame(schema={c: pl.Int64 for c in (nhdr.datapoint_num,)})
+    right = _processed_data(nhdr, schema, test_id=0)
+
+    merged = merge_data(left, right, schema=schema)
+    assert merged.raw.height == right.raw.height
+    assert merged.steps is not None
+
+
+def test_merge_empty_right_returns_copy_of_left():
+    nhdr = RawCols()
+    schema = _schema()
+    left = _processed_data(nhdr, schema, test_id=0)
+    right = Data()
+    right.raw = pl.DataFrame(schema={c: pl.Int64 for c in (nhdr.datapoint_num,)})
+
+    merged = merge_data(left, right, schema=schema)
+    assert merged.raw.height == left.raw.height
+
+
+def test_merge_does_not_mutate_inputs():
+    nhdr = RawCols()
+    schema = _schema()
+    left = _processed_data(nhdr, schema, test_id=0)
+    right = _processed_data(nhdr, schema, test_id=1)
+    left_dp_max = left.raw[nhdr.datapoint_num].max()
+    right_dp_max = right.raw[nhdr.datapoint_num].max()
+
+    merge_data(left, right, schema=schema)
+
+    assert left.raw[nhdr.datapoint_num].max() == left_dp_max
+    assert right.raw[nhdr.datapoint_num].max() == right_dp_max
+
+
+def test_merge_carries_cumulative_summary_forward():
+    nhdr = RawCols()
+    schema = _schema()
+    chdr = schema.cycle
+    left = _processed_data(nhdr, schema, test_id=0, scale=1.0)
+    right = _processed_data(nhdr, schema, test_id=1, scale=2.0)
+
+    merged = merge_data(left, right, schema=schema)
+    s = merged.summary.sort([chdr.test_id, chdr.cycle_num])
+
+    left_last_cum = left.summary.sort(chdr.cycle_num)[
+        chdr.test_cumulated_charge_capacity
+    ][-1]
+    right_first_cum = s.filter(pl.col(chdr.test_id) == 1)[
+        chdr.test_cumulated_charge_capacity
+    ][0]
+    right_first_cc = s.filter(pl.col(chdr.test_id) == 1)[chdr.charge_capacity][0]
+
+    assert right_first_cum == pytest.approx(left_last_cum + right_first_cc)
+
+
+def test_merge_core_data_on_cell():
+    nhdr = RawCols()
+    schema = _schema()
+    cell = CellpyCellCore(initialize=False)
+    left = _processed_data(nhdr, schema, test_id=0)
+    right = _processed_data(nhdr, schema, test_id=1)
+
+    merged = cell.merge_core_data(left, right)
+    assert merged.raw.height == 40
+
+
+def test_merge_requires_raw_on_both_sides():
+    schema = _schema()
+    with pytest.raises(ValueError, match="requires both"):
+        merge_data(Data(), Data(), schema=schema)
+
+
+def _process_raw(raw: pl.DataFrame, schema: Schema) -> Data:
+    data = Data()
+    data.raw = raw
+    summarizers.make_step_table(data, schema=schema, nom_cap=1.0)
+    summarizers.make_summary(data, schema=schema)
+    return data
+
+
+def _steps_oracle_equal(got, expected, shdr: StepCols) -> None:
+    sort_cols = [shdr.cycle_num, shdr.step_num, shdr.datapoint_num_first]
+    g = got.sort(sort_cols)
+    e = expected.sort(sort_cols)
+    assert g.height == e.height
+    assert g.select(sort_cols).equals(e.select(sort_cols))
+
+
+def _summary_oracle_equal(got, expected, chdr: CycleCols) -> None:
+    sort_cols = [chdr.cycle_num]
+    g = got.sort(sort_cols)
+    e = expected.sort(sort_cols)
+    assert g.height == e.height
+    for col in (
+        chdr.charge_capacity,
+        chdr.discharge_capacity,
+        chdr.coulombic_efficiency,
+    ):
+        assert g[col].to_list() == pytest.approx(
+            e[col].to_list(), rel=1e-9, nan_ok=True
+        )
+
+
+def test_update_overlap_matches_full_recompute_oracle():
+    nhdr = RawCols()
+    schema = _schema()
+    shdr, chdr = schema.step, schema.cycle
+
+    full_raw = _single_test_raw(nhdr, n_cycles=2)
+    oracle = _process_raw(full_raw, schema)
+
+    base_raw = full_raw.filter(pl.col(nhdr.source_datapoint_num) <= 9)
+    base = _process_raw(base_raw, schema)
+    extension = full_raw.filter(pl.col(nhdr.source_datapoint_num) >= 9)
+
+    updated = update_data(base, extension, schema=schema)
+
+    _steps_oracle_equal(updated.steps, oracle.steps, shdr)
+    _summary_oracle_equal(updated.summary, oracle.summary, chdr)
+
+
+def test_update_gap_append_matches_full_recompute_oracle():
+    nhdr = RawCols()
+    schema = _schema()
+    shdr, chdr = schema.step, schema.cycle
+
+    full_raw = _single_test_raw(nhdr, n_cycles=3)
+    oracle = _process_raw(full_raw, schema)
+
+    base_raw = full_raw.filter(pl.col(nhdr.source_datapoint_num) < 20)
+    base = _process_raw(base_raw, schema)
+    extension = full_raw.filter(pl.col(nhdr.source_datapoint_num) >= 20)
+
+    updated = update_data(base, extension, schema=schema)
+
+    _steps_oracle_equal(updated.steps, oracle.steps, shdr)
+    _summary_oracle_equal(updated.summary, oracle.summary, chdr)
+
+
+def test_update_full_replace_raises():
+    nhdr = RawCols()
+    schema = _schema()
+    base = _processed_data(nhdr, schema)
+    new_raw = _single_test_raw(nhdr, n_cycles=1)
+
+    with pytest.raises(ValueError, match="full reload"):
+        update_data(base, new_raw, schema=schema)
+
+
+def test_update_does_not_mutate_input():
+    nhdr = RawCols()
+    schema = _schema()
+    full_raw = _single_test_raw(nhdr, n_cycles=2)
+    base_raw = full_raw.filter(pl.col(nhdr.source_datapoint_num) < 10)
+    base = _process_raw(base_raw, schema)
+    extension = full_raw.filter(pl.col(nhdr.source_datapoint_num) >= 9)
+    raw_before = base.raw.clone()
+    steps_before = base.steps.clone()
+
+    update_data(base, extension, schema=schema)
+
+    assert base.raw.equals(raw_before)
+    assert base.steps.equals(steps_before)
+
+
+def test_update_requires_processed_data():
+    nhdr = RawCols()
+    schema = _schema()
+    data = Data()
+    data.raw = _single_test_raw(nhdr, n_cycles=1)
+    with pytest.raises(
+        ValueError, match="requires data.raw, data.steps, and data.summary"
+    ):
+        update_data(data, _single_test_raw(nhdr, n_cycles=1), schema=schema)
+
+
+def test_update_core_data_refresh_derived():
+    nhdr = RawCols()
+    schema = _schema()
+    cell = CellpyCellCore(initialize=False)
+    full_raw = _single_test_raw(nhdr, n_cycles=2)
+    base = _process_raw(full_raw.filter(pl.col(nhdr.source_datapoint_num) < 10), schema)
+    extension = full_raw.filter(pl.col(nhdr.source_datapoint_num) >= 9)
+
+    updated = cell.update_core_data(base, extension)
+    chdr = schema.cycle
+    assert chdr.charge_c_rate in updated.summary.columns
+    assert chdr.ir_charge in updated.summary.columns


### PR DESCRIPTION
## Summary

- Add `merge_data` to combine two processed `Data` objects (raw + optional steps/summary): datapoint offset, optional cycle renumbering (default on), test_id collision guard, cumulative summary carry-forward.
- Add `update_data` to incrementally append new raw rows to processed data using `source_datapoint_num` overlap detection, incremental step recompute via `from_data_point`, and full summary rebuild.
- Expose `CellpyCellCore.merge_core_data` and `update_core_data` (with optional IR/C-rate refresh); export from `cellpycore`.
- Add 17 tests in `tests/test_merge.py`.

Closes #86

## Test plan

- [x] `uv run pytest` (148 passed)
- [x] `uv run ruff check && uv run ruff format --check`


Made with [Cursor](https://cursor.com)