### PR TITLE
feat(mapping): attribute-level table + shared postfix expansion (Stage 1.14, #116)

### DIFF
--- a/.issueflows/03-solved-issues/issue116_original.md
+++ b/.issueflows/03-solved-issues/issue116_original.md
@@ -1,0 +1,22 @@
+# Issue #116 — Stage 1.14: legacy mapping extensions — postfix expansion + attribute-level table
+
+GitHub: https://github.com/cellpy/cellpy-core/issues/116
+Labels: cellpy2-stage1, yolo
+
+## Goal
+
+Two additive pieces in `cellpycore.legacy.mapping`:
+
+- `expand_specific_columns(rename, modes)` — the `{col}_{gravimetric|areal|absolute}`
+  postfix expansion currently inlined in `OldCellpyCellCore.add_scaled_summary_columns`
+  (cell_core.py:1086–1092), lifted so the bridge and the future file-importer share it.
+- `LEGACY_ATTR_TO_SCHEMA` — attribute-level table (legacy attribute name → native
+  schema path, e.g. `voltage_txt → raw.potential`), needed because the value-based
+  mapping cannot serve the accessor shim; ~60 attributes cover everything the utils use.
+  Handle the duplicate-value pair (`HeadersSummary.discharge_capacity` vs
+  `discharge_capacity_raw`) explicitly.
+
+## Acceptance
+
+- Totality + bijectivity tests extended; bridge re-pointed at `expand_specific_columns`
+  with byte-identical goldens; release tagged for cellpy re-pin.

--- a/.issueflows/03-solved-issues/issue116_plan.md
+++ b/.issueflows/03-solved-issues/issue116_plan.md
@@ -1,0 +1,24 @@
+# Plan — issue #116 (Stage 1.14)
+
+1. **`expand_specific_columns(rename, specific_columns, modes)`** — lift the
+   bridge's inline postfix loop verbatim into `mapping.py` as a pure,
+   non-mutating function (`legacy_col` falls back to the native name when
+   unmapped, exactly as before); re-point
+   `OldCellpyCellCore.add_scaled_summary_columns` at it. Behavior guarded by
+   the existing bridge byte-parity goldens.
+2. **`LEGACY_ATTR_TO_SCHEMA`** — three sub-tables keyed by Schema frame
+   (`raw` / `step` / `cycle`), legacy dataclass *attribute* name → native
+   field name (`raw`/`cycle`) or base-signal name (`step`, combined with
+   `STAT_SUFFIXES` for statistic columns). Companion `LEGACY_ATTR_UNMAPPED`
+   exception sets (mirroring the `LEGACY_ONLY_*` value sets) give the same
+   totality discipline: an uncategorized attribute fails the build.
+3. **Duplicate-value pairs** (`charge_capacity`/`charge_capacity_raw`,
+   `discharge_capacity`/`discharge_capacity_raw`) mapped on both sides and
+   declared in `DUPLICATE_VALUE_ATTRS`; the shim owns the disambiguation
+   warning (native-headers plan D6).
+4. **`legacy_attr_to_native(frame, attr)`** — small resolver with clear
+   KeyErrors distinguishing legacy-only vs unknown attributes.
+5. **Tests** — six new cases in `tests/test_header_mapping.py`: attribute
+   totality per class, targets exist on native classes, attribute table agrees
+   with the value-based pair tables, duplicate pairs coincide, resolver raise
+   behavior, and expansion equivalence (mapped, unmapped, non-mutating).

--- a/.issueflows/03-solved-issues/issue116_status.md
+++ b/.issueflows/03-solved-issues/issue116_status.md
@@ -1,0 +1,15 @@
+# Status — issue #116 (Stage 1.14)
+
+- [x] Done
+
+## 2026-07-14
+
+- Added `LEGACY_ATTR_TO_SCHEMA` (10 raw + 14 step + 25 cycle attributes),
+  `LEGACY_ATTR_UNMAPPED`, `DUPLICATE_VALUE_ATTRS`, `legacy_attr_to_native`,
+  and `expand_specific_columns` to `cellpycore/legacy/mapping.py`.
+- Re-pointed `OldCellpyCellCore.add_scaled_summary_columns` at
+  `expand_specific_columns` (behavior-preserving; bridge goldens green).
+- The new attribute-totality test caught one omission during development
+  (`discharge_capacity_loss`) — the discipline works.
+- Full suite: 202 passed. Consumed by cellpy Stage 1.15 (#458) after
+  release + re-pin.

--- a/src/cellpycore/cell_core.py
+++ b/src/cellpycore/cell_core.py
@@ -1084,11 +1084,9 @@ class OldCellpyCellCore(CellpyCellCore):
             )
 
         # native -> legacy, incl. the generated ``{col}_{mode}`` specific columns.
-        rename = self._native_to_legacy_summary_rename()
-        for col in specific_columns:
-            legacy_col = rename.get(col, col)
-            for mode in specifics:
-                rename[f"{col}_{mode}"] = f"{legacy_col}_{mode}"
+        rename = mapping.expand_specific_columns(
+            self._native_to_legacy_summary_rename(), specific_columns, specifics
+        )
         result = nd.summary.to_pandas().rename(columns=rename)
         result.index = list(range(len(result)))
         data.summary = result

--- a/src/cellpycore/legacy/mapping.py
+++ b/src/cellpycore/legacy/mapping.py
@@ -300,6 +300,208 @@ NATIVE_ONLY_CYCLE = frozenset(
 
 
 # -----------------------------------------------------------------------------
+#   Attribute-level mapping (issue #116, Stage 1.14).
+#
+#   The value-based tables above serve DataFrame renames; the deprecation shim
+#   and ``translate.py`` also need to resolve **legacy attribute names**
+#   (``headers_normal.voltage_txt``, ``hdr_steps.cycle``, ...) onto the native
+#   schema. Keys below are the legacy dataclass *attribute* names; values are:
+#
+#   - "raw" / "cycle": the native ``RawCols`` / ``CycleCols`` field name.
+#   - "step": the native **base-signal** name (statistic columns are formed by
+#     appending ``STAT_SUFFIXES`` variants, exactly as in
+#     :func:`native_to_legacy_step`); scalar step attributes resolve to their
+#     ``StepCols`` field directly.
+#
+#   Totality discipline: every attribute of the legacy dataclass is either a
+#   key here or listed in ``LEGACY_ATTR_UNMAPPED`` (its column value has no
+#   native counterpart — same population as the ``LEGACY_ONLY_*`` value sets).
+# -----------------------------------------------------------------------------
+LEGACY_ATTR_TO_SCHEMA = {
+    "raw": {
+        # HeadersNormal attribute -> RawCols field
+        "charge_capacity_txt": "cumulative_charge_capacity",
+        "current_txt": "current",
+        "cycle_index_txt": "cycle_num",
+        "data_point_txt": "datapoint_num",
+        "discharge_capacity_txt": "cumulative_discharge_capacity",
+        "internal_resistance_txt": "internal_resistance",
+        "step_index_txt": "step_num",
+        "step_time_txt": "step_time",
+        "test_time_txt": "test_time",
+        "voltage_txt": "potential",
+    },
+    "step": {
+        # HeadersStepTable attribute -> StepCols base signal or scalar field
+        "charge": "charge_capacity",
+        "current": "current",
+        "cycle": "cycle_num",
+        "discharge": "discharge_capacity",
+        "internal_resistance": "internal_resistance",
+        "point": "datapoint_num",
+        "rate_avr": "c_rate",
+        "step": "step_num",
+        "step_time": "step_time",
+        "sub_step": "sub_step_num",
+        "sub_type": "sub_step_type",
+        "test_time": "test_time",
+        "type": "step_type",
+        "voltage": "potential",
+    },
+    "cycle": {
+        # HeadersSummary attribute -> CycleCols field
+        "charge_c_rate": "charge_c_rate",
+        "charge_capacity": "charge_capacity",
+        "charge_capacity_loss": "charge_capacity_loss",
+        # Duplicate-value pair: ``charge_capacity_raw`` shares its column value
+        # with ``charge_capacity`` (both "charge_capacity"); the shim maps both
+        # here and owns the disambiguation warning (native-headers plan D6).
+        "charge_capacity_raw": "charge_capacity",
+        "coulombic_difference": "coulombic_difference",
+        "coulombic_efficiency": "coulombic_efficiency",
+        "cumulated_charge_capacity": "test_cumulated_charge_capacity",
+        "cumulated_charge_capacity_loss": "test_cumulated_charge_capacity_loss",
+        "cumulated_coulombic_difference": "test_cumulated_coulombic_difference",
+        "cumulated_discharge_capacity": "test_cumulated_discharge_capacity",
+        "cumulated_discharge_capacity_loss": "test_cumulated_discharge_capacity_loss",
+        "cycle_index": "cycle_num",
+        "data_point": "datapoint_num_last",
+        "discharge_c_rate": "discharge_c_rate",
+        "discharge_capacity": "discharge_capacity",
+        "discharge_capacity_loss": "discharge_capacity_loss",
+        # Duplicate-value pair partner of ``discharge_capacity`` (see above).
+        "discharge_capacity_raw": "discharge_capacity",
+        "end_voltage_charge": "potential_end_charge",
+        "end_voltage_discharge": "potential_end_discharge",
+        "ir_charge": "ir_charge",
+        "ir_discharge": "ir_discharge",
+        "normalized_cycle_index": "normalized_cycle_index",
+        "temperature_last": "temperature_cell_last",
+        "temperature_mean": "temperature_cell_mean",
+        "test_time": "last_test_time",
+    },
+}
+
+# Legacy attributes whose column values have no native counterpart (they mirror
+# the ``LEGACY_ONLY_*`` value sets, keyed by attribute name instead of value).
+LEGACY_ATTR_UNMAPPED = {
+    "raw": frozenset(
+        {
+            "aci_phase_angle_txt",
+            "ref_aci_phase_angle_txt",
+            "ac_impedance_txt",
+            "ref_ac_impedance_txt",
+            "charge_energy_txt",
+            "datetime_txt",
+            "discharge_energy_txt",
+            "power_txt",
+            "is_fc_data_txt",
+            "sub_step_index_txt",
+            "sub_step_time_txt",
+            "test_id_txt",
+            "ref_voltage_txt",
+            "dv_dt_txt",
+            "frequency_txt",
+            "amplitude_txt",
+            "channel_id_txt",
+            "data_flag_txt",
+            "test_name_txt",
+        }
+    ),
+    "step": frozenset({"test", "ustep", "info", "internal_resistance_change"}),
+    "cycle": frozenset(
+        {
+            "datetime",
+            "test_name",
+            "data_flag",
+            "channel_id",
+            "cumulated_coulombic_efficiency",
+            "normalized_charge_capacity",
+            "normalized_discharge_capacity",
+            "shifted_charge_capacity",
+            "shifted_discharge_capacity",
+            "ocv_first_min",
+            "ocv_second_min",
+            "ocv_first_max",
+            "ocv_second_max",
+            "cumulated_ric_disconnect",
+            "cumulated_ric_sei",
+            "cumulated_ric",
+            "low_level",
+            "high_level",
+            "pre_aux",
+        }
+    ),
+}
+
+# The legacy attribute pairs that share one column value (native-headers plan
+# D6): the accessor shim maps both sides and warns about the ambiguity.
+DUPLICATE_VALUE_ATTRS = {
+    "cycle": (
+        ("charge_capacity", "charge_capacity_raw"),
+        ("discharge_capacity", "discharge_capacity_raw"),
+    ),
+}
+
+
+def legacy_attr_to_native(frame: str, attr: str) -> str:
+    """Resolve a legacy header *attribute* name to its native name.
+
+    Args:
+        frame: ``"raw"``, ``"step"``, or ``"cycle"`` (the Schema frame).
+        attr: The legacy dataclass attribute (e.g. ``"voltage_txt"``).
+
+    Returns:
+        The native field name (``"raw"``/``"cycle"``) or base-signal name
+        (``"step"`` — combine with :data:`STAT_SUFFIXES` for statistic columns).
+
+    Raises:
+        KeyError: When the frame is unknown, or the attribute is unmapped
+            (legacy-only) or entirely unknown.
+    """
+    try:
+        table = LEGACY_ATTR_TO_SCHEMA[frame]
+    except KeyError:
+        raise KeyError(
+            f"unknown frame {frame!r}; expected one of {sorted(LEGACY_ATTR_TO_SCHEMA)}"
+        ) from None
+    if attr in table:
+        return table[attr]
+    if attr in LEGACY_ATTR_UNMAPPED[frame]:
+        raise KeyError(
+            f"legacy attribute {attr!r} ({frame}) has no native counterpart "
+            "(legacy-only column)"
+        )
+    raise KeyError(f"unknown legacy attribute {attr!r} for frame {frame!r}")
+
+
+def expand_specific_columns(rename: dict, specific_columns, modes) -> dict:
+    """Extend a native → legacy rename dict with ``{col}_{mode}`` variants.
+
+    The ``{col}_{gravimetric|areal|absolute}`` postfix expansion previously
+    inlined in ``OldCellpyCellCore.add_scaled_summary_columns`` — lifted here
+    (issue #116) so the bridge and the cellpy-file importer share one
+    implementation.
+
+    Args:
+        rename: Base native → legacy rename mapping (not mutated).
+        specific_columns: Native column names that carry specific variants.
+        modes: Postfix modes (e.g. ``["gravimetric", "areal", "absolute"]``).
+
+    Returns:
+        dict: A new mapping = ``rename`` plus ``{col}_{mode} ->
+        {legacy_col}_{mode}`` for every combination (``legacy_col`` falls back
+        to ``col`` when unmapped).
+    """
+    expanded = dict(rename)
+    for col in specific_columns:
+        legacy_col = rename.get(col, col)
+        for mode in modes:
+            expanded[f"{col}_{mode}"] = f"{legacy_col}_{mode}"
+    return expanded
+
+
+# -----------------------------------------------------------------------------
 #   Derivation helpers (the bridge builds its rename dicts from these).
 # -----------------------------------------------------------------------------
 def legacy_to_native_raw(columns=None) -> dict:

--- a/tests/test_header_mapping.py
+++ b/tests/test_header_mapping.py
@@ -167,3 +167,105 @@ def test_bridge_uses_header_mapping():
     assert core._legacy_to_native_step_rename() == mapping.legacy_to_native_step()
     assert core._native_to_legacy_summary_rename() == mapping.native_to_legacy_summary()
     assert core._legacy_to_native_summary_rename() == mapping.legacy_to_native_summary()
+
+
+# --- attribute-level mapping + postfix expansion (issue #116) -----------------
+
+import pytest  # noqa: E402
+
+_LEGACY_ATTR_CLASSES = {
+    "raw": HeadersNormal,
+    "step": HeadersStepTable,
+    "cycle": HeadersSummary,
+}
+
+
+def _legacy_attr_names(headers_cls) -> set:
+    return {f.name for f in dataclasses.fields(headers_cls)}
+
+
+def test_legacy_attr_totality():
+    """Every legacy attribute is either mapped or documented unmapped."""
+    for frame, headers_cls in _LEGACY_ATTR_CLASSES.items():
+        mapped = set(mapping.LEGACY_ATTR_TO_SCHEMA[frame])
+        unmapped = set(mapping.LEGACY_ATTR_UNMAPPED[frame])
+        assert not (mapped & unmapped), f"{frame}: overlap {mapped & unmapped}"
+        assert mapped | unmapped == _legacy_attr_names(headers_cls), (
+            f"{frame}: attribute set drifted"
+        )
+
+
+def test_legacy_attr_targets_exist_on_native_classes():
+    raw_fields = set(config.RawCols.__annotations__)
+    cycle_fields = set(config.CycleCols.__annotations__)
+    step_bases = {native for native, _ in mapping.STEP_BASE_PAIRS} | {
+        native for native, _ in mapping.STEP_SCALAR_PAIRS
+    }
+    for attr, target in mapping.LEGACY_ATTR_TO_SCHEMA["raw"].items():
+        assert target in raw_fields, f"raw.{attr} -> {target} not on RawCols"
+    for attr, target in mapping.LEGACY_ATTR_TO_SCHEMA["cycle"].items():
+        assert target in cycle_fields, f"cycle.{attr} -> {target} not on CycleCols"
+    for attr, target in mapping.LEGACY_ATTR_TO_SCHEMA["step"].items():
+        assert target in step_bases, f"step.{attr} -> {target} not a step signal"
+
+
+def test_legacy_attr_matches_value_mapping():
+    """The attribute table agrees with the value-based pair tables."""
+    raw_value_map = mapping.legacy_to_native_raw()
+    hn = HeadersNormal()
+    for attr, target in mapping.LEGACY_ATTR_TO_SCHEMA["raw"].items():
+        assert raw_value_map[getattr(hn, attr)] == target, attr
+
+    summary_value_map = mapping.legacy_to_native_summary()
+    hs = HeadersSummary()
+    for attr, target in mapping.LEGACY_ATTR_TO_SCHEMA["cycle"].items():
+        assert summary_value_map[getattr(hs, attr)] == target, attr
+
+    step_base = {legacy: native for native, legacy in mapping.STEP_BASE_PAIRS}
+    step_scalar = {legacy: native for native, legacy in mapping.STEP_SCALAR_PAIRS}
+    ht = HeadersStepTable()
+    for attr, target in mapping.LEGACY_ATTR_TO_SCHEMA["step"].items():
+        legacy_value = getattr(ht, attr)
+        resolved = step_base.get(legacy_value, step_scalar.get(legacy_value))
+        assert resolved == target, attr
+
+
+def test_duplicate_value_attrs_map_to_same_target():
+    for frame, pairs in mapping.DUPLICATE_VALUE_ATTRS.items():
+        table = mapping.LEGACY_ATTR_TO_SCHEMA[frame]
+        for first, second in pairs:
+            assert table[first] == table[second], (first, second)
+
+
+def test_legacy_attr_to_native_resolves_and_raises():
+    assert mapping.legacy_attr_to_native("raw", "voltage_txt") == "potential"
+    assert mapping.legacy_attr_to_native("step", "voltage") == "potential"
+    assert (
+        mapping.legacy_attr_to_native("cycle", "end_voltage_charge")
+        == "potential_end_charge"
+    )
+    with pytest.raises(KeyError, match="legacy-only"):
+        mapping.legacy_attr_to_native("raw", "power_txt")
+    with pytest.raises(KeyError, match="unknown legacy attribute"):
+        mapping.legacy_attr_to_native("raw", "nope")
+    with pytest.raises(KeyError, match="unknown frame"):
+        mapping.legacy_attr_to_native("bogus", "voltage_txt")
+
+
+def test_expand_specific_columns_matches_bridge_inline_behavior():
+    base = mapping.native_to_legacy_summary()
+    out = mapping.expand_specific_columns(
+        base,
+        ["test_cumulated_charge_capacity", "unmapped_col"],
+        ["gravimetric", "areal"],
+    )
+    # mapped column: legacy name carries the postfix
+    assert (
+        out["test_cumulated_charge_capacity_gravimetric"]
+        == "cumulated_charge_capacity_gravimetric"
+    )
+    # unmapped column: falls back to the native name
+    assert out["unmapped_col_areal"] == "unmapped_col_areal"
+    # base entries are preserved and the input is not mutated
+    assert out["cycle_num"] == "cycle_index"
+    assert "test_cumulated_charge_capacity_gravimetric" not in base


### PR DESCRIPTION
Closes #116 (Stage 1.14).

Two additive pieces in `cellpycore.legacy.mapping`, consumed by cellpy's Stage 1.15 `translate.py` (jepegit/cellpy#458) and later the accessor shim:

- **`LEGACY_ATTR_TO_SCHEMA`** — legacy `Headers*` *attribute* name → native field (`raw`/`cycle`) or base-signal name (`step`, combined with `STAT_SUFFIXES`), 49 attributes total. Companion `LEGACY_ATTR_UNMAPPED` exception sets give the same totality discipline as the value tables — an uncategorized attribute fails the build (the new test caught one omission during development, so the discipline demonstrably works).
- **`expand_specific_columns(rename, specific_columns, modes)`** — the `{col}_{gravimetric|areal|absolute}` postfix expansion lifted out of `OldCellpyCellCore.add_scaled_summary_columns`; the bridge is re-pointed at it (behavior-preserving; bridge goldens green).

Also: `DUPLICATE_VALUE_ATTRS` declares the `charge/discharge_capacity(_raw)` shared-value pairs explicitly (native-headers plan D6 — the shim owns the disambiguation warning), and `legacy_attr_to_native(frame, attr)` resolves with distinct legacy-only vs unknown KeyErrors.

Tests: six new cases in `test_header_mapping.py` (attribute totality, native-target existence, agreement with the value tables, duplicate pairs, resolver raises, expansion equivalence). Full suite: **202 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)