### PR TITLE
Harden cycle_mode->TestMode translator; warn on unknown (#127)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Harden `_cycle_mode_to_test_mode`: recognize all inverted-convention spellings
+  (`"anode"`, `"inverted"`, `"i"`) case- and whitespace-insensitively, accept the
+  known normal spellings, and warn (instead of silently falling back to NORMAL)
+  on an unrecognized `cycle_mode`. Fixes the silent NORMAL fallback that inverted
+  `coulombic_efficiency` and sign-flipped `coulombic_difference` for anode
+  half-cells. (#127)
 - Sync development guide with architecture-plan and current cellpycore layout. (#121)
 - Sync stale statuses in integration design docs (STEP-12, #54, header mapping path,
   make_step_table). (#114)

--- a/src/cellpycore/cell_core.py
+++ b/src/cellpycore/cell_core.py
@@ -13,18 +13,49 @@ DataFrame = TypeVar("DataFrame")
 logger = logging.getLogger(__name__)
 
 
+# cycle_mode spellings that select the inverted (anode half-cell) convention:
+# cellpy's legacy ``"anode"``, this package's ``TestMode`` value ``"inverted"``,
+# and batbase's short code ``"i"`` (see ``config.TestMode`` docstring).
+_INVERTED_CYCLE_MODES = frozenset({"anode", "inverted", "i"})
+# Recognized spellings that select the NORMAL convention. Anything outside either
+# set (and not ``None``/empty) is unknown -> NORMAL *with a warning*.
+_NORMAL_CYCLE_MODES = frozenset(
+    {"normal", "n", "cathode", "full_cell", "fullcell", "full cell", "standard"}
+)
+
+
 def _cycle_mode_to_test_mode(cycle_mode: Optional[str]) -> config.TestMode:
-    """Map legacy ``cycle_mode`` string to ``TestMode``.
+    """Map a legacy ``cycle_mode`` string to a :class:`config.TestMode`.
+
+    The inverted (anode half-cell) convention is selected by any of ``"anode"``
+    (cellpy), ``"inverted"`` (this package's ``TestMode`` value) or ``"i"``
+    (batbase short code), matched case-insensitively and whitespace-tolerantly.
+    ``None`` and the recognized normal-convention spellings map to
+    ``TestMode.NORMAL``.
+
+    An *unrecognized* non-empty value also maps to ``NORMAL`` but logs a warning,
+    so a mistyped or unmapped mode fails loudly instead of silently flipping the
+    ``coulombic_efficiency`` / ``coulombic_difference`` sign conventions.
 
     Args:
-        cycle_mode: Legacy mode string (``"anode"`` selects inverted convention).
-            ``None`` and all other values map to ``TestMode.NORMAL``.
+        cycle_mode: Legacy mode string, or ``None``.
 
     Returns:
         The corresponding ``TestMode`` for summary sign conventions.
     """
-    if cycle_mode == "anode":
+    if cycle_mode is None:
+        return config.TestMode.NORMAL
+    key = cycle_mode.strip().lower()
+    if key in _INVERTED_CYCLE_MODES:
         return config.TestMode.INVERTED
+    if key == "" or key in _NORMAL_CYCLE_MODES:
+        return config.TestMode.NORMAL
+    logger.warning(
+        "Unrecognized cycle_mode %r; defaulting to NORMAL convention. Use "
+        "'anode'/'inverted' for anode half-cells, or one of "
+        "'normal'/'cathode'/'full_cell'/'standard' for the ordinary case.",
+        cycle_mode,
+    )
     return config.TestMode.NORMAL
 
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -548,6 +548,51 @@ def test_cycle_mode_anode_via_cellpy_cell_core():
         assert cd[i] == pytest.approx(dc[i] - cc[i])
 
 
+# --- issue #127: robust cycle_mode -> TestMode translation --------------------
+@pytest.mark.parametrize(
+    "cycle_mode",
+    ["anode", "inverted", "i", "ANODE", "  anode  ", "Inverted"],
+)
+def test_cycle_mode_to_test_mode_inverted_spellings(cycle_mode):
+    """All recognized anode spellings select INVERTED, case/whitespace-tolerant."""
+    from cellpycore.cell_core import _cycle_mode_to_test_mode
+
+    assert _cycle_mode_to_test_mode(cycle_mode) == config.TestMode.INVERTED
+
+
+@pytest.mark.parametrize(
+    "cycle_mode",
+    [
+        None,
+        "",
+        "normal",
+        "n",
+        "cathode",
+        "full_cell",
+        "fullcell",
+        "standard",
+        "STANDARD",
+    ],
+)
+def test_cycle_mode_to_test_mode_normal_spellings(cycle_mode, caplog):
+    """None and recognized normal spellings select NORMAL without warning."""
+    from cellpycore.cell_core import _cycle_mode_to_test_mode
+
+    with caplog.at_level("WARNING"):
+        assert _cycle_mode_to_test_mode(cycle_mode) == config.TestMode.NORMAL
+    assert caplog.records == []
+
+
+def test_cycle_mode_to_test_mode_unknown_warns(caplog):
+    """An unrecognized non-empty value defaults to NORMAL but logs a warning."""
+    from cellpycore.cell_core import _cycle_mode_to_test_mode
+
+    with caplog.at_level("WARNING"):
+        result = _cycle_mode_to_test_mode("anodee")
+    assert result == config.TestMode.NORMAL
+    assert any("Unrecognized cycle_mode" in r.message for r in caplog.records)
+
+
 def test_initialized_and_uninitialized_core_share_cycle_mode_default():
     """initialize=True vs False must not diverge on default polarity."""
     assert CellpyCellCore(initialize=False).cycle_mode is None


### PR DESCRIPTION
Closes #127.

## Problem

`_cycle_mode_to_test_mode` (`src/cellpycore/cell_core.py`) matched only the
literal string `"anode"` to select `TestMode.INVERTED`; every other value —
`None`, `"inverted"` (this package's own `TestMode` value), `"i"` (batbase short
code), mixed case, surrounding whitespace, or a typo — **silently** fell through
to `NORMAL`.

For an anode half-cell processed as `NORMAL`, the summary engine (correct and
already mode-aware) produces the wrong-direction conventions:

- `coulombic_efficiency` **inverted** (reciprocal) — first-cycle CE reads ~106%
  instead of ~94%, crossing 100% and breaking CE-based QC thresholds;
- `coulombic_difference` family (incl. `cumulated_*`, `shifted_*`,
  `cumulated_ric*`) **sign-flipped**.

These are the two most user-facing deltas in the Stage-1 v1.0.3-vs-v1.0.4a3
validation (`architecture-plan/cellpy-v103-vs-v104a3-observations.md`, §3.1/§3.2).
Root cause is this translator, not the summary engine.

## Change

- Recognize `"anode"` / `"inverted"` / `"i"` as `INVERTED`, case- and
  whitespace-insensitive.
- Accept the known normal spellings (`"normal"`, `"n"`, `"cathode"`,
  `"full_cell"`/`"fullcell"`, `"standard"`) and `None`/empty → `NORMAL`.
- Any **unrecognized** non-empty value → `NORMAL` **plus a `logger.warning`**, so
  a mistyped/unmapped mode fails loudly instead of silently flipping signs.
- Default unchanged: `None` → `NORMAL` (batbase-consistent); the bridge still
  sets `"anode"` on real anode half-cells.

## Tests

- New unit tests cover the inverted spellings, the normal spellings (assert no
  warning), and the unknown-value warning path.
- Full suite: 255 passed, ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
