### PR TITLE
Add explicit column ordering to RawCols/CycleCols/StepCols

### DIFF
--- a/.issueflows/03-solved-issues/issue96_original.md
+++ b/.issueflows/03-solved-issues/issue96_original.md
@@ -1,0 +1,47 @@
+# Issue #96: Add explicit column ordering to RawCols/CycleCols/StepCols
+
+Source: https://github.com/cellpy/cellpy-core/issues/96
+
+## Original issue text
+
+## Context
+
+Enumerating native column names via `vars(RawCols)` works but is easy to misuse (e.g. `dataclasses.fields(RawCols)` only returns inherited `__version__` from `BaseCols`).
+
+Source: `SCRATCHPAD.md` (Ordered headers section).
+
+## Proposal
+
+Add explicit ordering to header classes, e.g.:
+
+```python
+class RawCols(Cols):
+    __column_order__ = (
+        "datapoint_num", "source_datapoint_num", "mask", ...
+    )
+
+    @classmethod
+    def ordered_names(cls) -> list[str]:
+        cols = cls()
+        return [getattr(cols, name) for name in cls.__column_order__]
+```
+
+Apply the same pattern to `CycleCols` and `StepCols` where column order matters (fixtures, converters, parquet I/O).
+
+## Acceptance criteria
+
+- [ ] `RawCols.ordered_names()` (or equivalent) returns names in harmonized-raw spec order
+- [ ] `dev/make_harmonized_raw.py` and tests can use the helper instead of `vars(RawCols)`
+- [ ] Document that `fields(RawCols)` is not the right tool for column enumeration
+
+## Comments (curated summary)
+
+- **Additional tasks**:
+  - Implement column ordering helper on the `Cols` base class so `RawCols`, `CycleCols`, and `StepCols` inherit it rather than duplicating logic per class.
+- **Clarifications / constraints**:
+  - Do not introduce a separate `__column_order__` tuple — re-listing column names creates two sources of truth.
+  - Derive order from dataclass field declaration order; filter out fields whose names start with `_`.
+- **Superseded / retracted**:
+  - Per-class `__column_order__` tuple plus a classmethod that maps attribute names through that tuple (the pattern shown in the issue body).
+
+_Note: this section is an interpretive summary of the comment thread, not a verbatim dump. Source comments: 1, last comment by @jepegit on 2026-07-05._

