### PR TITLE
feat(metadata): legacy⇄core field mapping + G9/volume decisions (Stage 1.16, #117)

### DIFF
--- a/.issueflows/03-solved-issues/issue117_original.md
+++ b/.issueflows/03-solved-issues/issue117_original.md
@@ -1,0 +1,21 @@
+# Issue #117 — Stage 1.16: metadata — legacy⇄core field-mapping module (meta_mapping)
+
+GitHub: https://github.com/cellpy/cellpy-core/issues/117
+Labels: cellpy2-stage1, yolo
+
+## Goal
+
+`cellpycore/legacy/meta_mapping.py` declaring the legacy `CellpyMetaCommon` /
+`CellpyMetaIndividualTest` ⇄ core `CellMeta` / `TestMeta` translation once:
+`COMMON_TO_CELL_PAIRS`, `COMMON_TO_TEST_PAIRS` (the re-homed `cell_name`,
+`start_datetime`, `time_zone`, `tester_ID→tester_id`), `INDIVIDUAL_TO_TEST_PAIRS`
+(incl. `test_ID→test_id` int coercion), `LEGACY_ONLY` (each with documented
+destination), `CORE_ONLY` (migration fills from context) — with the same
+bijectivity/round-trip/totality tests as the header mapping. Resolve in the same PR:
+the G9 decision (tester software/calibration fields → recommendation: into `TestMeta`)
+and `CellMeta.volume` (needed by volumetric units mode).
+
+## Acceptance
+
+- Totality tests in place; G9 + volume decisions recorded in the metadata plan doc
+  (dated note) and implemented.

--- a/.issueflows/03-solved-issues/issue117_plan.md
+++ b/.issueflows/03-solved-issues/issue117_plan.md
@@ -1,0 +1,26 @@
+# Plan — issue #117 (Stage 1.16)
+
+1. **Model changes (the two decisions, implemented):**
+   - G9: `tester_server_software_version`, `tester_client_software_version`,
+     `tester_calibration_date` become `TestMeta` fields (test-dependent
+     provenance; no `extra` dict).
+   - `CellMeta.volume: Optional[float]` (cellpy units convention, `cm**3`),
+     wired into `get_converter_to_specific(mode="volumetric", cell_meta=…)`.
+   - Both recorded as dated notes in the metadata plan
+     (architecture-plan repo, Step 1 section).
+2. **`cellpycore/legacy/meta_mapping.py`** — pair tables
+   (`COMMON_TO_CELL_PAIRS` 19, `COMMON_TO_TEST_PAIRS` 7 incl. the G9 triplet,
+   `INDIVIDUAL_TO_TEST_PAIRS` 8), `LEGACY_ONLY` with documented destinations
+   (`file_errors` dropped, `raw_id` → `TestMeta.uuid`, `cellpy_file_version` →
+   file-format layer), `CORE_ONLY_CELL` / `CORE_ONLY_TEST`, pinned legacy field
+   inventories (core cannot import cellpy; cellpy contract tests guard the pins).
+3. **Helpers:** `coerce_test_id` (int coercion; legacy list → first entry,
+   logged; bool/garbage → ValueError) and `legacy_meta_to_core(common,
+   individual)` (pure translation, provenance untouched, accepts mappings or
+   attribute-style objects).
+4. **Quirk found and documented:** legacy `schedule_file_name` is an
+   un-annotated class attribute, not a dataclass field.
+5. **Tests:** `tests/test_meta_mapping.py` — totality on all four sides,
+   bijectivity, no target collisions, documented destinations, `coerce_test_id`
+   matrix, end-to-end translation incl. re-homing and legacy-only skips;
+   volumetric-via-CellMeta test added to the units suite.

--- a/.issueflows/03-solved-issues/issue117_status.md
+++ b/.issueflows/03-solved-issues/issue117_status.md
@@ -1,0 +1,15 @@
+# Status — issue #117 (Stage 1.16)
+
+- [x] Done
+
+## 2026-07-15
+
+- `cellpycore/legacy/meta_mapping.py` landed with pair tables, exception sets,
+  pinned legacy inventories, `coerce_test_id`, `legacy_meta_to_core`.
+- G9 decision implemented (tester triplet onto `TestMeta`); `CellMeta.volume`
+  added and wired into the volumetric converter path. Dated decision notes
+  written into `architecture-plan/cellpy2-metadata-handling-plan.md`.
+- Quirk documented: legacy `schedule_file_name` is an un-annotated class
+  attribute (not a dataclass field) — cellpy's contract test must include it
+  explicitly.
+- Full suite: 224 passed.

--- a/src/cellpycore/legacy/meta_mapping.py
+++ b/src/cellpycore/legacy/meta_mapping.py
@@ -1,0 +1,245 @@
+"""Authoritative legacy ⇄ core metadata field mapping (issue #117, Stage 1.16).
+
+Declares once how legacy cellpy's two metadata dataclasses
+(``cellpy.parameters.internal_settings.CellpyMetaCommon`` /
+``CellpyMetaIndividualTest``) translate onto the core models
+(``cellpycore.metadata.models.CellMeta`` / ``TestMeta``), following the same
+pair-tables + exception-sets + totality-tests pattern as the header mapping
+(``cellpycore.legacy.mapping``).
+
+Key re-homing decision (metadata plan Step 1): legacy misfiles four
+test-dependent fields under "common" (``cell_name``, ``start_datetime``,
+``time_zone``, ``tester_ID``) — they map onto ``TestMeta``, not ``CellMeta``.
+
+G9 decision (recorded 2026-07-14): the three tester software/calibration fields
+are legitimate test-dependent provenance and map onto ``TestMeta`` fields of the
+same name (added there in this change), rather than into an ``extra`` dict.
+
+cellpy-core cannot import cellpy, so the legacy field inventories are pinned
+here as frozensets; cellpy's own contract tests guard that the pinned lists
+match the real legacy dataclasses (the same arrangement as
+``cellpycore.legacy.headers``).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Mapping, Optional
+
+from cellpycore.metadata.models import CellMeta, TestMeta
+
+logger = logging.getLogger(__name__)
+
+# --- pinned legacy field inventories -----------------------------------------
+# ``cellpy.parameters.internal_settings.CellpyMetaCommon`` (29 fields).
+LEGACY_COMMON_FIELDS = frozenset(
+    {
+        "cell_name",
+        "start_datetime",
+        "time_zone",
+        "comment",
+        "file_errors",
+        "raw_id",
+        "cellpy_file_version",
+        "tester_ID",
+        "tester_server_software_version",
+        "tester_client_software_version",
+        "tester_calibration_date",
+        "material",
+        "mass",
+        "tot_mass",
+        "nom_cap",
+        "nom_cap_specifics",
+        "active_electrode_area",
+        "active_electrode_thickness",
+        "active_electrode_loading",
+        "electrolyte_volume",
+        "electrolyte_type",
+        "active_electrode_type",
+        "counter_electrode_type",
+        "reference_electrode_type",
+        "experiment_type",
+        "cell_type",
+        "separator_type",
+        "active_electrode_current_collector",
+        "reference_electrode_current_collector",
+    }
+)
+
+# ``cellpy.parameters.internal_settings.CellpyMetaIndividualTest``.
+# Note: ``schedule_file_name`` is an **un-annotated class attribute** in the
+# legacy dataclass (``schedule_file_name = None``), not a dataclass field —
+# it still carries data when set, so it participates in the mapping; cellpy's
+# contract test must compare against fields *plus* this documented attribute.
+LEGACY_INDIVIDUAL_FIELDS = frozenset(
+    {
+        "channel_index",
+        "creator",
+        "schedule_file_name",
+        "test_type",
+        "voltage_lim_low",
+        "voltage_lim_high",
+        "cycle_mode",
+        "test_ID",
+    }
+)
+
+# --- pair tables ---------------------------------------------------------------
+# ``(legacy_field, core_field)``; mostly identity for the cell-dependent block.
+COMMON_TO_CELL_PAIRS = [
+    ("material", "material"),
+    ("mass", "mass"),
+    ("tot_mass", "tot_mass"),
+    ("nom_cap", "nom_cap"),
+    ("nom_cap_specifics", "nom_cap_specifics"),
+    ("active_electrode_area", "active_electrode_area"),
+    ("active_electrode_thickness", "active_electrode_thickness"),
+    ("active_electrode_loading", "active_electrode_loading"),
+    ("electrolyte_volume", "electrolyte_volume"),
+    ("electrolyte_type", "electrolyte_type"),
+    ("active_electrode_type", "active_electrode_type"),
+    ("counter_electrode_type", "counter_electrode_type"),
+    ("reference_electrode_type", "reference_electrode_type"),
+    ("separator_type", "separator_type"),
+    ("cell_type", "cell_type"),
+    ("experiment_type", "experiment_type"),
+    ("active_electrode_current_collector", "active_electrode_current_collector"),
+    ("reference_electrode_current_collector", "reference_electrode_current_collector"),
+    ("comment", "comment"),
+]
+
+# The re-homed fields: legacy filed them under "common", but they are
+# test-dependent — they land on ``TestMeta``. Includes the G9 tester triplet.
+COMMON_TO_TEST_PAIRS = [
+    ("cell_name", "cell_name"),
+    ("start_datetime", "start_datetime"),
+    ("time_zone", "time_zone"),
+    ("tester_ID", "tester_id"),
+    ("tester_server_software_version", "tester_server_software_version"),
+    ("tester_client_software_version", "tester_client_software_version"),
+    ("tester_calibration_date", "tester_calibration_date"),
+]
+
+# ``CellpyMetaIndividualTest`` fields — all map onto ``TestMeta``.
+INDIVIDUAL_TO_TEST_PAIRS = [
+    ("channel_index", "channel"),
+    ("creator", "creator"),
+    ("schedule_file_name", "schedule_file_name"),
+    ("test_type", "test_type"),
+    ("voltage_lim_low", "voltage_lim_low"),
+    ("voltage_lim_high", "voltage_lim_high"),
+    ("cycle_mode", "cycle_mode"),
+    ("test_ID", "test_id"),  # int coercion; see ``coerce_test_id``
+]
+
+# --- documented exceptions -------------------------------------------------------
+# Legacy fields that die or move to other layers; value = destination note.
+LEGACY_ONLY = {
+    "file_errors": "dropped (marked 'not in use' in legacy)",
+    "raw_id": "superseded by TestMeta.uuid",
+    "cellpy_file_version": "file-format layer (cellpy readers/cellpy_file/format.py)",
+}
+
+# Core fields legacy never had. Migration fills them from context (provenance
+# stamped by the loading framework; ``volume`` is the new volumetric-mode field).
+CORE_ONLY_CELL = frozenset({"volume"})
+CORE_ONLY_TEST = frozenset(
+    {
+        "uuid",
+        "test_family",
+        "source_kind",
+        "source_type",
+        "source_uri",
+        "source_uuid",
+        "raw_file_names",
+        "loaded_datetime",
+        "comment",
+        "cell",
+    }
+)
+
+
+# --- helpers ----------------------------------------------------------------------
+def coerce_test_id(value: Any, *, default: int = 0) -> int:
+    """Coerce a legacy ``test_ID`` value to a compact int ``test_id``.
+
+    Legacy sometimes holds lists (multi-test files): take the first entry and
+    log the rest, per the metadata plan Step 1.
+
+    Args:
+        value: Legacy ``test_ID`` (int, numeric string, list/tuple, or None).
+        default: Returned when ``value`` is None or empty.
+
+    Returns:
+        The coerced integer test id.
+
+    Raises:
+        ValueError: When the value (or its first list entry) is not
+            interpretable as an integer.
+    """
+    if value is None:
+        return default
+    if isinstance(value, (list, tuple)):
+        if not value:
+            return default
+        if len(value) > 1:
+            logger.info(
+                "legacy test_ID holds %d values %r; taking the first",
+                len(value),
+                value,
+            )
+        value = value[0]
+    if isinstance(value, bool):
+        raise ValueError(f"cannot interpret legacy test_ID {value!r} as an int")
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"cannot interpret legacy test_ID {value!r} as an int"
+        ) from exc
+
+
+def _pick(source: Mapping[str, Any], key: str) -> Any:
+    """Read ``key`` from a mapping or attribute-style legacy object."""
+    if hasattr(source, "get"):
+        return source.get(key)
+    return getattr(source, key, None)
+
+
+def legacy_meta_to_core(
+    common: Optional[Mapping[str, Any]] = None,
+    individual: Optional[Mapping[str, Any]] = None,
+) -> tuple[CellMeta, TestMeta]:
+    """Build ``(CellMeta, TestMeta)`` from legacy metadata objects/mappings.
+
+    Pure translation via the pair tables — no provenance is invented here
+    (that is the loading framework's job). ``LEGACY_ONLY`` fields are ignored
+    with their documented destinations; absent fields stay ``None``.
+
+    Args:
+        common: Legacy ``CellpyMetaCommon`` instance or field mapping.
+        individual: Legacy ``CellpyMetaIndividualTest`` instance or mapping.
+
+    Returns:
+        The translated ``(CellMeta, TestMeta)`` pair (``TestMeta.cell`` is left
+        unset; linking is the caller's decision).
+    """
+    cell = CellMeta()
+    test = TestMeta()
+    if common is not None:
+        for legacy_field, core_field in COMMON_TO_CELL_PAIRS:
+            value = _pick(common, legacy_field)
+            if value is not None:
+                setattr(cell, core_field, value)
+        for legacy_field, core_field in COMMON_TO_TEST_PAIRS:
+            value = _pick(common, legacy_field)
+            if value is not None:
+                setattr(test, core_field, value)
+    if individual is not None:
+        for legacy_field, core_field in INDIVIDUAL_TO_TEST_PAIRS:
+            value = _pick(individual, legacy_field)
+            if core_field == "test_id":
+                test.test_id = coerce_test_id(value)
+            elif value is not None:
+                setattr(test, core_field, value)
+    return cell, test

--- a/src/cellpycore/metadata/models.py
+++ b/src/cellpycore/metadata/models.py
@@ -75,6 +75,9 @@ class CellMeta:
         tot_mass: Total material mass.
         nom_cap: Nominal capacity.
         nom_cap_specifics: How ``nom_cap`` is specified (e.g. gravimetric).
+        volume: Cell / electrode volume (cellpy units convention, ``cm**3``);
+            needed by the volumetric specific-capacity mode (decision recorded
+            2026-07-14, issue #117 / metadata plan Step 1).
         active_electrode_area: Active-electrode area.
         active_electrode_thickness: Active-electrode thickness.
         active_electrode_loading: Active-electrode loading (e.g. mAh/cm2).
@@ -97,6 +100,7 @@ class CellMeta:
     tot_mass: Optional[float] = None
     nom_cap: Optional[float] = None
     nom_cap_specifics: Optional[str] = None
+    volume: Optional[float] = None
     active_electrode_area: Optional[float] = None
     active_electrode_thickness: Optional[float] = None
     active_electrode_loading: Optional[float] = None
@@ -143,6 +147,12 @@ class TestMeta:
         creator: Who produced / imported the test.
         channel: Tester channel id.
         tester_id: Tester / server identity.
+        tester_server_software_version: Tester server software version
+            (test-dependent provenance; G9 decision, issue #117).
+        tester_client_software_version: Tester client software version
+            (test-dependent provenance; G9 decision, issue #117).
+        tester_calibration_date: Tester calibration date at test time
+            (test-dependent provenance; G9 decision, issue #117).
         voltage_lim_low: Lower voltage limit used for the test.
         voltage_lim_high: Upper voltage limit used for the test.
         start_datetime: Test start time (ISO 8601 string).
@@ -171,6 +181,9 @@ class TestMeta:
     creator: Optional[str] = None
     channel: Optional[str] = None
     tester_id: Optional[str] = None
+    tester_server_software_version: Optional[str] = None
+    tester_client_software_version: Optional[str] = None
+    tester_calibration_date: Optional[str] = None
     voltage_lim_low: Optional[float] = None
     voltage_lim_high: Optional[float] = None
     start_datetime: Optional[str] = None

--- a/src/cellpycore/units/converters.py
+++ b/src/cellpycore/units/converters.py
@@ -271,7 +271,7 @@ def get_converter_to_specific(
             if value is not None
             else _resolve_optional_attr(
                 explicit=volume,
-                cell_meta=None,
+                cell_meta=cell_meta,
                 meta_attr="volume",
                 data=data,
                 data_attr="volume",

--- a/tests/test_meta_mapping.py
+++ b/tests/test_meta_mapping.py
@@ -1,0 +1,170 @@
+"""Totality / round-trip tests for the legacy ⇄ core metadata field mapping.
+
+Same discipline as ``tests/test_header_mapping.py``: every legacy field is
+either mapped or listed in a documented exception, every core field is either a
+mapping target or listed core-only — adding a field on either side fails these
+tests until it is deliberately categorized. The legacy inventories are pinned
+in the module (core cannot import cellpy); cellpy's contract tests guard the
+pins against the real legacy dataclasses.
+"""
+
+import dataclasses
+
+import pytest
+
+from cellpycore.legacy import meta_mapping
+from cellpycore.metadata.models import CellMeta, TestMeta
+
+
+def _core_field_names(model_cls) -> set:
+    return {f.name for f in dataclasses.fields(model_cls)}
+
+
+# --- totality -----------------------------------------------------------------
+def test_legacy_common_totality():
+    mapped = {legacy for legacy, _ in meta_mapping.COMMON_TO_CELL_PAIRS} | {
+        legacy for legacy, _ in meta_mapping.COMMON_TO_TEST_PAIRS
+    }
+    legacy_only = set(meta_mapping.LEGACY_ONLY)
+    assert not (mapped & legacy_only)
+    assert mapped | legacy_only == meta_mapping.LEGACY_COMMON_FIELDS
+
+
+def test_legacy_individual_totality():
+    mapped = {legacy for legacy, _ in meta_mapping.INDIVIDUAL_TO_TEST_PAIRS}
+    assert mapped == meta_mapping.LEGACY_INDIVIDUAL_FIELDS
+
+
+def test_cell_meta_totality():
+    targets = {core for _, core in meta_mapping.COMMON_TO_CELL_PAIRS}
+    assert not (targets & meta_mapping.CORE_ONLY_CELL)
+    assert targets | meta_mapping.CORE_ONLY_CELL == _core_field_names(CellMeta)
+
+
+def test_test_meta_totality():
+    targets = {core for _, core in meta_mapping.COMMON_TO_TEST_PAIRS} | {
+        core for _, core in meta_mapping.INDIVIDUAL_TO_TEST_PAIRS
+    }
+    assert not (targets & meta_mapping.CORE_ONLY_TEST)
+    assert targets | meta_mapping.CORE_ONLY_TEST == _core_field_names(TestMeta)
+
+
+def test_no_target_collisions_between_common_and_individual():
+    common_targets = {core for _, core in meta_mapping.COMMON_TO_TEST_PAIRS}
+    individual_targets = {core for _, core in meta_mapping.INDIVIDUAL_TO_TEST_PAIRS}
+    assert not (common_targets & individual_targets)
+
+
+def test_pair_tables_bijective():
+    for pairs in (
+        meta_mapping.COMMON_TO_CELL_PAIRS,
+        meta_mapping.COMMON_TO_TEST_PAIRS,
+        meta_mapping.INDIVIDUAL_TO_TEST_PAIRS,
+    ):
+        legacy_side = [legacy for legacy, _ in pairs]
+        core_side = [core for _, core in pairs]
+        assert len(set(legacy_side)) == len(legacy_side)
+        assert len(set(core_side)) == len(core_side)
+
+
+def test_legacy_only_destinations_documented():
+    for legacy_field, destination in meta_mapping.LEGACY_ONLY.items():
+        assert destination, f"{legacy_field} needs a documented destination"
+
+
+# --- coerce_test_id ------------------------------------------------------------
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (None, 0),
+        (3, 3),
+        ("7", 7),
+        (2.0, 2),
+        ([4, 9], 4),
+        ((5,), 5),
+        ([], 0),
+    ],
+)
+def test_coerce_test_id(value, expected):
+    assert meta_mapping.coerce_test_id(value) == expected
+
+
+def test_coerce_test_id_default():
+    assert meta_mapping.coerce_test_id(None, default=42) == 42
+
+
+@pytest.mark.parametrize("bad", ["banana", object(), [None], True])
+def test_coerce_test_id_rejects_uninterpretable(bad):
+    with pytest.raises(ValueError, match="test_ID"):
+        meta_mapping.coerce_test_id(bad)
+
+
+# --- legacy_meta_to_core ---------------------------------------------------------
+def test_legacy_meta_to_core_translates_and_rehomes():
+    common = {
+        "material": "silicon",
+        "mass": 2.5,
+        "comment": "hello",
+        # re-homed fields (legacy filed these under "common"):
+        "cell_name": "cell_01",
+        "start_datetime": "2026-07-14T12:00:00",
+        "time_zone": "Europe/Oslo",
+        "tester_ID": "arbin-42",
+        "tester_calibration_date": "2026-01-01",
+        # legacy-only (must be ignored):
+        "raw_id": "abc",
+        "cellpy_file_version": 8,
+        "file_errors": None,
+    }
+    individual = {
+        "channel_index": "3",
+        "creator": "jepe",
+        "schedule_file_name": "protocol.sdu",
+        "test_type": "cycling",
+        "voltage_lim_low": 0.05,
+        "voltage_lim_high": 1.0,
+        "cycle_mode": "anode",
+        "test_ID": [2, 5],
+    }
+    cell, test = meta_mapping.legacy_meta_to_core(common, individual)
+
+    assert cell.material == "silicon"
+    assert cell.mass == 2.5
+    assert cell.comment == "hello"
+    assert cell.volume is None  # core-only, never filled from legacy
+
+    assert test.cell_name == "cell_01"
+    assert test.start_datetime == "2026-07-14T12:00:00"
+    assert test.time_zone == "Europe/Oslo"
+    assert test.tester_id == "arbin-42"
+    assert test.tester_calibration_date == "2026-01-01"
+    assert test.channel == "3"
+    assert test.creator == "jepe"
+    assert test.schedule_file_name == "protocol.sdu"
+    assert test.test_type == "cycling"
+    assert test.voltage_lim_low == 0.05
+    assert test.voltage_lim_high == 1.0
+    assert test.cycle_mode == "anode"
+    assert test.test_id == 2  # first of the legacy list
+
+    # provenance stays untouched (framework's job, not the mapping's)
+    assert test.uuid is None
+    assert test.source_uri is None
+    assert test.cell is None
+
+
+def test_legacy_meta_to_core_accepts_attribute_objects_and_none():
+    class LegacyCommon:
+        material = "graphite"
+        mass = 1.0
+        cell_name = "c2"
+
+    cell, test = meta_mapping.legacy_meta_to_core(LegacyCommon(), None)
+    assert cell.material == "graphite"
+    assert cell.mass == 1.0
+    assert test.cell_name == "c2"
+    assert test.test_id == 0
+
+    cell_empty, test_empty = meta_mapping.legacy_meta_to_core(None, None)
+    assert cell_empty == CellMeta()
+    assert test_empty == TestMeta()

--- a/tests/test_units_converters.py
+++ b/tests/test_units_converters.py
@@ -314,3 +314,11 @@ def test_validate_units_unknown_key_warns_and_is_dropped():
     with pytest.warns(UserWarning, match="unknown unit key"):
         spec = units.validate_units({"charge": "mAh", "swagger": "V"})
     assert "swagger" not in spec.keys()
+
+
+def test_get_converter_to_specific_volumetric_via_cell_meta():
+    """CellMeta.volume (issue #117) now feeds the volumetric mode."""
+    meta = CellMeta(volume=2.0)
+    assert units.get_converter_to_specific(
+        mode="volumetric", cell_meta=meta
+    ) == pytest.approx(0.5)


### PR DESCRIPTION
Closes #117 (Stage 1.16 / metadata plan Step 1).

**`cellpycore/legacy/meta_mapping.py`** — the legacy `CellpyMetaCommon` / `CellpyMetaIndividualTest` ⇄ core `CellMeta` / `TestMeta` translation declared once, same pattern as the header mapping:

- `COMMON_TO_CELL_PAIRS` (19, mostly identity) and `COMMON_TO_TEST_PAIRS` — the **re-homed** fields legacy misfiled under common (`cell_name`, `start_datetime`, `time_zone`, `tester_ID→tester_id`) plus the G9 tester triplet.
- `INDIVIDUAL_TO_TEST_PAIRS` incl. `test_ID→test_id` with `coerce_test_id` (legacy lists → first entry, logged; garbage → `ValueError`).
- `LEGACY_ONLY` with documented destinations (`file_errors` dropped, `raw_id` superseded by `TestMeta.uuid`, `cellpy_file_version` → file-format layer); `CORE_ONLY_CELL`/`CORE_ONLY_TEST` for migration-filled fields.
- `legacy_meta_to_core(common, individual)` — pure translation; provenance untouched (framework's job).

**Decisions implemented + recorded (dated notes in the metadata plan, architecture-plan repo):**
- **G9:** `tester_server_software_version`, `tester_client_software_version`, `tester_calibration_date` become `TestMeta` fields (test-dependent provenance; no `extra` dict).
- **`CellMeta.volume`** added (cellpy units convention, `cm**3`) and wired into `get_converter_to_specific(mode="volumetric", cell_meta=…)`.

**Quirk found:** legacy `schedule_file_name` is an **un-annotated class attribute**, not a dataclass field — pinned + documented; cellpy's contract test must compare fields *plus* that attribute.

Tests: `tests/test_meta_mapping.py` (totality × 4 sides, bijectivity, collision guard, coercion matrix, end-to-end translation) + volumetric-via-CellMeta in the units suite. Full suite: **224 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)