### PR TITLE
feat(units): convert_value, calculate_scaler, validate_units (Stage 1.13, #115)

### DIFF
--- a/.issueflows/03-solved-issues/issue115_original.md
+++ b/.issueflows/03-solved-issues/issue115_original.md
@@ -1,0 +1,29 @@
+# Issue #115 — Stage 1.13: units — convert_value, calculate_scaler, validate_units
+
+GitHub: https://github.com/cellpy/cellpy-core/issues/115
+Labels: cellpy2-stage1, yolo
+
+## Goal
+
+Three additive helpers in `cellpycore.units` (behind the existing `units` extra):
+
+- `convert_value(value, physical_property, from_units=None, to_units=None) -> float` —
+  port of cellpy's `to_cellpy_unit` generalized (accepts number / pint-quantity string /
+  `(value, unit)` tuple; defaults from raw→cellpy units).
+- `calculate_scaler(from_unit, to_unit) -> float` — port of `unit_scaler_from_raw`
+  (`Q(1, a).to(b).m`).
+- `validate_units(units) -> CellpyUnits` — every label pint-parsable, warn on unknown
+  keys; the loader-boundary validator (note the `"C"` Celsius-vs-Coulomb pitfall —
+  decide `degC` handling here).
+
+## Why
+
+cellpy Stage 1.6 (jepegit/cellpy#451) deletes its duplicated converter bodies and needs
+these to wrap; the loader port later calls `validate_units` on every configuration.
+Additions cross the repos core-first (release + re-pin) per the merge-order rule.
+
+## Acceptance
+
+- Unit tests incl. quantity-string and tuple inputs, bad-label failures, temperature
+  handling documented; pint-optional guard still green (helpers raise only when called).
+- Tagged release cut so cellpy can re-pin (release-procedure.md).

--- a/.issueflows/03-solved-issues/issue115_plan.md
+++ b/.issueflows/03-solved-issues/issue115_plan.md
@@ -1,0 +1,30 @@
+# Plan — issue #115 (Stage 1.13)
+
+All three helpers live in `src/cellpycore/units/converters.py` (behind the lazy
+pint import; nothing touches the compute hot path) and are exported from
+`cellpycore.units`.
+
+1. **Label-alias decision (the `"C"` pitfall).** pint parses bare `"C"` as
+   *coulomb* and rejects the spec's lowercase `"hz"` outright (verified against
+   the installed pint). Decision: a small per-property alias table
+   `_PINT_LABEL_ALIASES` maps `temperature: "C" → "degC"` and
+   `frequency: "hz" → "Hz"` for parsing/validation only — the spec keeps its
+   legacy labels, so nothing user-visible changes.
+2. **`convert_value`** — port of legacy `CellpyCell.to_cellpy_unit`,
+   generalized: number → `Q(v, from_units[prop])`; quantity string → parsed by
+   pint (unitless strings rejected, same rule as `_as_quantity`); `(value,
+   unit)` tuple → `Q(*value)`; unknown property → `KeyError`. Defaults:
+   `CellpyUnits()` on both sides (raw → cellpy direction).
+3. **`calculate_scaler(from_unit, to_unit)`** — `Q(1, a).to(b).m`; offset units
+   (degC) raise by pint design, documented (use `convert_value` for
+   temperatures). cellpy's `unit_scaler_from_raw(unit, prop)` becomes
+   `calculate_scaler(raw_units[prop], unit)`.
+4. **`validate_units(units, strict=True)`** — accepts `CellpyUnits` or plain
+   mapping; every label must be a string (floats → `TypeError` naming the v7
+   artifact) and pint-parsable through the alias table (else `ValueError`, or
+   warning when `strict=False` — the `local_instrument` escape hatch); unknown
+   keys are warned about, label-checked, and left out of the returned spec;
+   validated labels are layered over `CellpyUnits()` defaults.
+5. **Tests** — appended to `tests/test_units_converters.py` (17 new cases) and
+   the pint-optional guard extended so all three helpers raise the clear
+   `ModuleNotFoundError` naming the `units` extra.

