### PR TITLE
fix: move return out of finally in legacy mock_core set_col_first

### DIFF
--- a/.issueflows/03-solved-issues/issue95_original.md
+++ b/.issueflows/03-solved-issues/issue95_original.md
@@ -1,0 +1,29 @@
+# Issue #95: Fix SyntaxWarning: 'return' in finally block in legacy/mock_core.py
+
+Source: https://github.com/cellpy/cellpy-core/issues/95
+
+## Original issue text
+
+## Context
+
+When importing `cellpycore` in JupyterLab with Python 3.14, a `SyntaxWarning` is emitted:
+
+```
+src/cellpycore/legacy/mock_core.py:66: SyntaxWarning: 'return' in a 'finally' block
+  return df
+```
+
+Source: `SCRATCHPAD.md` (Syntax warning section).
+
+## Problem
+
+`return` inside a `finally` block is deprecated/problematic in Python 3.14+ and triggers a syntax warning at import time.
+
+## Suggested fix
+
+Refactor `set_col_first` (or the surrounding try/finally in `legacy/mock_core.py`) so the return happens outside the `finally` block, preserving behaviour.
+
+## Acceptance criteria
+
+- [ ] No `SyntaxWarning` when importing `cellpycore` on Python 3.14
+- [ ] Existing tests for legacy/mock helpers still pass

--- a/.issueflows/03-solved-issues/issue95_plan.md
+++ b/.issueflows/03-solved-issues/issue95_plan.md
@@ -1,0 +1,19 @@
+# Issue #95 — Plan
+
+## Goal
+
+Eliminate `SyntaxWarning: 'return' in a 'finally' block` from `legacy/mock_core.py` on Python 3.14+ import.
+
+## Approach
+
+Move `return df` out of the `finally` block in `set_col_first`. Keep `df.reindex(columns=column_headings)` in `finally` so column reorder still runs even if the loop raises.
+
+## Files to touch
+
+- `src/cellpycore/legacy/mock_core.py` — refactor `set_col_first`
+- `tests/test_import.py` — optional import-with-warnings check (if trivial)
+
+## Test strategy
+
+- `uv run pytest` (full suite)
+- `uv run python -W error::SyntaxWarning -c "import cellpycore"` to assert no warning

--- a/.issueflows/03-solved-issues/issue95_status.md
+++ b/.issueflows/03-solved-issues/issue95_status.md
@@ -1,0 +1,14 @@
+# Issue #95 — Status
+
+## Done
+
+- [x] Moved `return df` outside `finally` in `set_col_first` (`legacy/mock_core.py`)
+- [x] Added subprocess import test with `-W error::SyntaxWarning`
+- [x] Full test suite passes
+
+## Acceptance criteria
+
+- [x] No `SyntaxWarning` when importing `cellpycore` on Python 3.14
+- [x] Existing tests for legacy/mock helpers still pass
+
+- [x] Done

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Fix `SyntaxWarning` from `return` in `finally` block in `legacy/mock_core.py` on Python 3.14+ import. (#95)
+
 ## [0.1.4] - 2026-07-04
 
 - Migrate documentation to Zensical with Read the Docs hosting

--- a/src/cellpycore/legacy/mock_core.py
+++ b/src/cellpycore/legacy/mock_core.py
@@ -60,7 +60,6 @@ def set_col_first(df, col_names):
         for col_name in col_names:
             column_headings.pop(column_headings.index(col_name))
             column_headings.insert(0, col_name)
-
     finally:
         df = df.reindex(columns=column_headings)
-        return df
+    return df

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -54,6 +54,19 @@ def test_cellpycore_version():
         pytest.fail(f"Failed to import cellpycore for version test: {e}")
 
 
+def test_cellpycore_import_no_syntax_warning():
+    """Import must not emit SyntaxWarning (e.g. return in finally on Py 3.14+)."""
+    import subprocess
+
+    result = subprocess.run(
+        [sys.executable, "-W", "error::SyntaxWarning", "-c", "import cellpycore"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
 def test_cellpycore_in_sys_modules():
     """Test that cellpycore is properly registered in sys.modules."""
     assert "cellpycore" in sys.modules


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes `SyntaxWarning: 'return' in a 'finally' block` emitted when importing `cellpycore` on Python 3.14+.

`set_col_first` in `legacy/mock_core.py` now keeps `df.reindex(columns=column_headings)` in the `finally` block (preserving behaviour on exceptions) but moves `return df` outside it.

## Test plan

- [x] `uv run pytest` (151 passed)
- [x] `uv run python -W error::SyntaxWarning -c "import cellpycore"` (no warning)
- [x] New `test_cellpycore_import_no_syntax_warning` subprocess check

Closes #95
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7bc9c6d5-68a1-4a86-8c24-bb3c3ace261c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7bc9c6d5-68a1-4a86-8c24-bb3c3ace261c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