--- a/.issueflows/03-solved-issues/issue96_plan.md
+++ b/.issueflows/03-solved-issues/issue96_plan.md
@@ -1,0 +1,84 @@
+# Issue #96 — Plan
+
+## Goal
+
+Add `Cols.ordered_names()` — a single, canonical way to enumerate native column
+name strings in declaration order — and migrate callers off fragile `vars(RawCols)`
+/ misuse of `dataclasses.fields()`.
+
+## Constraints
+
+- No separate `__column_order__` tuple (maintainer comment; two sources of truth).
+- Implement on `Cols` base class; `RawCols`, `StepCols`, `CycleCols` inherit.
+- Scope: helper + migrate known callers + tests/docs in docstring. No engine /
+  legacy header changes.
+
+### Prior art
+
+- `tests/test_config_columns._declared_columns()` — iterates `cls.__annotations__`
+  (same ordering source; to be replaced by `ordered_names()` in tests).
+- `dev/make_harmonized_raw.py` — `vars(RawCols)` + `_` filter for parquet column
+  order (migrate to `ordered_names()`).
+- `tests/test_harmonized_fixture._rawcols_names()` — same `vars()` pattern (migrate).
+- `tests/test_header_mapping._native_values()` — set from `__annotations__`; order
+  not needed; **leave as-is**.
+- `column-headers-review.md` — three-layer header story; no update needed for this
+  small API helper.
+
+## Approach
+
+Add a `@classmethod` on `Cols`:
+
+```python
+@classmethod
+def ordered_names(cls) -> list[str]:
+    cols = cls()
+    return [
+        getattr(cols, name)
+        for name in cls.__annotations__
+        if not name.startswith("_")
+    ]
+```
+
+Design choices (grill-me resolved):
+
+| Decision | Choice |
+|----------|--------|
+| Ordering source | `cls.__annotations__` declaration order |
+| Return value | Column name strings (attribute values) |
+| Resolution | `getattr(cls(), name)` — instance lookup for `FlexibleCols` compat |
+| `_` prefix | Excluded |
+| `__version__` | Not in subclass `__annotations__`; excluded automatically |
+| Docs | `ordered_names()` docstring `Note:` — prefer over `vars()` / `dataclasses.fields()` |
+| Tests | Drop `_declared_columns`; assert `ordered_names() == *_EXPECTED`; add `_` filter unit test |
+| Fixture test | `list(df.columns) == RawCols.ordered_names()` (order + schema) |
+
+Verified: for `RawCols` today, `vars(RawCols)` and `__annotations__` yield the
+same 29 names in the same order — parquet regen not expected, but run
+`dev/make_harmonized_raw.py` if the order assertion fails.
+
+## Files to touch
+
+| File | Change |
+|------|--------|
+| [`src/cellpycore/config.py`](src/cellpycore/config.py) | Add `Cols.ordered_names()` classmethod + Google docstring |
+| [`tests/test_config_columns.py`](tests/test_config_columns.py) | Remove `_declared_columns`; use `ordered_names()`; add `_` prefix filter test |
+| [`dev/make_harmonized_raw.py`](dev/make_harmonized_raw.py) | Replace `vars(RawCols)` loop with `RawCols.ordered_names()` |
+| [`tests/test_harmonized_fixture.py`](tests/test_harmonized_fixture.py) | Replace `_rawcols_names()`; assert ordered column list |
+
+## Test strategy
+
+```bash
+uv run pytest tests/test_config_columns.py tests/test_harmonized_fixture.py
+uv run pytest
+```
+
+New / updated coverage:
+
+- `test_raw_cols_match_spec` / step / cycle — `assert cls.ordered_names() == *_EXPECTED`
+- `test_ordered_names_skips_underscore_prefixed` — minimal `Cols` subclass smoke test
+- `test_harmonized_columns_match_rawcols` — ordered list equality
+
+## Open questions
+
+None — all branches resolved in grill-me.