--- a/.issueflows/03-solved-issues/issue115_status.md
+++ b/.issueflows/03-solved-issues/issue115_status.md
@@ -1,0 +1,14 @@
+# Status — issue #115 (Stage 1.13)
+
+- [x] Done
+
+## 2026-07-14
+
+- Implemented `convert_value`, `calculate_scaler`, `validate_units` in
+  `src/cellpycore/units/converters.py`; exported from `cellpycore.units`.
+- Recorded the label decision: `temperature="C"` means Celsius (validated as
+  `degC`, never coulomb); `frequency="hz"` accepted as hertz — handled by
+  `_PINT_LABEL_ALIASES`, spec labels preserved.
+- Tests: 17 new cases in `tests/test_units_converters.py`; pint-optional guard
+  extended in `tests/test_units_optional.py`. Full suite: 196 passed.
+- Follow-up (not this issue): cellpy #451 wraps these after release + re-pin.

--- a/src/cellpycore/units/__init__.py
+++ b/src/cellpycore/units/__init__.py
@@ -4,12 +4,15 @@ from cellpycore.units.converters import (
     Q,
     calculate_current_conversion_factor,
     calculate_nom_cap_abs_from_specific,
+    calculate_scaler,
     calculate_specific_conversion_factors,
     calculate_specific_converters,
+    convert_value,
     get_cellpy_units,
     get_converter_to_specific,
     get_default_output_units,
     nominal_capacity_as_absolute,
+    validate_units,
 )
 from cellpycore.units.spec import CellpyUnits
 
@@ -18,10 +21,13 @@ __all__ = [
     "Q",
     "calculate_current_conversion_factor",
     "calculate_nom_cap_abs_from_specific",
+    "calculate_scaler",
     "calculate_specific_conversion_factors",
     "calculate_specific_converters",
+    "convert_value",
     "get_cellpy_units",
     "get_converter_to_specific",
     "get_default_output_units",
     "nominal_capacity_as_absolute",
+    "validate_units",
 ]

