### PR TITLE
Issue #100: interim BDF read/export prototype under scripts/bdf

### DIFF
--- a/.issueflows/01-current-issues/issue100_original.md
+++ b/.issueflows/01-current-issues/issue100_original.md
@@ -1,0 +1,38 @@
+# Issue #100: BDF read/export: decide placement (scripts vs cellpy-io)
+
+Source: https://github.com/cellpy/cellpy-core/issues/100
+
+## Original issue text
+
+## Context
+
+Should BDF format read/export live in cellpy-core or a separate repo (e.g. cellpy-io)?
+
+Interim idea from `SCRATCHPAD.md`: add a `scripts/` folder in cellpy-core for experimental BDF tooling until ownership is decided.
+
+## Questions
+
+- Is BDF I/O in scope for the core engine library, or an I/O/exchange layer?
+- Does cellpy-io (or similar) already exist / is planned as the home for format adapters?
+- What is the minimum viable script (read only, export only, round-trip)?
+
+## Interim proposal
+
+- Park a prototype under `scripts/` in this repo (not part of the public API).
+- Document the open decision and link from ROADMAP or designs-and-guides when resolved.
+
+## Acceptance criteria
+
+- [ ] Decision recorded in `.issueflows/04-designs-and-guides/` (or ROADMAP)
+- [ ] If interim script: lives under `scripts/`, not imported by `cellpycore` package
+
+## Comments (curated summary)
+
+- **Additional tasks**:
+  - Implement the interim proposal: put the BDF prototype in a subfolder inside `scripts/` so it can be treated as a package.
+  - Try adding a `pyproject.toml` inside that subfolder; if it interferes with the root cellpy-core `pyproject.toml`, fall back to PEP 723 inline script metadata instead.
+- **Clarifications / constraints**:
+  - Decision made: the **interim proposal** was chosen (prototype lives in this repo under `scripts/`, not in a separate cellpy-io repo for now).
+  - BDF format specification reference: https://battery-data-alliance.github.io/battery-data-format-ontology/battery-data-format.html
+
+_Note: this section is an interpretive summary of the comment thread, not a verbatim dump. Source comments: 2, last comment by @jepegit on 2026-07-06._