--- a/.issueflows/03-solved-issues/issue96_status.md
+++ b/.issueflows/03-solved-issues/issue96_status.md
@@ -1,0 +1,15 @@
+# Issue #96 — Status
+
+- [x] Done
+
+## What's done
+
+- Added `Cols.ordered_names()` on `Cols` base (`config.py`) with Google docstring
+- Migrated `dev/make_harmonized_raw.py` off `vars(RawCols)`
+- Updated `tests/test_config_columns.py` — uses `ordered_names()`, added `_` prefix test
+- Updated `tests/test_harmonized_fixture.py` — ordered column list assertion
+- All 152 tests pass; ruff clean
+
+## Remaining work
+
+- None

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 - Fix `SyntaxWarning` from `return` in `finally` block in `legacy/mock_core.py` on Python 3.14+ import. (#95)
+- Add `Cols.ordered_names()` for declaration-order column enumeration on `RawCols`, `StepCols`, and `CycleCols`. (#96)
 
 ## [0.1.4] - 2026-07-04
 

--- a/dev/make_harmonized_raw.py
+++ b/dev/make_harmonized_raw.py
@@ -111,9 +111,7 @@ def build_harmonized(raw: pl.DataFrame, cols: RawCols) -> pl.DataFrame:
 
     # Emit every remaining RawCols column as null so the fixture is a complete
     # harmonized-schema example, ordered to match the spec table.
-    ordered = [
-        getattr(cols, name) for name in vars(RawCols) if not name.startswith("_")
-    ]
+    ordered = RawCols.ordered_names()
     missing = [name for name in ordered if name not in out.columns]
     out = out.with_columns([pl.lit(None).alias(name) for name in missing])
     return out.select(ordered)

--- a/src/cellpycore/config.py
+++ b/src/cellpycore/config.py
@@ -281,7 +281,29 @@ class Cols(BaseCols):
     ``FlexibleCols`` (which incurs some performance loss).
     """
 
-    pass
+    @classmethod
+    def ordered_names(cls) -> list[str]:
+        """Return native column name strings in class declaration order.
+
+        Iterates ``cls.__annotations__`` (declaration order) and resolves each
+        attribute on a fresh instance so ``FlexibleCols`` subclasses can
+        transform names via ``__getattribute__``. Attributes whose names start
+        with ``_`` are omitted.
+
+        Returns:
+            list[str]: Column name strings in spec/declaration order.
+
+        Note:
+            Prefer this over ``vars(RawCols)`` (picks up non-column class
+            entries) or ``dataclasses.fields(RawCols)`` (only sees inherited
+            ``BaseCols`` fields such as ``__version__``, not subclass columns).
+        """
+        cols = cls()
+        return [
+            getattr(cols, name)
+            for name in cls.__annotations__
+            if not name.startswith("_")
+        ]
 
 
 @dataclass(frozen=True)

--- a/tests/test_config_columns.py
+++ b/tests/test_config_columns.py
@@ -6,12 +6,7 @@ representations cannot silently drift again. The expected column sets below are
 transcribed from those specs.
 """
 
-from cellpycore.config import CycleCols, RawCols, StepCols
-
-
-def _declared_columns(cols_cls) -> dict:
-    """Map declared column attribute -> its string value for a Cols subclass."""
-    return {name: getattr(cols_cls, name) for name in cols_cls.__annotations__}
+from cellpycore.config import Cols, CycleCols, RawCols, StepCols
 
 
 def _aggregates(signal: str) -> list:
@@ -177,22 +172,29 @@ CYCLE_EXPECTED = [
 
 
 def test_raw_cols_match_spec():
-    declared = _declared_columns(RawCols)
-    assert list(declared) == RAW_EXPECTED
-    # each column attribute value equals its name
-    assert all(declared[name] == name for name in declared)
+    names = RawCols.ordered_names()
+    assert names == RAW_EXPECTED
+    assert names == list(RawCols.__annotations__)
 
 
 def test_step_cols_match_spec():
-    declared = _declared_columns(StepCols)
-    assert list(declared) == STEP_EXPECTED
-    assert all(declared[name] == name for name in declared)
+    names = StepCols.ordered_names()
+    assert names == STEP_EXPECTED
+    assert names == list(StepCols.__annotations__)
 
 
 def test_cycle_cols_match_spec():
-    declared = _declared_columns(CycleCols)
-    assert list(declared) == CYCLE_EXPECTED
-    assert all(declared[name] == name for name in declared)
+    names = CycleCols.ordered_names()
+    assert names == CYCLE_EXPECTED
+    assert names == list(CycleCols.__annotations__)
+
+
+def test_ordered_names_skips_underscore_prefixed():
+    class _SampleCols(Cols):
+        visible: str = "visible"
+        _private: str = "skip"
+
+    assert _SampleCols.ordered_names() == ["visible"]
 
 
 def test_no_legacy_raw_names():

--- a/tests/test_harmonized_fixture.py
+++ b/tests/test_harmonized_fixture.py
@@ -21,14 +21,9 @@ HARMONIZED_RAW = DATA_DIR / "cycler_cc_harmonized_raw.parquet"
 EXPECTED_ROWS = 10261
 
 
-def _rawcols_names() -> set[str]:
-    cols = RawCols()
-    return {getattr(cols, name) for name in vars(RawCols) if not name.startswith("_")}
-
-
 def test_harmonized_columns_match_rawcols():
     df = pl.read_parquet(HARMONIZED_RAW)
-    assert set(df.columns) == _rawcols_names()
+    assert list(df.columns) == RawCols.ordered_names()
 
 
 def test_harmonized_row_count_and_key_values():


### PR DESCRIPTION
## Summary

- Add `Cols.ordered_names()` on the `Cols` base class — returns native column name strings in `__annotations__` declaration order, excluding `_`-prefixed attributes.
- Migrate `dev/make_harmonized_raw.py` and tests off fragile `vars(RawCols)` enumeration.
- Strengthen harmonized fixture test to assert column order, not just set equality.

## Test plan

- [x] `uv run pytest tests/test_config_columns.py tests/test_harmonized_fixture.py`
- [x] `uv run pytest` (152 passed)

Closes #96

Made with [Cursor](https://cursor.com)