--- a/src/cellpycore/units/converters.py
+++ b/src/cellpycore/units/converters.py
@@ -559,6 +559,138 @@ def calculate_current_conversion_factor(
     return factor.to_reduced_units().m
 
 
+# Per-property aliases for spec labels whose bare string means something else
+# (or nothing) to pint. The spec keeps the legacy label; conversion/validation
+# uses the pint-parsable form. Decision recorded on issue #115:
+# temperature "C" is Celsius (never coulomb), frequency "hz" is hertz.
+_PINT_LABEL_ALIASES: dict[str, dict[str, str]] = {
+    "temperature": {"C": "degC"},
+    "frequency": {"hz": "Hz"},
+}
+
+
+def _pint_unit_label(physical_property: str, unit: str) -> str:
+    """Return the pint-parsable label for a unit string on the spec."""
+    return _PINT_LABEL_ALIASES.get(physical_property, {}).get(unit, unit)
+
+
+def convert_value(
+    value: Union[QuantityValue, tuple],
+    physical_property: str,
+    from_units: Optional[CellpyUnits] = None,
+    to_units: Optional[CellpyUnits] = None,
+) -> float:
+    """Convert ``value`` between unit specs for one physical property.
+
+    Generalized port of legacy ``CellpyCell.to_cellpy_unit`` (unit plan §3):
+    the default direction is raw units → cellpy units, both falling back to
+    ``CellpyUnits()`` when unset.
+
+    Args:
+        value: A bare number (interpreted in ``from_units[physical_property]``),
+            a pint quantity string (e.g. ``"25 mV"``), or a ``(value, unit)``
+            tuple (e.g. ``(25, "mV")``).
+        physical_property: Key on the ``CellpyUnits`` spec (e.g. ``"voltage"``).
+        from_units: Input unit spec; defaults to ``CellpyUnits()``.
+        to_units: Output unit spec; defaults to ``CellpyUnits()``.
+
+    Returns:
+        The value expressed in ``to_units[physical_property]`` (float).
+
+    Raises:
+        KeyError: When ``physical_property`` is not a ``CellpyUnits`` field.
+        ValueError: When a quantity string carries no units.
+        TypeError: When ``value`` is neither number, string, nor tuple.
+    """
+    source = from_units or CellpyUnits()
+    target = to_units or CellpyUnits()
+    if physical_property not in source.keys():
+        raise KeyError(
+            f"unknown physical_property {physical_property!r}; expected one of "
+            f"{sorted(CellpyUnits().keys())}"
+        )
+    default_unit = _pint_unit_label(physical_property, source[physical_property])
+    target_unit = _pint_unit_label(physical_property, target[physical_property])
+    if isinstance(value, tuple):
+        quantity = Q(*value)
+    else:
+        quantity = _as_quantity(value, default_unit, name=physical_property)
+    return quantity.to(target_unit).m
+
+
+def calculate_scaler(from_unit: str, to_unit: str) -> float:
+    """Return the multiplicative factor that converts ``from_unit`` → ``to_unit``.
+
+    Port of legacy ``CellpyCell.unit_scaler_from_raw`` reduced to its essence
+    (``Q(1, a).to(b).m``); cellpy wraps it as
+    ``calculate_scaler(raw_units[prop], unit)``.
+
+    Note: only valid for multiplicative units — offset units (``degC``) raise
+    ``pint.errors.OffsetUnitCalculusError`` by design; use ``convert_value``
+    for temperatures.
+    """
+    return Q(1.0, from_unit).to(to_unit).m
+
+
+def validate_units(units: Any, *, strict: bool = True) -> CellpyUnits:
+    """Validate a unit spec: every label must be a pint-parsable unit string.
+
+    The loader-boundary validator (unit plan Phase 3, loader plan §2.2):
+    instrument configurations declare ``raw_units`` and this turns them into a
+    validated ``CellpyUnits`` built on top of the defaults.
+
+    Args:
+        units: A ``CellpyUnits`` instance or a plain mapping of
+            ``physical_property -> unit label``.
+        strict: When ``True`` (default) an unparsable label raises
+            ``ValueError``; when ``False`` it downgrades to a warning
+            (the ``local_instrument`` escape hatch).
+
+    Returns:
+        A ``CellpyUnits`` with the validated labels applied over the defaults.
+        Keys unknown to ``CellpyUnits`` are warned about, label-checked, and
+        left out of the returned spec.
+
+    Raises:
+        TypeError: When a label is not a string (e.g. a legacy v7 float scale
+            factor).
+        ValueError: When a label does not parse as a pint unit (strict mode).
+
+    Notes:
+        ``temperature="C"`` is accepted and means Celsius (validated as
+        ``degC``, never coulomb); ``frequency="hz"`` is accepted as hertz.
+        The original labels are preserved on the returned spec.
+    """
+    registry = _get_unit_registry()
+    known = set(CellpyUnits().keys())
+    spec = CellpyUnits()
+    items = units.items() if hasattr(units, "items") else dict(units).items()
+    for key, label in items:
+        if not isinstance(label, str):
+            raise TypeError(
+                f"unit label for {key!r} must be a string, got "
+                f"{type(label).__name__} ({label!r}); float scale factors are a "
+                "legacy v7 artifact - declare real unit strings instead"
+            )
+        try:
+            registry.Unit(_pint_unit_label(key, label))
+        except Exception as exc:
+            message = f"unit label for {key!r} does not parse: {label!r} ({exc})"
+            if strict:
+                raise ValueError(message) from exc
+            warnings.warn(message, stacklevel=2)
+            continue
+        if key in known:
+            spec[key] = label
+        else:
+            warnings.warn(
+                f"unknown unit key {key!r} (validated but kept out of the "
+                "CellpyUnits spec)",
+                stacklevel=2,
+            )
+    return spec
+
+
 def calculate_specific_conversion_factors(
     *,
     mass: Optional[QuantityValue] = None,

--- a/tests/test_units_converters.py
+++ b/tests/test_units_converters.py
@@ -216,3 +216,101 @@ def test_as_quantity_rejects_unitless_string():
 
     with pytest.raises(ValueError, match="no units"):
         _as_quantity("3.579", "mAh/g", name="nom_cap")
+
+
+# --- convert_value (issue #115, Stage 1.13) --------------------------------------
+
+
+def test_convert_value_bare_number_default_specs_is_identity():
+    assert units.convert_value(2.0, "mass") == pytest.approx(2.0)
+
+
+def test_convert_value_between_specs():
+    grams = CellpyUnits(mass="g")
+    assert units.convert_value(2.0, "mass", from_units=grams) == pytest.approx(2000.0)
+    assert units.convert_value(2000.0, "mass", to_units=grams) == pytest.approx(2.0)
+
+
+def test_convert_value_quantity_string():
+    assert units.convert_value("0.5 Ah", "charge") == pytest.approx(500.0)
+
+
+def test_convert_value_tuple():
+    assert units.convert_value((0.5, "Ah"), "charge") == pytest.approx(500.0)
+
+
+def test_convert_value_temperature_c_means_celsius():
+    kelvin = CellpyUnits(temperature="K")
+    assert units.convert_value(25.0, "temperature", to_units=kelvin) == pytest.approx(
+        298.15
+    )
+
+
+def test_convert_value_unknown_property_raises_keyerror():
+    with pytest.raises(KeyError, match="physical_property"):
+        units.convert_value(1.0, "swagger")
+
+
+def test_convert_value_unitless_string_raises():
+    with pytest.raises(ValueError, match="no units"):
+        units.convert_value("5", "mass")
+
+
+def test_convert_value_bad_type_raises():
+    with pytest.raises(TypeError):
+        units.convert_value(object(), "mass")
+
+
+# --- calculate_scaler -------------------------------------------------------------
+
+
+def test_calculate_scaler_ma_to_a():
+    assert units.calculate_scaler("mA", "A") == pytest.approx(1e-3)
+
+
+def test_calculate_scaler_identity():
+    assert units.calculate_scaler("V", "V") == pytest.approx(1.0)
+
+
+def test_calculate_scaler_from_raw_spec_matches_legacy_semantics():
+    raw = CellpyUnits()
+    assert units.calculate_scaler(raw["charge"], "Ah") == pytest.approx(1e-3)
+
+
+# --- validate_units ---------------------------------------------------------------
+
+
+def test_validate_units_default_spec_is_valid():
+    spec = units.validate_units(CellpyUnits())
+    assert isinstance(spec, CellpyUnits)
+    assert spec["temperature"] == "C"
+    assert spec["frequency"] == "hz"
+
+
+def test_validate_units_mapping_layers_over_defaults():
+    spec = units.validate_units({"charge": "Ah", "mass": "g"})
+    assert spec["charge"] == "Ah"
+    assert spec["mass"] == "g"
+    assert spec["current"] == CellpyUnits().current
+
+
+def test_validate_units_bad_label_raises():
+    with pytest.raises(ValueError, match="does not parse"):
+        units.validate_units({"charge": "not-a-unit"})
+
+
+def test_validate_units_bad_label_warns_when_not_strict():
+    with pytest.warns(UserWarning, match="does not parse"):
+        spec = units.validate_units({"charge": "not-a-unit"}, strict=False)
+    assert spec["charge"] == CellpyUnits().charge
+
+
+def test_validate_units_float_label_raises_typeerror():
+    with pytest.raises(TypeError, match="v7"):
+        units.validate_units({"charge": 1000.0})
+
+
+def test_validate_units_unknown_key_warns_and_is_dropped():
+    with pytest.warns(UserWarning, match="unknown unit key"):
+        spec = units.validate_units({"charge": "mAh", "swagger": "V"})
+    assert "swagger" not in spec.keys()

--- a/tests/test_units_optional.py
+++ b/tests/test_units_optional.py
@@ -84,6 +84,15 @@ def test_unit_helpers_raise_clear_error_without_pint(pint_absent):
     with pytest.raises(ModuleNotFoundError, match="units"):
         units.get_converter_to_specific(_DummyData(), mode="absolute")
 
+    with pytest.raises(ModuleNotFoundError, match="units"):
+        units.convert_value(1.0, "mass")
+
+    with pytest.raises(ModuleNotFoundError, match="units"):
+        units.calculate_scaler("mA", "A")
+
+    with pytest.raises(ModuleNotFoundError, match="units"):
+        units.validate_units({"charge": "mAh"})
+
 
 class _DummyData:
     """Carries the attributes the converter would read before hitting pint."""


### PR DESCRIPTION
Closes #115 (Stage 1.13).

Three additive helpers in `cellpycore.units` behind the optional `units` extra:

- **`convert_value(value, physical_property, from_units=None, to_units=None)`** — generalized port of cellpy's `to_cellpy_unit`: accepts a bare number (interpreted in `from_units`), a pint quantity string (`"25 mV"`), or a `(value, unit)` tuple; defaults raw → cellpy units.
- **`calculate_scaler(from_unit, to_unit)`** — port of `unit_scaler_from_raw` reduced to `Q(1, a).to(b).m`; offset units documented to raise (use `convert_value` for temperatures).
- **`validate_units(units, strict=True)`** — the loader-boundary validator: labels must be pint-parsable strings; floats rejected with a message naming the legacy v7 artifact; unknown keys warned + dropped; `strict=False` escape hatch for `local_instrument`.

**Label decision (recorded per the issue):** `temperature="C"` means Celsius — validated as `degC`, never coulomb — and `frequency="hz"` is hertz (bare `hz` is undefined in pint). Handled by a per-property alias table used only for parsing; spec labels are preserved.

Tests: 17 new converter cases + extended pint-optional guard (all three helpers raise the clear `ModuleNotFoundError` naming the extra). Full suite: **196 passed**.

Follow-ups: release + re-pin (release-procedure.md), then jepegit/cellpy#451 wraps these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)