--- a/.issueflows/01-current-issues/issue100_plan.md
+++ b/.issueflows/01-current-issues/issue100_plan.md
@@ -1,0 +1,113 @@
+# Issue #100 — plan: BDF read/export placement (interim `scripts/` prototype)
+
+## Goal
+
+Record the placement decision (interim: BDF tooling lives in this repo under
+`scripts/`, not in a separate cellpy-io repo) and land a minimal BDF
+export/read prototype as a self-contained package under `scripts/bdf/`, never
+imported by the `cellpycore` package.
+
+## Constraints
+
+- Decision already made in the issue comments: **interim proposal** chosen;
+  prototype goes in a subfolder of `scripts/` treated as a package. Try a
+  nested `pyproject.toml`; if it interferes with the root
+  `pyproject.toml` / `uv` setup, fall back to PEP 723 inline script metadata.
+- Acceptance criteria: decision recorded in
+  `.issueflows/04-designs-and-guides/` (or ROADMAP); interim code lives under
+  `scripts/`, **not imported by** the `cellpycore` package.
+- BDF spec reference:
+  <https://battery-data-alliance.github.io/battery-data-format-ontology/battery-data-format.html>
+  (snake_case column notations with units, e.g. `current_ampere`,
+  `cycle_count`, `cycle_charging_capacity_ah`; obligations
+  required/recommended/optional; converters must not renumber cycles).
+- Core non-goals hold (`this-project.md`): no file IO and no unit conversion
+  in the engine itself — that is exactly why this lives in `scripts/`.
+- Repo config already cooperates: `/scripts` excluded from sdist, wheel builds
+  only `src/cellpycore`, pytest `testpaths = ["tests"]` (root CI will not
+  collect prototype tests). Ruff lints `scripts/` — keep it clean.
+
+### Prior art
+
+- `cellpycore.config.RawCols` — authoritative harmonized-raw column names
+  (mirrors `docs/specifications/harmonized-raw.md`); the mapping table must
+  key off these attributes, not hard-coded strings. Reuse.
+- `cellpycore.testing.mock_data` — mock raw frames for the round-trip test.
+  Reuse.
+- `cellpycore/metadata/io.py` (`to_dict` / `to_json`) — only existing
+  export-style helpers; different domain (metadata), coexist.
+- Toolbox `.issueflows/00-tools/` empty; graph report has no BDF nodes.
+- No `scripts/` folder exists yet — created fresh by this issue.
+
+## Approach
+
+1. **Decision doc** — new
+   `.issueflows/04-designs-and-guides/bdf-io-placement.md`: context, the
+   decision (interim `scripts/bdf/` prototype; cellpy-io remains the candidate
+   long-term home), alternatives considered (core module, separate repo now),
+   revisit criteria, link to issue #100 and the BDF spec.
+2. **ROADMAP** — one line under the relevant section linking the decision doc;
+   remove/annotate the stale BDF entry in `SCRATCHPAD.md`.
+3. **Prototype package `scripts/bdf/`** (own nested `pyproject.toml`, project
+   name `cellpy-bdf`, deps: `polars`, `pyarrow`, `cellpycore`):
+   - `src/cellpy_bdf/mapping.py` — declarative mapping table harmonized-raw
+     attribute -> BDF notation (e.g. `current` -> `current_ampere`,
+     `potential` -> `voltage_volt`, `cycle_num` -> `cycle_count`,
+     `step_num` -> `step_count`, `test_time` -> `test_time_second`,
+     per-cycle-reset capacities/energies -> `cycle_*_ah` / `cycle_*_wh`),
+     resolved against an injected `Schema` (native default).
+   - `src/cellpy_bdf/export.py` — `export_bdf(frame, path, *, schema=None,
+     conversion_factors=None)`: rename + select per mapping, apply by-value
+     conversion factors (default 1.0, engine convention), write parquet
+     (and csv via suffix).
+   - `src/cellpy_bdf/read.py` — `read_bdf(path, *, schema=None)`: inverse
+     rename back to harmonized-raw names, return polars frame usable by
+     `Data.from_raw_frame`.
+   - `tests/test_roundtrip.py` — mock-data round-trip: harmonized frame ->
+     BDF parquet -> back, frame equality on mapped columns.
+   - Package is standalone: **not** a uv workspace member, no imports from
+     `src/cellpycore` into it (only the reverse: it imports `cellpycore`).
+4. **Nested-pyproject verification** (the comment's open point) — after adding
+   the folder, verify root tooling is undisturbed: `uv sync`, `uv run pytest`,
+   `uv lock --check` (or diff), `uv run ruff check`. If interference shows up,
+   collapse the prototype to PEP 723 single-file scripts
+   (`scripts/bdf/export_bdf.py` with `# /// script` metadata) and note that in
+   the decision doc.
+
+## Files to touch
+
+- `.issueflows/04-designs-and-guides/bdf-io-placement.md` — new decision doc.
+- `ROADMAP.md` — link to the decision doc.
+- `SCRATCHPAD.md` — mark BDF idea as resolved by issue #100.
+- `scripts/bdf/pyproject.toml` — nested prototype project.
+- `scripts/bdf/README.md` — how to run (`uv run --project scripts/bdf ...`),
+  prototype status, spec link.
+- `scripts/bdf/src/cellpy_bdf/{__init__.py,mapping.py,export.py,read.py}` —
+  prototype code.
+- `scripts/bdf/tests/test_roundtrip.py` — round-trip test (run via
+  `uv run --project scripts/bdf pytest tests`, not root CI).
+- `.issueflows/01-current-issues/issue100_status.md` — status tracking.
+
+## Test strategy
+
+- Root suite untouched and green: `uv run pytest`; lint `uv run ruff check`
+  and `uv run ruff format --check` (CI commands).
+- Prototype: `uv run --project scripts/bdf pytest tests` for the round-trip
+  test; plus a manual end-to-end run exporting mock data and reading it back.
+- Explicit nested-pyproject interference check: `uv sync` + `uv lock` diff at
+  repo root after adding `scripts/bdf/pyproject.toml`.
+
+## Open questions
+
+1. **MVP scope** — issue asks read-only / export-only / round-trip.
+   Recommendation: **round-trip** (export + read), since the round-trip test
+   is what validates the mapping in both directions and costs little extra.
+2. **Container format** — BDF terms are column notations; recommend parquet as
+   primary output with csv as a convenience (by file suffix). OK?
+3. **Units** — BDF requires SI-ish units (A, V, Ah, Wh, s); core is
+   unit-agnostic. Recommendation: caller passes by-value conversion factors
+   (default 1.0) mirroring the engine convention — no pint on the hot path.
+4. **cellpycore dependency direction** — prototype imports `cellpycore` (for
+   `RawCols` / mock data). Acceptance only forbids the reverse. Confirm OK.
+5. **CI** — keep prototype tests out of CI for now (it is explicitly
+   experimental)? Recommendation: yes, revisit when placement is final.

--- a/.issueflows/01-current-issues/issue100_status.md
+++ b/.issueflows/01-current-issues/issue100_status.md
@@ -1,0 +1,23 @@
+# Issue #100 — status
+
+- [ ] Done
+
+## What's done
+
+- Issue captured (`issue100_original.md`) and plan confirmed (`issue100_plan.md`).
+- Decision recorded in `.issueflows/04-designs-and-guides/bdf-io-placement.md`;
+  ROADMAP links it; stale SCRATCHPAD entry marked resolved.
+- Prototype package `scripts/bdf/` (`cellpy_bdf`): declarative
+  harmonized-raw <-> BDF mapping (`mapping.py`), `export_bdf` /
+  `to_bdf_frame` (`export.py`), `read_bdf` / `from_bdf_frame` (`read.py`),
+  README, nested `pyproject.toml` (path source on in-repo `cellpycore`),
+  committed `uv.lock`.
+- Round-trip tests (7) in `scripts/bdf/tests/test_roundtrip.py`; run via
+  `uv run --directory scripts/bdf pytest` — all pass.
+- Nested-pyproject interference check: root `uv run pytest` (150 passed),
+  `uv lock --check` clean, root `uv.lock` untouched, `uv run ruff check` and
+  `uv run ruff format --check` green. PEP 723 fallback not needed.
+
+## Remaining work
+
+- `/iflow-close`: final checks, commit/push, PR review + merge.

--- a/.issueflows/04-designs-and-guides/bdf-io-placement.md
+++ b/.issueflows/04-designs-and-guides/bdf-io-placement.md
@@ -1,0 +1,52 @@
+# BDF read/export — placement decision
+
+Issue: [#100](https://github.com/cellpy/cellpy-core/issues/100)
+
+## Context
+
+The Battery Data Alliance defines the **Battery Data Format (BDF)**: a set of
+standardized, snake_case column notations with fixed units (e.g.
+``current_ampere``, ``voltage_volt``, ``cycle_count``,
+``cycle_charging_capacity_ah``) and obligations (required / recommended /
+optional). Spec:
+<https://battery-data-alliance.github.io/battery-data-format-ontology/battery-data-format.html>
+
+cellpy would like to read and export BDF, but file/format IO is explicitly a
+non-goal of the cellpy-core engine (see `this-project.md`). The open question
+was where BDF tooling should live: inside cellpy-core, or in a dedicated
+IO/exchange repo (e.g. a future *cellpy-io*).
+
+## Decision (interim)
+
+- BDF tooling lives **in this repo under `scripts/bdf/`** as an experimental,
+  self-contained prototype package (`cellpy_bdf`), with its **own nested
+  `pyproject.toml`** so it can be run and tested in isolation via
+  `uv run --project scripts/bdf ...`.
+- It is **not part of the public API**: nothing in `src/cellpycore` imports
+  it, it is excluded from the sdist (`/scripts` in the hatch exclude list) and
+  from the wheel (which only packages `src/cellpycore`), and root CI does not
+  collect its tests (`testpaths = ["tests"]`).
+- The dependency direction is one-way: the prototype imports `cellpycore`
+  (for `RawCols` and the timestamp helpers), never the reverse.
+- A separate **cellpy-io** repo remains the candidate long-term home for
+  format adapters. This placement is deliberately cheap to move.
+
+## Alternatives considered
+
+- **Core module (`cellpycore.io.bdf`)** — rejected: file IO and unit
+  conversion are engine non-goals; would grow the public API before the
+  format ownership question is settled.
+- **Separate repo now (cellpy-io)** — rejected for now: too much ceremony for
+  a prototype; revisit once the adapter has stabilized and a second format
+  needs a home.
+- **PEP 723 single-file scripts** — fallback if the nested `pyproject.toml`
+  had interfered with the root `uv` setup. Verified it does not (root
+  `uv sync` / `uv lock` / `pytest` / `ruff` unaffected), so the package form
+  was kept.
+
+## Revisit criteria
+
+Move the prototype out of `scripts/` (to cellpy-io or a core extra) when any
+of these happen: a second exchange format needs the same scaffolding, cellpy
+proper wants to depend on BDF export, or the BDF controlled vocabulary
+stabilizes enough to freeze a public API around it.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,6 +34,14 @@ DONE
 
 DONE
 
+## BDF read/export (interim placement decided)
+
+- **Battery Data Format (BDF) adapter** — An experimental read/export prototype lives
+  under `scripts/bdf/` (standalone `cellpy_bdf` package, not part of the public API).
+  Long-term home (cellpy-io vs core extra) is an open question; decision, alternatives
+  and revisit criteria are recorded in
+  `.issueflows/04-designs-and-guides/bdf-io-placement.md` (issue #100).
+
 ## Communication protocols & persistence (open decision)
 
 - **Should core ship out-of-the-box I/O beyond compute?** Today `cellpycore.metadata.io`

--- a/SCRATCHPAD.md
+++ b/SCRATCHPAD.md
@@ -4,9 +4,8 @@
 
 ### BDF format
 
-Read and export in BDF format; should it be a part of cellpy-core, or should it be a part of another repo (cellpy-io)?
-
-Idea: create a folder called scripts in cellpy-core repo and put it there for now. Then we can decide later where to finally put it.
+Resolved by issue #100: interim prototype lives under `scripts/bdf/`; decision and
+revisit criteria recorded in `.issueflows/04-designs-and-guides/bdf-io-placement.md`.
 
 
 ### Ordered headers

--- a/scripts/bdf/README.md
+++ b/scripts/bdf/README.md
@@ -1,0 +1,48 @@
+# cellpy-bdf — experimental BDF read/export prototype
+
+Prototype adapter between the cellpy-core **harmonized-raw** schema
+(`cellpycore.config.RawCols`) and the Battery Data Alliance
+**[Battery Data Format (BDF)](https://battery-data-alliance.github.io/battery-data-format-ontology/battery-data-format.html)**
+column notations.
+
+**Status: experimental, not part of the cellpy-core public API.** Nothing in
+`cellpycore` imports this package; it is excluded from the sdist/wheel and
+from root CI. The placement decision (and when to move it out, e.g. to a
+cellpy-io repo) is recorded in
+[`.issueflows/04-designs-and-guides/bdf-io-placement.md`](../../.issueflows/04-designs-and-guides/bdf-io-placement.md)
+(issue #100).
+
+## Usage
+
+This folder is a standalone `uv` project (own `pyproject.toml`, depends on the
+in-repo `cellpycore` via a path source). Run everything from the repo root
+with `--directory` (which also changes the working directory, so pytest picks
+up this project's config instead of the repo root's):
+
+```bash
+# run the prototype's tests
+uv run --directory scripts/bdf pytest
+
+# use it in a script
+uv run --directory scripts/bdf python - <<'EOF'
+from cellpycore.testing.mock_data import create_raw_data
+from cellpy_bdf import export_bdf, read_bdf
+
+frame = create_raw_data()                      # harmonized-raw polars frame
+export_bdf(frame, "/tmp/example_bdf.parquet")  # BDF-named parquet (or .csv)
+back = read_bdf("/tmp/example_bdf.parquet")    # back to harmonized-raw names
+EOF
+```
+
+## Conventions
+
+- **Cycle-reset capacities:** cellpy-core capacities/energies are cumulative
+  per cycle, per direction — mapped to the BDF `cycle_*_ah` / `cycle_*_wh`
+  terms, not the never-resetting test-level family.
+- **Timestamps:** `epoch_time_utc` (int64 ns, UTC) <-> `unix_time_second`
+  (float s), converted on export/read.
+- **Units:** the engine is unit-agnostic; pass by-value `conversion_factors`
+  (keyed by BDF notation) when the raw data is not already in BDF units.
+  Factors are multiplied in on export and divided out on read.
+- **Preservation:** cycles are never renumbered and `step_type` values pass
+  through as reported, per the BDF spec.

--- a/scripts/bdf/pyproject.toml
+++ b/scripts/bdf/pyproject.toml
@@ -1,0 +1,32 @@
+[project]
+name = "cellpy-bdf"
+version = "0.1.0"
+description = "Experimental BDF (Battery Data Format) read/export prototype for cellpy-core (not part of the public API)"
+readme = "README.md"
+requires-python = ">=3.13"
+
+dependencies = [
+    "cellpycore>=0.1.4",
+    "polars>=1.29.0",
+]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0.0",
+]
+
+[build-system]
+requires = ["hatchling >= 1.27"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/cellpy_bdf"]
+
+# Track the in-repo cellpycore instead of the PyPI release so the prototype
+# never drifts from the engine it sits next to.
+[tool.uv.sources]
+cellpycore = { path = "../../", editable = true }
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-v --tb=short"

--- a/scripts/bdf/src/cellpy_bdf/__init__.py
+++ b/scripts/bdf/src/cellpy_bdf/__init__.py
@@ -1,0 +1,14 @@
+"""Experimental BDF (Battery Data Format) read/export prototype.
+
+Not part of the cellpy-core public API. See the placement decision in
+``.issueflows/04-designs-and-guides/bdf-io-placement.md`` (issue #100) and the
+BDF spec at
+https://battery-data-alliance.github.io/battery-data-format-ontology/battery-data-format.html
+"""
+
+from cellpy_bdf.export import export_bdf
+from cellpy_bdf.mapping import bdf_mapping
+from cellpy_bdf.read import read_bdf
+
+__all__ = ["bdf_mapping", "export_bdf", "read_bdf"]
+__version__ = "0.1.0"

--- a/scripts/bdf/src/cellpy_bdf/export.py
+++ b/scripts/bdf/src/cellpy_bdf/export.py
@@ -1,0 +1,84 @@
+"""Export a harmonized-raw polars frame to a BDF file."""
+
+from pathlib import Path
+from typing import Optional, Union
+
+import polars as pl
+
+from cellpy_bdf.mapping import BDF_UNIX_TIME, REQUIRED_BDF_COLUMNS, bdf_mapping
+from cellpycore import config
+from cellpycore.timestamps import epoch_ns_to_seconds_expr
+
+
+def to_bdf_frame(
+    frame: pl.DataFrame,
+    raw_cols: Optional[config.Cols] = None,
+    conversion_factors: Optional[dict[str, float]] = None,
+) -> pl.DataFrame:
+    """Convert a harmonized-raw frame to a BDF-named frame.
+
+    Args:
+        frame: A ``polars.DataFrame`` in the harmonized-raw schema.
+        raw_cols: The raw column-header schema. Defaults to the native
+            ``config.RawCols``.
+        conversion_factors: Optional by-value unit-conversion factors keyed by
+            **BDF notation** (e.g. ``{"cycle_charging_capacity_ah": 0.001}``
+            for mAh raw data). Values are multiplied in on export; missing
+            keys default to ``1.0`` (raw data assumed already in BDF units).
+
+    Returns:
+        A frame holding only the mapped columns, renamed to BDF notations,
+        with ``unix_time_second`` converted from epoch nanoseconds.
+
+    Raises:
+        ValueError: If a BDF-required column (current, voltage) is missing.
+    """
+    mapping = {
+        raw: bdf for raw, bdf in bdf_mapping(raw_cols).items() if raw in frame.columns
+    }
+    missing = [c for c in REQUIRED_BDF_COLUMNS if c not in mapping.values()]
+    if missing:
+        raise ValueError(f"frame lacks columns for required BDF terms: {missing}")
+
+    out = frame.select(list(mapping)).rename(mapping)
+    if BDF_UNIX_TIME in out.columns:
+        out = out.with_columns(epoch_ns_to_seconds_expr(BDF_UNIX_TIME))
+    if conversion_factors:
+        out = out.with_columns(
+            pl.col(bdf_name) * factor
+            for bdf_name, factor in conversion_factors.items()
+            if bdf_name in out.columns
+        )
+    return out
+
+
+def export_bdf(
+    frame: pl.DataFrame,
+    path: Union[str, Path],
+    raw_cols: Optional[config.Cols] = None,
+    conversion_factors: Optional[dict[str, float]] = None,
+) -> Path:
+    """Write a harmonized-raw frame to a BDF file (parquet or csv by suffix).
+
+    Args:
+        frame: A ``polars.DataFrame`` in the harmonized-raw schema.
+        path: Output file path; ``.parquet`` or ``.csv`` decides the format.
+        raw_cols: The raw column-header schema. Defaults to the native
+            ``config.RawCols``.
+        conversion_factors: See :func:`to_bdf_frame`.
+
+    Returns:
+        The output path.
+
+    Raises:
+        ValueError: On a missing required column or an unsupported suffix.
+    """
+    path = Path(path)
+    out = to_bdf_frame(frame, raw_cols=raw_cols, conversion_factors=conversion_factors)
+    if path.suffix == ".parquet":
+        out.write_parquet(path)
+    elif path.suffix == ".csv":
+        out.write_csv(path)
+    else:
+        raise ValueError(f"unsupported BDF file suffix: {path.suffix!r}")
+    return path

--- a/scripts/bdf/src/cellpy_bdf/mapping.py
+++ b/scripts/bdf/src/cellpy_bdf/mapping.py
@@ -1,0 +1,62 @@
+"""Column mapping between the harmonized-raw schema and BDF notations.
+
+The harmonized-raw side is resolved from an injected ``cellpycore.config``
+column object (``RawCols`` by default), so custom schemas keep working. The
+BDF side uses the notations from the Battery Data Alliance ontology:
+https://battery-data-alliance.github.io/battery-data-format-ontology/battery-data-format.html
+
+Conventions honored:
+
+- cellpy-core capacities/energies are cumulative **per cycle, per direction**
+  (reset each cycle), which matches the BDF ``cycle_*`` terms — not the
+  never-resetting test-level ``charging_capacity_ah`` family.
+- ``epoch_time_utc`` (int64 nanoseconds, UTC) maps to ``unix_time_second``
+  (float seconds); the ns <-> s conversion is handled by export/read, not by
+  this table.
+- BDF says converters must not renumber cycles and should preserve
+  ``step_type`` values as reported; the mapping only renames, never rewrites.
+"""
+
+from typing import Optional
+
+from cellpycore import config
+
+# BDF notation of the absolute-timestamp column; needs ns <-> s conversion.
+BDF_UNIX_TIME = "unix_time_second"
+
+# BDF obligation "required" — export fails fast when these are missing.
+REQUIRED_BDF_COLUMNS = ("current_ampere", "voltage_volt")
+
+
+def bdf_mapping(raw_cols: Optional[config.Cols] = None) -> dict[str, str]:
+    """Build the harmonized-raw -> BDF column-name mapping.
+
+    Args:
+        raw_cols: The raw column-header schema to resolve harmonized-raw
+            names from. Defaults to the native ``config.RawCols``.
+
+    Returns:
+        Mapping of harmonized-raw column name to BDF notation. Harmonized
+        columns without a BDF counterpart (bookkeeping columns like
+        ``source_uuid`` or ``test_id``) are deliberately absent.
+    """
+    r = raw_cols if raw_cols is not None else config.RawCols()
+    return {
+        r.datapoint_num: "record_index",
+        r.epoch_time_utc: BDF_UNIX_TIME,
+        r.test_time: "test_time_second",
+        r.step_time: "step_time_second",
+        r.step_num: "step_count",
+        r.cycle_num: "cycle_count",
+        r.step_type: "step_type",
+        r.potential: "voltage_volt",
+        r.current: "current_ampere",
+        r.cumulative_charge_capacity: "cycle_charging_capacity_ah",
+        r.cumulative_discharge_capacity: "cycle_discharging_capacity_ah",
+        r.cumulative_charge_energy: "cycle_charging_energy_wh",
+        r.cumulative_discharge_energy: "cycle_discharging_energy_wh",
+        r.internal_resistance: "internal_resistance_ohm",
+        r.aux_temperature_cell: "surface_temperature_celsius",
+        r.aux_temperature_chamber: "ambient_temperature_celsius",
+        r.aux_pressure_cell: "surface_pressure_pa",
+    }

--- a/scripts/bdf/src/cellpy_bdf/read.py
+++ b/scripts/bdf/src/cellpy_bdf/read.py
@@ -1,0 +1,80 @@
+"""Read a BDF file back into the harmonized-raw schema."""
+
+from pathlib import Path
+from typing import Optional, Union
+
+import polars as pl
+
+from cellpy_bdf.mapping import BDF_UNIX_TIME, bdf_mapping
+from cellpycore import config
+from cellpycore.timestamps import NS_PER_SECOND
+
+
+def from_bdf_frame(
+    frame: pl.DataFrame,
+    raw_cols: Optional[config.Cols] = None,
+    conversion_factors: Optional[dict[str, float]] = None,
+) -> pl.DataFrame:
+    """Convert a BDF-named frame back to harmonized-raw column names.
+
+    Args:
+        frame: A ``polars.DataFrame`` with BDF-notation columns.
+        raw_cols: The raw column-header schema to rename into. Defaults to
+            the native ``config.RawCols``.
+        conversion_factors: The same factors passed to export (keyed by BDF
+            notation); values are divided out here.
+
+    Returns:
+        A frame with the recognized columns renamed to harmonized-raw names
+        and the epoch timestamp restored to int64 nanoseconds. Unrecognized
+        BDF columns are kept as-is.
+    """
+    if conversion_factors:
+        frame = frame.with_columns(
+            pl.col(bdf_name) / factor
+            for bdf_name, factor in conversion_factors.items()
+            if bdf_name in frame.columns
+        )
+    if BDF_UNIX_TIME in frame.columns:
+        frame = frame.with_columns(
+            (pl.col(BDF_UNIX_TIME) * NS_PER_SECOND).round(0).cast(pl.Int64)
+        )
+    inverse = {
+        bdf: raw for raw, bdf in bdf_mapping(raw_cols).items() if bdf in frame.columns
+    }
+    return frame.rename(inverse)
+
+
+def read_bdf(
+    path: Union[str, Path],
+    raw_cols: Optional[config.Cols] = None,
+    conversion_factors: Optional[dict[str, float]] = None,
+) -> pl.DataFrame:
+    """Read a BDF file (parquet or csv by suffix) as a harmonized-raw frame.
+
+    The result is suitable for ``Data.from_raw_frame(..., validate=False)``;
+    full validation may require bookkeeping columns (``source_uuid`` etc.)
+    that BDF does not carry.
+
+    Args:
+        path: Input file path; ``.parquet`` or ``.csv`` decides the format.
+        raw_cols: The raw column-header schema to rename into. Defaults to
+            the native ``config.RawCols``.
+        conversion_factors: See :func:`from_bdf_frame`.
+
+    Returns:
+        A ``polars.DataFrame`` with harmonized-raw column names.
+
+    Raises:
+        ValueError: On an unsupported suffix.
+    """
+    path = Path(path)
+    if path.suffix == ".parquet":
+        frame = pl.read_parquet(path)
+    elif path.suffix == ".csv":
+        frame = pl.read_csv(path)
+    else:
+        raise ValueError(f"unsupported BDF file suffix: {path.suffix!r}")
+    return from_bdf_frame(
+        frame, raw_cols=raw_cols, conversion_factors=conversion_factors
+    )

--- a/scripts/bdf/tests/test_roundtrip.py
+++ b/scripts/bdf/tests/test_roundtrip.py
@@ -1,0 +1,86 @@
+"""Round-trip tests for the BDF prototype (harmonized-raw -> BDF -> back)."""
+
+import polars as pl
+import pytest
+from cellpy_bdf import bdf_mapping, export_bdf, read_bdf
+from cellpy_bdf.export import to_bdf_frame
+from polars.testing import assert_frame_equal
+
+from cellpycore.config import RawCols
+from cellpycore.testing.mock_data import create_raw_data
+
+
+@pytest.fixture
+def raw_frame() -> pl.DataFrame:
+    return create_raw_data()
+
+
+def _mapped_subset(frame: pl.DataFrame) -> pl.DataFrame:
+    mapped = [c for c in bdf_mapping() if c in frame.columns]
+    return frame.select(mapped)
+
+
+@pytest.mark.parametrize("suffix", [".parquet", ".csv"])
+def test_roundtrip_preserves_mapped_columns(raw_frame, tmp_path, suffix):
+    path = export_bdf(raw_frame, tmp_path / f"bdf_export{suffix}")
+    back = read_bdf(path)
+    assert_frame_equal(
+        back.select(_mapped_subset(raw_frame).columns),
+        _mapped_subset(raw_frame),
+        check_column_order=False,
+    )
+
+
+def test_roundtrip_with_conversion_factors(raw_frame, tmp_path):
+    factors = {"cycle_charging_capacity_ah": 0.001, "current_ampere": 2.0}
+    path = export_bdf(
+        raw_frame, tmp_path / "bdf_export.parquet", conversion_factors=factors
+    )
+    raw_cols = RawCols()
+
+    exported = pl.read_parquet(path)
+    expected_ah = raw_frame[raw_cols.cumulative_charge_capacity] * 0.001
+    assert exported["cycle_charging_capacity_ah"].equals(
+        expected_ah.rename("cycle_charging_capacity_ah")
+    )
+
+    back = read_bdf(path, conversion_factors=factors)
+    assert_frame_equal(
+        back.select(_mapped_subset(raw_frame).columns),
+        _mapped_subset(raw_frame),
+        check_column_order=False,
+    )
+
+
+def test_export_uses_bdf_notations_and_unix_seconds(raw_frame, tmp_path):
+    out = to_bdf_frame(raw_frame)
+    assert "current_ampere" in out.columns
+    assert "voltage_volt" in out.columns
+    assert "cycle_count" in out.columns
+    # epoch ns -> unix seconds: mock data starts at 2021-01-01T00:00:00 UTC
+    assert out["unix_time_second"].dtype == pl.Float64
+    assert out["unix_time_second"][0] == 1609459200.0
+    # no harmonized-only bookkeeping columns leak into the BDF file
+    assert "source_uuid" not in out.columns
+
+
+def test_export_fails_without_required_columns(raw_frame, tmp_path):
+    crippled = raw_frame.drop(RawCols().current)
+    with pytest.raises(ValueError, match="current_ampere"):
+        export_bdf(crippled, tmp_path / "bdf.parquet")
+
+
+def test_readback_feeds_from_raw_frame(raw_frame, tmp_path):
+    from cellpycore.cell_core import Data
+
+    path = export_bdf(raw_frame, tmp_path / "bdf.parquet")
+    back = read_bdf(path)
+    data = Data.from_raw_frame(back, validate=False)
+    assert data.raw.height == raw_frame.height
+
+
+def test_unsupported_suffix(raw_frame, tmp_path):
+    with pytest.raises(ValueError, match="suffix"):
+        export_bdf(raw_frame, tmp_path / "bdf.xlsx")
+    with pytest.raises(ValueError, match="suffix"):
+        read_bdf(tmp_path / "bdf.xlsx")

--- a/scripts/bdf/uv.lock
+++ b/scripts/bdf/uv.lock
@@ -1,0 +1,310 @@
+version = 1
+revision = 3
+requires-python = ">=3.13"
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+
+[[package]]
+name = "cellpy-bdf"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "cellpycore" },
+    { name = "polars" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "cellpycore", editable = "../../" },
+    { name = "polars", specifier = ">=1.29.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8.0.0" }]
+
+[[package]]
+name = "cellpycore"
+version = "0.1.4"
+source = { editable = "../../" }
+dependencies = [
+    { name = "pandas" },
+    { name = "polars" },
+    { name = "pyarrow" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pandas", specifier = ">=2.2.3" },
+    { name = "pint", marker = "extra == 'units'", specifier = ">=0.25" },
+    { name = "polars", specifier = ">=1.29.0" },
+    { name = "pyarrow", specifier = ">=20.0.0" },
+]
+provides-extras = ["units"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "marimo", specifier = ">=0.23.10" },
+    { name = "matplotlib", specifier = ">=3.10.6" },
+    { name = "pint", specifier = ">=0.25" },
+    { name = "pre-commit", specifier = ">=4.6.0" },
+    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "pytest-benchmark", specifier = ">=5.2.3" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "ruff", specifier = ">=0.11.8" },
+]
+docs = [
+    { name = "ipykernel", specifier = ">=7.3.0" },
+    { name = "matplotlib", specifier = ">=3.10.6" },
+    { name = "nbconvert", specifier = ">=7.17.1" },
+    { name = "zensical", specifier = ">=0.0.46" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz", hash = "sha256:a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3", size = 20755553, upload-time = "2026-07-04T17:08:00.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/07/ec2a3f0c91761581d4b7104a740791800025983f9a4dc4e73f91a99aeac4/numpy-2.5.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0bfebd8695f9863592fe744be833a258120b14a9f39da255e8aa8fade2c0ddd1", size = 16796419, upload-time = "2026-07-04T17:06:40.37Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ab/ddb499fc4f8780354395face5b65c7fd107bcd6e1d667a5f07d046956f6f/numpy-2.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:30b44a6b53a7ae63c54c089a8726e5563ed302716c5b7ccc85afade40b0e7ff6", size = 11765832, upload-time = "2026-07-04T17:06:42.768Z" },
+    { url = "https://files.pythonhosted.org/packages/88/b3/3c28c558a09fc72100c646dac6d2fce8e834c471b0edca01a29996706117/numpy-2.5.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:6165343f81b56ef8f514f396989e529b61d9dc709b99421b07e9f3e698e2287d", size = 5325143, upload-time = "2026-07-04T17:06:45.466Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/0e/ce19b985bb15c596f4f05954e76cccc77c845083b3b8f938a6c68e523128/numpy-2.5.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:4939237038ada79308dda3204ac6462df056b5672b2e25db1149cf873668b3e1", size = 6659749, upload-time = "2026-07-04T17:06:47.288Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/20/1ee6614d64332a1bba6411f38e68cb79eec1b2459e20a623777c5c5492a2/numpy-2.5.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c6759f538fb912fc46de0a6b1758ccf7b57bc7c7ebebc23974fdac3de8db0cd", size = 15164716, upload-time = "2026-07-04T17:06:49.494Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a7/2bcd3fdbb87804755c35b729bf8709d62025c5f4cfd7d5b2415997097515/numpy-2.5.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9726558e8db4a5bf7929a70ae50f63abda4daf0efe810e3bfbab95976f75fc1a", size = 16661440, upload-time = "2026-07-04T17:06:52.061Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/d7/a41e3310c886fe457d36e670bbf24fae411aca8a7b6ad92a32afd924077c/numpy-2.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3935f3b419b244a02732676fa5317a9193cc596a4c0646db07e5b421229ac9f7", size = 16526305, upload-time = "2026-07-04T17:06:54.605Z" },
+    { url = "https://files.pythonhosted.org/packages/53/75/4333a9a707c1edd3a4e1a0c58eca52c0f31e55089fa80db02b5565b24df7/numpy-2.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dc932a65ded7ce9013d120845a2514dcccb1a67bfc8deb8d37633762951904a6", size = 18423008, upload-time = "2026-07-04T17:06:57.54Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/e314a32b1c11a2ffe818ddad3a57b50b4b6e1b6c487192eb50cdef0415d0/numpy-2.5.1-cp313-cp313-win32.whl", hash = "sha256:4b4ff1608417eb7a59da7b967bbb798cacfe071d2caf526a24281cd562072ed9", size = 6063885, upload-time = "2026-07-04T17:07:00.14Z" },
+    { url = "https://files.pythonhosted.org/packages/10/70/800b3fca480af32df9e8ea9f3d4a0c8feb4b32d7f195d174eabbda4829ad/numpy-2.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:6c3fe51bc6a16453d452997053454f309e8e0ed7b42d6b361ce4ac8c32913d74", size = 12425674, upload-time = "2026-07-04T17:07:02.387Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/0b/196350c122f50f6ca56846f2d71efd5e0d24b7b2e07355e019b2e2c7a11e/numpy-2.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:f7feb014281029e628ba2d5a007407443b06e418b6fe451d1e2adcbc8eba0107", size = 10350256, upload-time = "2026-07-04T17:07:04.878Z" },
+    { url = "https://files.pythonhosted.org/packages/db/f4/731b6085a83faf6ca843394cbd5e217280c214399f7e8b21b9f552af0ae2/numpy-2.5.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:7c786fe9a5bbe360022e584c5a34cf6b54265c71bd7ec8ac3d8fec38968071f8", size = 16795063, upload-time = "2026-07-04T17:07:07.374Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/64/0e215f2048dd11a55bb989ed41b3585ef57452404e638d703a211a3e4157/numpy-2.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:32985c896d897419ef8da6917872d80b78ad0ea26d85b23245c7366ffde76d75", size = 11776652, upload-time = "2026-07-04T17:07:09.907Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/59/2b844c7a6e9deff69b404a66221e1542937734f65d5e6e39411876053862/numpy-2.5.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:efd736408cc97c79b9e6917338dfc8f06013b2274f992e96b1d9a81a71e2a2c2", size = 5335944, upload-time = "2026-07-04T17:07:12.227Z" },
+    { url = "https://files.pythonhosted.org/packages/86/51/9bf7cb2cabcebc9e017e4ec7e6322b378317a542c08b4cb68479c1efc716/numpy-2.5.1-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:ab84dc6b074fa881cae55bea94cc4f68e285181ba7f32497bf7dee6b1496165b", size = 6656266, upload-time = "2026-07-04T17:07:14.368Z" },
+    { url = "https://files.pythonhosted.org/packages/83/3e/fb7615b211b82a32f44d5180a6d421b61f84d4fadd578b48ba4ac34e189f/numpy-2.5.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caf3e317d33d60c37986b452613f4ab51246d0691350c03d0cb4a898627f4a95", size = 15179720, upload-time = "2026-07-04T17:07:16.272Z" },
+    { url = "https://files.pythonhosted.org/packages/41/5f/0f992cb24560673496c5d68de61913b57166ce530ffda07c1f280e0cc464/numpy-2.5.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:54ad769f17bc2d833b620851989f62054fb9ab93c969d9e1dc3c8e3d56beea21", size = 16664835, upload-time = "2026-07-04T17:07:19.021Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/2f/97d6475ee91afe2587797d09446f9d3e475ad4cb681662d824809327b75a/numpy-2.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c12afb53450fa976d4c681c50a7423729a4c51c0465ed9f32b8a9cabbc472373", size = 16539135, upload-time = "2026-07-04T17:07:22.015Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/5b/4db81e4ba0be7e2776b1de68c82aa862c7f8ec27e1b4927d4ae075e20678/numpy-2.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e8c11c405efc5ff6816d5983c96cdfa215bab3428961243af3ff59b228490438", size = 18426684, upload-time = "2026-07-04T17:07:24.941Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/64/c0ba2d90724d450279a7df8f32057241070250a26a7e2b5337d77347f481/numpy-2.5.1-cp314-cp314-win32.whl", hash = "sha256:f2479a47f8d5932d1718168a681ad6e536a9df484c83cfcf9de365e164537ace", size = 6116103, upload-time = "2026-07-04T17:07:27.622Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/1a/837f9ed7405adcd7a40538792eb169eddd8fa5630c16a1ef49dae71a30f4/numpy-2.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:24d0eb82c0541d3415a33425db64ae439dffccd7b4dbcb30e7c35120205c506a", size = 12562177, upload-time = "2026-07-04T17:07:29.887Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/49707938b6dd0a78a9178dd93227dc89e4c11af47f5c798d70366e8d0483/numpy-2.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:5a4c988b38d261deeeaad9954e3deb091ad905c94e8bb6708654ef1d97f286b0", size = 10627739, upload-time = "2026-07-04T17:07:32.568Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c7/bb4b882cfe7f299cbc8b66e42e7dd78cf9d14e40f9469fc5e3db7e15b3bd/numpy-2.5.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a33276be12fa045805f477f22482088b66bb758ffbe89a9d21457de863a32e22", size = 11894709, upload-time = "2026-07-04T17:07:34.941Z" },
+    { url = "https://files.pythonhosted.org/packages/40/3f/5af7f4a7f6224aef48017aa82bb6174c7a659d724be0c75017b7e64a55b4/numpy-2.5.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:f089d7b00756190aacf1f5d34bdf38c3c430ac82b4f868f8cede73380460fce7", size = 5453810, upload-time = "2026-07-04T17:07:37.495Z" },
+    { url = "https://files.pythonhosted.org/packages/20/c9/3474309bc94d634d3f9c3eddf03250ecb8c22cd948ef16fef69a77cc5d7b/numpy-2.5.1-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:09e9bfd8d2cf479c7d174804fb3811c53a8e9f20a37444008606b57d6b7a826d", size = 6761189, upload-time = "2026-07-04T17:07:39.563Z" },
+    { url = "https://files.pythonhosted.org/packages/90/8a/558ae39fdd55d7e7f7fef9a84a6e964ac6b23edbd2a07e52bb084500507d/numpy-2.5.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e68d8dd1e7eba712948f2053a29ec86917bc70ba1358df869d9f06649ef9cf09", size = 15225039, upload-time = "2026-07-04T17:07:41.682Z" },
+    { url = "https://files.pythonhosted.org/packages/63/27/ca7392b2d030277bdf0273e7d23255b3ee57d57a7c170a6f4fb3981e1e5d/numpy-2.5.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:99d5095fa265a0c4152e7bb12759e14381ef5496152f1ce58f44bdf55c44beb4", size = 16701306, upload-time = "2026-07-04T17:07:44.611Z" },
+    { url = "https://files.pythonhosted.org/packages/02/42/03d53ae7996c44d4374a8262e9dc41671fd56cbb98f7d47ef85cf5da4c6b/numpy-2.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ab87a91b3cc3382b8956095bd8f95e00cf679bb81554339be1a2ba404a1473c1", size = 16589955, upload-time = "2026-07-04T17:07:47.694Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/15/6c1784ae469640e65db111e9a34b3d0f14d91e8a38b9ce34810ced370dbb/numpy-2.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:224ca51130ef7da85bea2191625181cb4f337f9cb64b471f10c1a12aa8b60077", size = 18464252, upload-time = "2026-07-04T17:07:50.684Z" },
+    { url = "https://files.pythonhosted.org/packages/94/a8/f98e50356cf167df656c526c2dfeec2d7dde182f2a3da4b458a5938e2776/numpy-2.5.1-cp314-cp314t-win32.whl", hash = "sha256:6eab239876581b2b3c5a242281b6007bbdbcd1c7085d7709bb57c5929b11e6bf", size = 6263298, upload-time = "2026-07-04T17:07:53.445Z" },
+    { url = "https://files.pythonhosted.org/packages/72/ac/96ae880cdecad0b3275d9359fcec72667b49a4863c9f12942e43679dda02/numpy-2.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:83ce9c80d5b521b0d77ddcbe5447c218d247929b6cc056ca5351342accfff0af", size = 12748623, upload-time = "2026-07-04T17:07:55.384Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/5a/4d2b1601df3602dba7a14f3348ba9bfe94a18adb428e693df6154c293831/numpy-2.5.1-cp314-cp314t-win_arm64.whl", hash = "sha256:5a6db61f9aaa57e369905c67d852045d3c4f7126405b29d09b19dec118e9c9cb", size = 10697674, upload-time = "2026-07-04T17:07:58.506Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pandas"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/87/4341c6252d1c47b08768c3d25ac487362bf403f0313ddae4a2a26c9b1b4c/pandas-3.0.3.tar.gz", hash = "sha256:696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc", size = 4651414, upload-time = "2026-05-11T18:54:29.21Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/90/62d8302883c44308c477e222c3daf7c813a34c8e96985882fbd53d964352/pandas-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:67b3b64c11910cfa29f4e94a14d3bff9ee693b6fc76055e7cad549cee0aec5fa", size = 10331071, upload-time = "2026-05-11T18:52:58.838Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/ae/6a6493c783a101f165e4356953ba3c74d6f77f0042fa7d753da9dfbb640c/pandas-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:39436b377d56d2a2e52d0395bdbee171f01068e99af5250509aceeb929f765c7", size = 9875690, upload-time = "2026-05-11T18:53:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7c/5df8e9f56c69a2769fbe9382a5ef8f2658c007e376434e1e2cbb57ad895f/pandas-3.0.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4be06d68f9ddcfc645b87534911da79a8fbffc7573c80e0edcf42a5020624d8", size = 10381634, upload-time = "2026-05-11T18:53:04.393Z" },
+    { url = "https://files.pythonhosted.org/packages/99/68/1237369725aa617bb358263d535803e3053fdbc593513ec5ed9c9896b5b6/pandas-3.0.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a4eeb6830daf35a71cc09649bd823e2b542dac246cdee9614c6e4bd65028cd6a", size = 10891243, upload-time = "2026-05-11T18:53:07.643Z" },
+    { url = "https://files.pythonhosted.org/packages/25/93/77d108e8af7222b4a503ebde0e30215b1c2e4f8e53a526431890f22d5586/pandas-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1928e07221f82db493cd4af1e23c1bfca524a19a4699887975bff68f49a72bfb", size = 11388659, upload-time = "2026-05-11T18:53:10.634Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/bd/eff5b4399f332ac386c853f6cd2bd3fa2ca0061b9f36ecd9c4d7c4265649/pandas-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51b1fe551acb77dac643c6fda86084d8d446c10fe64b06a9cc29c4cc8540e7f2", size = 11942880, upload-time = "2026-05-11T18:53:13.536Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/20/559ace4200982c3887d0b86bfd0d856a2143ef8ddab63cc07934951a964c/pandas-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:a82d532a3351d435432cd913edbccaf8b8e01d4dd0e5ced5a8d2e8ecd94c7e44", size = 9757091, upload-time = "2026-05-11T18:53:16.306Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/66/69055a09fe200f29f922a3eeec4804611900b95f52d932ece3393c3c0c19/pandas-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:275c14e0fce14a2ec20eee474aecd305478ea3c1e6f6a9d8fe219a165542717e", size = 9057282, upload-time = "2026-05-11T18:53:18.768Z" },
+    { url = "https://files.pythonhosted.org/packages/57/0e/efe801b0e6811e8e650cd21b7f2608e30f08a7067e2bf6e8752b0d56ee3c/pandas-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:46997386d528eb40376ecd6b033cf4a8a1e5282580f68f43de875b78cba2199d", size = 10767016, upload-time = "2026-05-11T18:53:21.227Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/dc/eb55135a1d5f0f0519f28da1f609a206d2cad1f9c35c32d51e38dd7261ae/pandas-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:261e308dfb22448384b7580cf719d2f998fe2966c92893c3e77d14008af1f066", size = 10420210, upload-time = "2026-05-11T18:53:23.982Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/3e/b1d5d955ce33ffecb407465a60bc32769d74fcf68224b7ae67ae11d4dea4/pandas-3.0.3-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dd1a5d1def6a46002e964510bdc67c368aa0951df5d1d9f8365336f5a1f490cd", size = 10336126, upload-time = "2026-05-11T18:53:26.731Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/76/a01261711ab60a22d71b862f0de20e4c504bf80457270ad8cb42110f6abc/pandas-3.0.3-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d72828c20c6d6e83e1e22a6a3b47b326b71664112fa9705dcbccfd7a39b62085", size = 10728051, upload-time = "2026-05-11T18:53:29.125Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/21/ea191195e587b18cf682e97f433f81b2d0fbe341380e80a3e0d6e4403c8e/pandas-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d26cbe1fcfc12e8fd900e2454163e466b2d3af84f7c75481df7683ffc073d870", size = 11350796, upload-time = "2026-05-11T18:53:32.056Z" },
+    { url = "https://files.pythonhosted.org/packages/64/69/f0eaaf54939f0e8c6768fd06be9af2cef9b36048b96dfb9e1b2c685a807e/pandas-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:3e91cec1879ada0624fc3dc9953c5cbd60208e59c0db28f540c5d6d47502422f", size = 11799741, upload-time = "2026-05-11T18:53:34.985Z" },
+    { url = "https://files.pythonhosted.org/packages/45/a4/865e0e510cae5fc2194de4db28be638952de942571ba9125934fd9c01d47/pandas-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:08d789b41f87e0905880e293cedf6197ce71fe67cc081358b1e148a491b9bd13", size = 10499958, upload-time = "2026-05-11T18:53:37.857Z" },
+    { url = "https://files.pythonhosted.org/packages/86/54/effdcc3c0ff7a08037889200e148ebe94c16c4f653be078c7b3675955df1/pandas-3.0.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3650109c0f22879df8bd6179ab9ee3d7f1d1d4e7e0094a3f0032d9f51e2e64ac", size = 10336065, upload-time = "2026-05-11T18:53:41.099Z" },
+    { url = "https://files.pythonhosted.org/packages/68/10/bf2d6738d72748b961a3751ab89522d58c54efc36a8e1a12161216cd45cf/pandas-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:bab900348131a7db1f69a7309ef141fd5680f1487094193bcbbb61791573bf8f", size = 9926101, upload-time = "2026-05-11T18:53:43.515Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/e9/e35cf11c8a136e757b956f5f0efdcaa50aecde85ea055f1898dfc68262f3/pandas-3.0.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ba7e08b9ac1d54569cd1e256e3668975ed624d6826f7b68df0342b012007bddb", size = 10457553, upload-time = "2026-05-11T18:53:46.394Z" },
+    { url = "https://files.pythonhosted.org/packages/58/3b/1cdec6772bdbaf7b25dab360c59f03cadf05492dd724c6540af905389b07/pandas-3.0.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d71c63ae4ebdbf70209742096f1fc46a83a0613c99d4b23766cced9ff8cd62a", size = 10914065, upload-time = "2026-05-11T18:53:49.134Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c2/1ef644445fcd72e3627bceec77e3560636f87ddce4ed841afe76b83b5bf9/pandas-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e3a2ec42c98ffa2565a67e08e218d06d72576d758d90facb7c00805194d8f360", size = 11459188, upload-time = "2026-05-11T18:53:52.527Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/49/4d8d4f42cbc9c4adc7a1870f269c02cbd6cd40d059622c06fb298addcbad/pandas-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:335f62418ed562cfc3c49e9e196375c28b729dcef8543abf4f9438e381bf3c76", size = 11982966, upload-time = "2026-05-11T18:53:55.043Z" },
+    { url = "https://files.pythonhosted.org/packages/38/55/792619469bab9882d8bbd5865d45a72f6478762d04a9af4bf0d08c503e95/pandas-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:3c20a521bbb85902f79f7270c80a59e1b5452d96d170c034f207181870f97ac5", size = 9876755, upload-time = "2026-05-11T18:53:58.067Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/af/33c469653b0ba03b50c3a98192d4c07f0c75c66b263ceb097fce0ee97d31/pandas-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:a2d2dff8a04f3917b55ab3910c32990f8ddf7eceba114947838cefa976a68977", size = 9198658, upload-time = "2026-05-11T18:54:00.733Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/fa/b8c257bd76b8bd060c3a9151c1fca05e9b9c5e3af5d0f549c0356f6d143d/pandas-3.0.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:0d589105b3c14645af1738ff279b2995102d8f7a03b0a66dc8d95550eb513e04", size = 10787242, upload-time = "2026-05-11T18:54:03.564Z" },
+    { url = "https://files.pythonhosted.org/packages/54/eb/f19206ffb0bf1919002969aa448b4702c6594845156a6f8050674855aac3/pandas-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:13fc1e853d9e04743d11ba75a985ccbc2a317fe07d8af61e445a6fd24dacd6a6", size = 10436369, upload-time = "2026-05-11T18:54:06.311Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/24/c7c39fb4fe22b71a0c2d78bf0c585c600092d85f94f086d2b3b2f6ca27e2/pandas-3.0.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:819959dab7bbd0049c15623fbac4e29a191b9528160a61fb1032242d8ced2d9c", size = 10358306, upload-time = "2026-05-11T18:54:09.085Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ec/dd2a9eb7fa1204df88c0864164e35b228ac581062ac612ba0a67fd812e4c/pandas-3.0.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:60ae316d3fd75d1858d450d0db0103ea2be3e7d4a95ec2f064f7e2ae63f7b028", size = 10758394, upload-time = "2026-05-11T18:54:11.956Z" },
+    { url = "https://files.pythonhosted.org/packages/95/6e/00c61ea8e85b4f6d8d35e11852a1a4998fc7fafc91c6a602d1cc9c972d64/pandas-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bd3a518890b400d32f9023722dc9a9a5c969f00b415419a3c06c043f09bb5d7d", size = 11375717, upload-time = "2026-05-11T18:54:14.539Z" },
+    { url = "https://files.pythonhosted.org/packages/31/89/8fc1c268969fac43688d65fd92e67df24bd128d53cb4d2eee534cd307399/pandas-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9c39be2d709d01fa972a0cabc522389fceca4f3969332ba25a7d6c5802cf976a", size = 11828897, upload-time = "2026-05-11T18:54:17.146Z" },
+    { url = "https://files.pythonhosted.org/packages/56/3b/e7d20dea247a3e6dc0bd8a6953854afbedc03951def4e7371e05e7263e25/pandas-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4db8c527972a821cf5286b40ccc57642a39bc62e62022b42f99f8a67fca8c3a1", size = 10900855, upload-time = "2026-05-11T18:54:19.72Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/54/68a0978d1ef8502b8492099beaa6e7a0c1b32e3b5d4f677f5810cb08711c/pandas-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:b2c95f8bfc1ee412bf482605d7bfd30c12d1d26bd59fdd91efeef1d4718decb1", size = 9466464, upload-time = "2026-05-11T18:54:22.754Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "polars"
+version = "1.42.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "polars-runtime-32" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/99/fe77f10a13a778705ef05b499fc708c9a0b0a3680d9eb6bc6e1b6a6b9914/polars-1.42.1.tar.gz", hash = "sha256:2fe94f3059334650bd850ae19a9c165dcd5d9cb12cd95ea04de2201662e70e8a", size = 741532, upload-time = "2026-06-30T04:57:51.504Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/6a/edd939cc6fa04b6415aaa9bf19720fc74ead81234b3d38542e0005816d4d/polars-1.42.1-py3-none-any.whl", hash = "sha256:3c0c65cdfa21a621650c4bdcbbccf93964d052fd766c3e70e84a55d961c259fd", size = 837622, upload-time = "2026-06-30T04:56:34.686Z" },
+]
+
+[[package]]
+name = "polars-runtime-32"
+version = "1.42.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/59/15bcc4dac380c6d63efa5446d8317f22671cbd6c9dadd576bd17a334c45a/polars_runtime_32-1.42.1.tar.gz", hash = "sha256:4d4809e1c1b9a6611f6944f27b24abea902b5159e6b6fa262fd716e947af5afd", size = 3045460, upload-time = "2026-06-30T04:57:52.866Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/29/16ff6e4e91d71e530d3581f45e342a9cc35072ac6b31dcbc2fa33de2569e/polars_runtime_32-1.42.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:bbdc26d68ee5b23b0ce227fa0599220aa35b77c826b6b0a6b2d8e7f6c1c36974", size = 53117325, upload-time = "2026-06-30T04:56:37.972Z" },
+    { url = "https://files.pythonhosted.org/packages/04/8e/4f8296fcfd1347f1351342fecf13bf2430d7efbae2f1f45964ec7930a99e/polars_runtime_32-1.42.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:f6c0288be940b607dc4a7476c01e67fb6bbee93f5f1dd42c64970274c71008ba", size = 47446251, upload-time = "2026-06-30T04:56:41.459Z" },
+    { url = "https://files.pythonhosted.org/packages/88/2e/0d66a7deadc453b890c3391034ca8ab4b05d0beaebbb92a7d65199fba61b/polars_runtime_32-1.42.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:635d9dbcae2302ae223afb395d5cd220bffa61a53d0ab6871d17c8bc830101cf", size = 51359402, upload-time = "2026-06-30T04:56:44.595Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/10/ffb85fa380bc9c9000dc35f40f44954dde49023018501c54faab94b3a39e/polars_runtime_32-1.42.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d059e8e53cc114ff82f9bd791fd341dc53534a2c745e6f6aa37594c3a93f01fe", size = 57302723, upload-time = "2026-06-30T04:56:47.609Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/63/ca50adc62e44224ca5c622a842ba6f35ee87d1d40ef0df7ea2ed6c6edb08/polars_runtime_32-1.42.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:f91f0b13588324905682809d270e1de5f1990c908721c8527657d77a044c9919", size = 51515673, upload-time = "2026-06-30T04:56:50.88Z" },
+    { url = "https://files.pythonhosted.org/packages/63/c3/08fbbf38deaa17bf34a601d327cb7451074098673c78b7c1a8538dde9794/polars_runtime_32-1.42.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8b8bf972d99d48aaaa2582e2bce966a6f43bc815bd8725d15f5cab9e2fb15d17", size = 55217259, upload-time = "2026-06-30T04:56:53.834Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/0e/51db89361668fe077a835fc579277f824ba526e7daf7b94d23d25439e0d0/polars_runtime_32-1.42.1-cp310-abi3-win_amd64.whl", hash = "sha256:e9364c26da389a8b7339e4d29e20a3d12af730247e6ed3b7804bddce2477f428", size = 52715432, upload-time = "2026-06-30T04:56:57.109Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c5/2fb8592d691bd114de25d9c84300b23541dca7060eac11d7b4bed0327786/polars_runtime_32-1.42.1-cp310-abi3-win_arm64.whl", hash = "sha256:7051226e6b42ffc395a7a9190377cd28649fbfb991b8f85c6271f4e1cfb736fb", size = 46718300, upload-time = "2026-06-30T04:56:59.855Z" },
+]
+
+[[package]]
+name = "pyarrow"
+version = "24.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/13/13e1069b351bdc3881266e11147ffccf687505dbb0ea74036237f5d454a5/pyarrow-24.0.0.tar.gz", hash = "sha256:85fe721a14dd823aca09127acbb06c3ca723efbd436c004f16bca601b04dcc83", size = 1180261, upload-time = "2026-04-21T10:51:25.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/d3/a1abf004482026ddc17f4503db227787fa3cfe41ec5091ff20e4fea55e57/pyarrow-24.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:02b001b3ed4723caa44f6cd1af2d5c86aa2cf9971dacc2ffa55b21237713dfba", size = 34976759, upload-time = "2026-04-21T10:48:07.258Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/4a/34f0a36d28a2dd32225301b79daad44e243dc1a2bb77d43b60749be255c4/pyarrow-24.0.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:04920d6a71aabd08a0417709efce97d45ea8e6fb733d9ca9ecffb13c67839f68", size = 36658471, upload-time = "2026-04-21T10:48:13.347Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/78/543b94712ae8bb1a6023bcc1acf1a740fbff8286747c289cd9468fced2a5/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a964266397740257f16f7bb2e4f08a0c81454004beab8ff59dd531b73610e9f2", size = 45675981, upload-time = "2026-04-21T10:48:20.201Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9f/8fb7c222b100d314137fa40ec050de56cd8c6d957d1cfff685ce72f15b17/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6f066b179d68c413374294bc1735f68475457c933258df594443bb9d88ddc2a0", size = 48859172, upload-time = "2026-04-21T10:48:27.541Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/d3/1ea72538e6c8b3b475ed78d1049a2c518e655761ea50fe1171fc855fcab7/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1183baeb14c5f587b1ec52831e665718ce632caab84b7cd6b85fd44f96114495", size = 49385733, upload-time = "2026-04-21T10:48:34.7Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/be/c3d8b06a1ba35f2260f8e1f771abbee7d5e345c0937aab90675706b1690a/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:806f24b4085453c197a5078218d1ee08783ebbba271badd153d1ae22a3ee804f", size = 51934335, upload-time = "2026-04-21T10:48:42.099Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/62/89e07a1e7329d2cde3e3c6994ba0839a24977a2beda8be6005ea3d860b99/pyarrow-24.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:e4505fc6583f7b05ab854934896bcac8253b04ac1171a77dfb73efef92076d91", size = 27271748, upload-time = "2026-04-21T10:49:42.532Z" },
+    { url = "https://files.pythonhosted.org/packages/17/1a/cff3a59f80b5b1658549d46611b67163f65e0664431c076ad728bf9d5af4/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:1a4e45017efbf115032e4475ee876d525e0e36c742214fbe405332480ecd6275", size = 35238554, upload-time = "2026-04-21T10:48:48.526Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/99/cce0f42a327bfef2c420fb6078a3eb834826e5d6697bf3009fe11d2ad051/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:7986f1fa71cee060ad00758bcc79d3a93bab8559bf978fab9e53472a2e25a17b", size = 36782301, upload-time = "2026-04-21T10:48:55.181Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/66/8e560d5ff6793ca29aca213c53eec0dd482dd46cb93b2819e5aab52e4252/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:d3e0b61e8efb24ed38898e5cdc5fffa9124be480008d401a1f8071500494ae42", size = 45721929, upload-time = "2026-04-21T10:49:03.676Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0c/a26e25505d030716e078d9f16eb74973cbf0b33b672884e9f9da1c83b871/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:55a3bc1e3df3b5567b7d27ef551b2283f0c68a5e86f1cd56abc569da4f31335b", size = 48825365, upload-time = "2026-04-21T10:49:11.714Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/eb/771f9ecb0c65e73fe9dccdd1717901b9594f08c4515d000c7c62df573811/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:641f795b361874ac9da5294f8f443dfdbee355cf2bd9e3b8d97aaac2306b9b37", size = 49451819, upload-time = "2026-04-21T10:49:21.474Z" },
+    { url = "https://files.pythonhosted.org/packages/48/da/61ae89a88732f5a785646f3ec6125dbb640fa98a540eb2b9889caa561403/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8adc8e6ce5fccf5dc707046ae4914fd537def529709cc0d285d37a7f9cd442ca", size = 51909252, upload-time = "2026-04-21T10:49:31.164Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1a/8dd5cafab7b66573fa91c03d06d213356ad4edd71813aa75e08ce2b3a844/pyarrow-24.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:9b18371ad2f44044b81a8d23bc2d8a9b6a6226dca775e8e16cfee640473d6c5d", size = 27388127, upload-time = "2026-04-21T10:49:37.334Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/80/d022a34ff05d2cbedd8ccf841fc1f532ecfa9eb5ed1711b56d0e0ea71fc9/pyarrow-24.0.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:1cc9057f0319e26333b357e17f3c2c022f1a83739b48a88b25bfd5fa2dc18838", size = 35007997, upload-time = "2026-04-21T10:49:48.796Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/ff/f01485fda6f4e5d441afb8dd5e7681e4db18826c1e271852f5d3957d6a80/pyarrow-24.0.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:e6f1278ee4785b6db21229374a1c9e54ec7c549de5d1efc9630b6207de7e170b", size = 36678720, upload-time = "2026-04-21T10:49:55.858Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c2/2d2d5fea814237923f71b36495211f20b43a1576f9a4d6da7e751a64ec6f/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:adbbedc55506cbdabb830890444fb856bfb0060c46c6f8026c6c2f2cf86ae795", size = 45741852, upload-time = "2026-04-21T10:50:04.624Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3a/28ba9c1c1ebdbb5f1b94dfebb46f207e52e6a554b7fe4132540fde29a3a0/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:ae8a1145af31d903fa9bb166824d7abe9b4681a000b0159c9fb99c11bc11ad26", size = 48889852, upload-time = "2026-04-21T10:50:12.293Z" },
+    { url = "https://files.pythonhosted.org/packages/df/51/4a389acfd31dca009f8fb82d7f510bb4130f2b3a8e18cf00194d0687d8ac/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d7027eba1df3b2069e2e8d80f644fa0918b68c46432af3d088ddd390d063ecde", size = 49445207, upload-time = "2026-04-21T10:50:20.677Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4b/0bab2b23d2ae901b1b9a03c0efd4b2d070256f8ce3fc43f6e58c167b2081/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e56a1ffe9bf7b727432b89104cc0849c21582949dd7bdcb34f17b2001a351a76", size = 51954117, upload-time = "2026-04-21T10:50:29.14Z" },
+    { url = "https://files.pythonhosted.org/packages/29/88/f4e9145da0417b3d2c12035a8492b35ff4a3dbc653e614fcfb51d9dedb38/pyarrow-24.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:38be1808cdd068605b787e6ca9119b27eb275a0234e50212c3492331680c3b1e", size = 28001155, upload-time = "2026-04-21T10:51:22.337Z" },
+    { url = "https://files.pythonhosted.org/packages/79/4f/46a49a63f43526da895b1a45bbb51d5baf8e4d77159f8528fc3e5490007f/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:418e48ce50a45a6a6c73c454677203a9c75c966cb1e92ca3370959185f197a05", size = 35250387, upload-time = "2026-04-21T10:50:35.552Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/da/d5e0cd5ef00796922404806d5f00325cdadc3441ce2c13fe7115f2df9a64/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:2f16197705a230a78270cdd4ea8a1d57e86b2fdcbc34a1f6aebc72e65c986f9a", size = 36797102, upload-time = "2026-04-21T10:50:42.417Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c7/5904145b0a593a05236c882933d439b5720f0a145381179063722fbfc123/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:fb24ac194bfc5e86839d7dcd52092ee31e5fe6733fe11f5e3b06ef0812b20072", size = 45745118, upload-time = "2026-04-21T10:50:49.324Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d3/cca42fe166d1c6e4d5b80e530b7949104d10e17508a90ae202dac205ce2a/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:9700ebd9a51f5895ce75ff4ac4b3c47a7d4b42bc618be8e713e5d56bacf5f931", size = 48844765, upload-time = "2026-04-21T10:50:55.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/49/942c3b79878ba928324d1e17c274ed84581db8c0a749b24bcf4cbdf15bd3/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d8ddd2768da81d3ee08cfea9b597f4abb4e8e1dc8ae7e204b608d23a0d3ab699", size = 49471890, upload-time = "2026-04-21T10:51:02.439Z" },
+    { url = "https://files.pythonhosted.org/packages/76/97/ff71431000a75d84135a1ace5ca4ba11726a231a8007bbb320a4c54075d5/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:61a3d7eaa97a14768b542f3d284dc6400dd2470d9f080708b13cd46b6ae18136", size = 51932250, upload-time = "2026-04-21T10:51:10.576Z" },
+    { url = "https://files.pythonhosted.org/packages/51/be/6f79d55816d5c22557cf27533543d5d70dfe692adfbee4b99f2760674f38/pyarrow-24.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:c91d00057f23b8d353039520dc3a6c09d8608164c692e9f59a175a42b2ae0c19", size = 28131282, upload-time = "2026-04-21T10:51:16.815Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Implements the interim decision from #100: BDF (Battery Data Format) read/export tooling lives in this repo as an experimental, self-contained package under `scripts/bdf/` — not part of the `cellpycore` public API.

- `.issueflows/04-designs-and-guides/bdf-io-placement.md` — decision record (context, alternatives, revisit criteria); linked from `ROADMAP.md`; stale `SCRATCHPAD.md` entry marked resolved.
- `scripts/bdf/` — standalone `cellpy_bdf` uv project (own nested `pyproject.toml` with a path source on the in-repo `cellpycore`):
  - `mapping.py` — declarative harmonized-raw (`RawCols`) -> BDF notation mapping (cycle-reset capacities map to BDF `cycle_*_ah`/`cycle_*_wh`; cycles never renumbered, `step_type` preserved as reported).
  - `export.py` / `read.py` — `export_bdf` / `read_bdf` (parquet or csv by suffix), epoch ns <-> `unix_time_second` conversion, optional by-value `conversion_factors`, fail-fast on missing BDF-required columns.
  - `tests/test_roundtrip.py` — 7 round-trip/edge tests, run via `uv run --directory scripts/bdf pytest`.
- Issue-flow docs (`issue100_original.md`, `issue100_plan.md`, `issue100_status.md`).

## Nested-pyproject verification (the open point from the issue comment)

The nested `pyproject.toml` does **not** interfere with root tooling: root `uv run pytest` (150 passed), `uv lock --check` clean, root `uv.lock` untouched, `uv run ruff check` + `uv run ruff format --check` green. The PEP 723 fallback was therefore not needed.

## Acceptance criteria

- [x] Decision recorded in `.issueflows/04-designs-and-guides/` (and ROADMAP)
- [x] Interim script lives under `scripts/`, not imported by the `cellpycore` package

## Testing

- `uv run --directory scripts/bdf pytest` — 7 passed (round-trip parquet+csv, conversion factors, required-column fail-fast, `Data.from_raw_frame` readback).
- Root: `uv run pytest` (150 passed), `uv run ruff check`, `uv run ruff format --check`, `uv lock --check` — all green.
- Manual end-to-end demo: mock harmonized frame -> `export_bdf` parquet with BDF notations -> `read_bdf` back to harmonized names, 1000 rows, epoch timestamp round-trips exactly.

Closes #100.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4c0279e-9618-49e1-b693-fd257f3a64e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4c0279e-9618-49e1-b693-fd257f3a64e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

