### PR TITLE
docs: sync stale integration guide statuses (#114)

### DIFF
--- a/.issueflows/03-solved-issues/issue114_original.md
+++ b/.issueflows/03-solved-issues/issue114_original.md
@@ -1,0 +1,34 @@
+# Issue #114: Stage 0.12: Doc-sync pass over the guiding documents (stale statuses)
+
+Source: https://github.com/cellpy/cellpy-core/issues/114
+
+## Original issue text
+
+> Part of **Stage 0 â€” foundations for cellpy 2** (see the tracking issue). Plan documents live in the shared workspace: `cellpy-workspace/architecture-plan/` (the [architecture-plan repo](https://github.com/cellpy/architecture-plan); formerly `architecture-plan/`) (alongside the `cellpy` and `cellpy-core` repos).
+
+## Goal
+
+A one-hour pass over `.issueflows/04-designs-and-guides/` + the integration roadmap fixing
+the stale statements found during the cellpy-2 planning cross-read:
+
+- Integration roadmap STEP-12: says "schema lives in `legacy.py`" â€” `cellpycore/units/spec.py`
+  exists (issue #40 executed, plus #112); remaining scope is only the cellpy-side delegation.
+- Roadmap STEP-13+ table: #54 (`exclude_step_types`) marked "future" but implemented
+  (`summarizers.py:655/715`, threaded through `make_core_summary`).
+- `column-headers-review.md` Â§Issue-#34 points at `src/cellpycore/header_mapping.py`;
+  the module lives at `src/cellpycore/legacy/mapping.py`.
+- `cellpy-core-integration-into-cellpy.md` "Key findings" still says `make_step_table` is
+  NOT ported (superseded by STEP-08 âœ… in the same folder).
+
+## Why
+
+Stale "partly done" statuses cost every future planner a code-level re-derivation â€” the
+cellpy-2 gap analysis (workspace: `architecture-plan/cellpy2-plans-gap-analysis.md`, item F7)
+had to verify each of these against the source. One hour now, saved repeatedly later.
+
+## Acceptance
+
+- The four listed corrections applied; a quick grep for other â¬œ/ðŸŸ¡ statuses done in the
+  same sitting and corrected or confirmed.
+
+

--- a/.issueflows/03-solved-issues/issue114_plan.md
+++ b/.issueflows/03-solved-issues/issue114_plan.md
@@ -1,0 +1,24 @@
+# Issue #114 — plan
+
+## Goal
+
+Sync stale statuses in `.issueflows/04-designs-and-guides/` so planners do not re-derive facts already true in code.
+
+## Approach
+
+1. **STEP-12 / #40** — `CellpyUnits` schema lives in `cellpycore.units.spec` (#40, #112 done on core); remaining scope is cellpy-side converter delegation only.
+2. **#54** — `exclude_step_types` implemented in `summarizers.py`; mark done in STEP-13+ table.
+3. **`column-headers-review.md`** — fix module path to `src/cellpycore/legacy/mapping.py`.
+4. **`cellpy-core-integration-into-cellpy.md`** — retire stale "make_step_table NOT ported" finding; align seam/follow-up bullets with STEP-08 ✅.
+5. **Grep sweep** — fix other `header_mapping.py` path refs in the same folder; leave intentional 🟡 (STEP-06 ongoing, STEP-12 partly) as-is.
+
+## Files to touch
+
+- `.issueflows/04-designs-and-guides/cellpy-core-integration-roadmap.md`
+- `.issueflows/04-designs-and-guides/column-headers-review.md`
+- `.issueflows/04-designs-and-guides/cellpy-core-integration-into-cellpy.md`
+- `.issueflows/04-designs-and-guides/code-review-2026-07.md` (path ref only, if present)
+
+## Test strategy
+
+Docs-only — re-run `uv run pytest` as sanity check; no new tests.

--- a/.issueflows/03-solved-issues/issue114_status.md
+++ b/.issueflows/03-solved-issues/issue114_status.md
@@ -1,0 +1,15 @@
+# Issue #114 — status
+
+## Done
+
+- [x] STEP-12 / #40: schema now `units/spec.py`; cellpy delegation noted as remaining
+- [x] #54 `exclude_step_types`: marked ✅ done in STEP-13+ table
+- [x] `column-headers-review.md`: path → `legacy/mapping.py`
+- [x] `cellpy-core-integration-into-cellpy.md`: retired stale `make_step_table NOT ported` finding
+- [x] Grep sweep: fixed `header_mapping.py` path refs in roadmap + `code-review-2026-07.md`
+
+## Tests
+
+- `uv run pytest` — 179 passed
+
+- [x] Done

--- a/.issueflows/04-designs-and-guides/cellpy-core-integration-into-cellpy.md
+++ b/.issueflows/04-designs-and-guides/cellpy-core-integration-into-cellpy.md
@@ -41,8 +41,9 @@ Companion GitHub issue lives on the **`cellpy`** repo (jepegit/cellpy) — see
      and values (verified field-by-field against `cellpy/parameters/internal_settings.py`).
    - `CellpyUnits` — **identical** (incl. `resistance="ohm"`; the `"Ohms"` in the
      docstring is a shared cosmetic artifact, not a value divergence).
-5. **`make_step_table` is NOT ported to core yet** (both `slim` and `cellpy-core` carry
-   `# TODO: implement make step table`). The step half still lives in `cellreader.py`.
+5. **`make_step_table` is ported and delegated (STEP-08 ✅).** `cellpycore.summarizers`
+   implements the step engine; `cellpy.make_step_table` is pure orchestration/delegation
+   across the seam. `CellpyLimits` is covered by the header/unit parity contract test.
 
 ## Decisions taken
 
@@ -66,10 +67,9 @@ package):
 1. Add `cellpycore` as a git/editable dependency.
 2. On `CellpyCell`: construct `self.core = OldCellpyCellCore(...)`.
 3. Move `Data` ownership: `data` property reads/writes `self.core._data`.
-4. Route `make_summary` (and master's newer `add_to_summary` / cycle-selection methods)
-   through `self.core`.
-5. Leave `make_step_table` in `cellreader.py` for now.
-6. Port `tests/test_slim.py` (from 334) as the seam's acceptance test; keep the full
+4. Route `make_summary` and `make_step_table` (plus master's newer `add_to_summary` /
+   cycle-selection methods) through `self.core`.
+5. Port `tests/test_slim.py` (from 334) as the seam's acceptance test; keep the full
    suite green.
 
 ## Regularly run the essential parity smoke tests (cellpy repo)
@@ -105,14 +105,12 @@ release/PR; `-m essential` is the fast inner-loop check.
 ## Follow-ups (after the first seam PR)
 
 - **Contract tests** asserting `cellpycore.legacy` headers/units equal
-  `cellpy.parameters.internal_settings` field-by-field, so the duplicated copies cannot
-  silently drift → jepegit/cellpy#378.
-- **Port `make_step_table`** into `cellpy-core` (the remaining half of the core),
-  **bringing `CellpyLimits` with it** (step-type detection thresholds, not yet copied
-  into core) → cellpy/cellpy-core#12.
-- Settle the column-header harmonization (`config.Cols` ↔ legacy `Headers*`) → existing
-  cellpy/cellpy-core#4 (SPEED-30, header enum structure); see also
-  `column-headers-review.md`.
+  `cellpy.parameters.internal_settings` field-by-field → ✅ done (STEP-05;
+  `cellpy/tests/test_core_settings_parity.py`).
+- **Port `make_step_table`** (+ `CellpyLimits`) into `cellpy-core` → ✅ done (STEP-08;
+  cellpy/cellpy-core#12).
+- Settle the column-header harmonization (`config.Cols` ↔ legacy `Headers*`) → ✅ done
+  (STEP-09; see `column-headers-review.md`).
 
 ## Recommended sequencing
 
@@ -120,8 +118,8 @@ release/PR; `-m essential` is the fast inner-loop check.
 2. Resolve the **Python floor** (small, independent).
 3. Land the **Data/processing seam** wired to `OldCellpyCellCore` + git dependency.
 4. Add **contract tests**.
-5. **Build-backend** swap (independent, whenever convenient).
-6. Port **`make_step_table`** (+ `CellpyLimits`) into core.
+5. **Build-backend** swap (independent, whenever convenient) — ✅ done (STEP-07).
+6. Port **`make_step_table`** (+ `CellpyLimits`) into core — ✅ done (STEP-08).
 
 ## Tracking
 

--- a/.issueflows/04-designs-and-guides/cellpy-core-integration-roadmap.md
+++ b/.issueflows/04-designs-and-guides/cellpy-core-integration-roadmap.md
@@ -43,10 +43,10 @@ Reconciled against the actual repo state on **2026-06-26**. Status legend: ✅ d
 | STEP-06 Golden fixtures | 🟡 ongoing | `cellpy-core/tests/test_golden.py` in place; extend as more is ported |
 | STEP-07 Build-backend swap | ✅ done | `cellpy` already hatchling+uv; no `setup.py` |
 | STEP-08 Port `make_step_table` | ✅ done | ported + routed; `CellpyLimits` now in the parity test (`cellpy/tests/test_core_settings_parity.py`); no dead step-table engine left in `cellpy` (`make_step_table` is pure delegation) |
-| STEP-09 Harmonize headers | ✅ done | `config.Cols` + spec tests; `header_mapping.py` gives lossless/total `config.Cols` ↔ legacy `Headers*` round-trip (`tests/test_header_mapping.py`) (#34/#35) |
+| STEP-09 Harmonize headers | ✅ done | `config.Cols` + spec tests; `legacy/mapping.py` gives lossless/total `config.Cols` ↔ legacy `Headers*` round-trip (`tests/test_header_mapping.py`) (#34/#35) |
 | STEP-10 Metadata scaffolding | ✅ done | `cellpycore.metadata` (`models.py`/`io.py`); `TestMeta`/`CellMeta`/`TestMetaCollection` + (de)serialize/merge; graceful-degradation guard (`tests/test_metadata.py`) (#37) |
 | STEP-11 Timestamp representation | ✅ done | `epoch_time_utc` + `first/last_epoch_time_utc` are int64-ns UTC; `cellpycore.timestamps` conversion helpers + fixture regenerated (`tests/test_timestamps.py`) (#32, PR #38) |
-| STEP-12 Unit-handling boundary | 🟡 partly done | `CellpyUnits` schema + `units.py` tooling behind the optional `units` extra; factors cross the seam by value; `cellpy` still keeps duplicate converters |
+| STEP-12 Unit-handling boundary | 🟡 partly done | `CellpyUnits` schema in `units/spec.py` (#40/#112) + `units.py` tooling behind the optional `units` extra; factors cross the seam by value; `cellpy` still keeps duplicate converters (delegation pending) |
 
 Per-step `Status:` lines below repeat this for context; this table is the quick reference.
 The forward work beyond these twelve steps (STEP-13+) is enumerated in
@@ -206,7 +206,7 @@ detection thresholds (`CellpyLimits`).
 ## STEP-09 Harmonize column headers
 
 **Status:** ✅ done — `config.Cols` (`RawCols` / `StepCols` / `CycleCols`) and their
-spec-conformance tests exist, and `header_mapping.py` now centralizes a lossless, total
+spec-conformance tests exist, and `legacy/mapping.py` now centralizes a lossless, total
 `config.Cols` ↔ legacy `Headers*` round-trip, covered by `tests/test_header_mapping.py`
 (#34/#35).
 
@@ -266,13 +266,12 @@ Adopt the internal int64-ns timestamp representation.
 
 ## STEP-12 Unit-handling boundary (scaffolding/tooling in core; population & policy upstream)
 
-**Status:** 🟡 partly done — the `CellpyUnits` schema (`cellpycore.legacy`) and the
-pint-based conversion tooling (`cellpycore.units`: `get_converter_to_specific`,
-`nominal_capacity_as_absolute`, `Q`, output-unit defaults) already exist behind the
-optional `units` extra, attached to the `OldCellpyCellCore` bridge, and conversion factors
-already cross the seam **by value**. Remaining: `cellpy` still keeps its own duplicate
-converter functions (not delegated to core), and the schema lives in `legacy.py` rather
-than a dedicated unit-spec module.
+**Status:** 🟡 partly done — the `CellpyUnits` schema lives in `cellpycore.units.spec`
+(#40, #112) and the pint-based conversion tooling (`cellpycore.units`:
+`get_converter_to_specific`, `nominal_capacity_as_absolute`, `Q`, output-unit defaults)
+already exist behind the optional `units` extra, attached to the `OldCellpyCellCore`
+bridge, and conversion factors already cross the seam **by value**. Remaining on the
+**cellpy** side only: duplicate converter functions not yet delegated to core.
 
 **Codebase:** `cellpy-core` (scaffolding/tooling — `legacy.py` + `units.py`); population
 (`raw_units` from loaders) and the decision to delegate are `cellpy`'s opt-in.
@@ -284,8 +283,7 @@ float conversion factors by value, never unit objects). The consumer owns *popul
 policy*: instrument loaders fill `data.raw_units`, and `cellpy` decides output-unit policy.
 The opt-in upstream move is for `cellpy` to delegate its duplicated
 `get_converter_to_specific` / `nominal_capacity_as_absolute` to `cellpycore.units` (as it
-already did for headers and the step engine), and optionally to promote `CellpyUnits` out
-of `legacy.py` into a first-class core unit-spec module.
+already did for headers and the step engine).
 
 **Tests (success criteria):**
 - `CellpyUnits` field parity is already guarded by the STEP-05 contract test (included in
@@ -309,13 +307,13 @@ jepegit/cellpy). Captured under issue #39.
 
 | Item | Issue | Status | Source / anchor |
 |------|-------|--------|-----------------|
-| Finalize STEP-12 (core): promote `CellpyUnits` out of `legacy.py` into a unit-spec module; add converter-parity + pint-optional guard tests | [#40](https://github.com/cellpy/cellpy-core/issues/40) | ⬜ actionable | STEP-12; `cellpy-core-migration.md` §4 |
+| Finalize STEP-12 (core): promote `CellpyUnits` out of `legacy.py` into a unit-spec module; add converter-parity + pint-optional guard tests | [#40](https://github.com/cellpy/cellpy-core/issues/40) | ✅ done | STEP-12; `cellpy-core-migration.md` §4; schema in `units/spec.py` |
 | Per-test metadata: add `test_id` to `StepCols`/`CycleCols` + composite group keys `(test_id, cycle_num, step_num, …)` | [#41](https://github.com/cellpy/cellpy-core/issues/41) | ⬜ actionable | `test-metadata-and-merging.md` |
 | Engine: reset-granularity normalization for step-/test-cumulative raw inputs | [#42](https://github.com/cellpy/cellpy-core/issues/42) | ⬜ future | `step-table-polars-migration.md` |
 | Native schema: add `ref_potential`/`ref_voltage` support | [#43](https://github.com/cellpy/cellpy-core/issues/43) | ⬜ future | `step-table-polars-migration.md` (Phase 1) |
 | Release: tag cellpy-core (and decide PyPI publish) so `cellpy` can pin a release ref | [#44](https://github.com/cellpy/cellpy-core/issues/44) | ⬜ future | `cellpy-core-migration.md` §2/§5 |
 | Cleanup: remove `create_selector`/`summary_selector_exluder` once `cellpy` migrates off them | [#45](https://github.com/cellpy/cellpy-core/issues/45) | ✅ done (2026-07-02: cellpy migrated on branch `core45-drop-create-selector`; both functions + dead `selector` param removed) | `selector-dead-code-deferral.md` |
-| Native exclude-types summary support (`exclude_step_types=` on `make_summary`; replaces the removed selector exclusion feature) | [#54](https://github.com/cellpy/cellpy-core/issues/54) | ⬜ future | `selector-dead-code-deferral.md` |
+| Native exclude-types summary support (`exclude_step_types=` on `make_summary`; replaces the removed selector exclusion feature) | [#54](https://github.com/cellpy/cellpy-core/issues/54) | ✅ done | `summarizers.py` (`make_core_summary`); `selector-dead-code-deferral.md` |
 
 Not tracked as a discrete issue: **STEP-06** (golden-fixture oracle) is a continuous
 activity — extended per-port against `cellpy`'s published goldens, not a closeable unit.

--- a/.issueflows/04-designs-and-guides/code-review-2026-07.md
+++ b/.issueflows/04-designs-and-guides/code-review-2026-07.md
@@ -16,7 +16,7 @@ Related issue: local issue 50 (docs-only; this report is the deliverable).
 
 The core is healthy. The polars engine (`summarizers.py`, `extractors.py`) is
 clean, schema-injected, and well-documented. The header mapping
-(`header_mapping.py`) is disciplined: totality-tested, with explicit exception
+(`legacy/mapping.py`) is disciplined: totality-tested, with explicit exception
 sets. The golden/parity test strategy is strong. The metadata scaffolding
 matches the boundary decision in `cellpy-core-migration.md` §4. The weak spots
 concentrate in the **edges**: legacy helpers, packaging, and the public API

--- a/.issueflows/04-designs-and-guides/column-headers-review.md
+++ b/.issueflows/04-designs-and-guides/column-headers-review.md
@@ -113,7 +113,7 @@ specifics `gravimetric`/`areal`/`absolute`; batbase-aligned `CellConfiguration`
 Settled the `config.Cols` <-> legacy `Headers*` story. Decisions:
 
 1. **One source of truth.** The native <-> legacy correspondence now lives in
-   `src/cellpycore/header_mapping.py` (per-family `RAW_PAIRS`, `STEP_BASE_PAIRS`
+   `src/cellpycore/legacy/mapping.py` (per-family `RAW_PAIRS`, `STEP_BASE_PAIRS`
    + `STEP_SCALAR_PAIRS` + `STAT_SUFFIXES`, `CYCLE_PAIRS`). The four rename dicts
    that used to be hand-maintained inside `OldCellpyCellCore` (`cell_core.py`)
    now derive from it; the bridge keeps no literal column maps. Behaviour is

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Sync stale statuses in integration design docs (STEP-12, #54, header mapping path,
+  make_step_table). (#114)
 - Unit conversion helpers accept pint quantity strings (e.g. ``"3.579 Ah/g"``),
   per-parameter unit overrides, and bulk ``cellpy_units=`` specs; document
   default input units in the standalone guide. (#112)


### PR DESCRIPTION
## Summary

- Fix four stale statements flagged in cellpy-2 gap analysis (F7): STEP-12 unit schema location, #54 `exclude_step_types`, header-mapping module path, and `make_step_table` port status.
- Grep sweep: corrected remaining `header_mapping.py` path references in the roadmap and code-review doc.
- Docs-only; no code changes.

## Test plan

- [x] `uv run pytest` — 179 passed

Closes #114


Made with [Cursor](https://cursor.com)