### PR TITLE
Guard against negative step_time_delta on golden data (#132)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Add a regression guard asserting `step_time_delta` is never negative on the
+  golden step table, locking in the 1.0.3 step-misclassification fix (obs doc
+  §2.1). (#132)
 - Harden `_cycle_mode_to_test_mode`: recognize all inverted-convention spellings
   (`"anode"`, `"inverted"`, `"i"`) case- and whitespace-insensitively, accept the
   known normal spellings, and warn (instead of silently falling back to NORMAL)

--- a/tests/test_golden.py
+++ b/tests/test_golden.py
@@ -153,6 +153,24 @@ def test_cycler_cc_step_types_match_cellpy_reference():
     )
 
 
+def test_step_time_delta_never_negative():
+    """Regression guard for the 1.0.3 misclassification bug (obs doc §2.1).
+
+    In cellpy 1.0.3, cycle 9 / step 21 got an empty type and a *negative*
+    ``step_time_delta`` (-0.00046 s) because its first/last/delta aggregates were
+    taken from wrongly-ordered rows. The polars engine orders correctly, so a
+    step's duration can never be negative. Assert that invariant on real data so
+    the bug class cannot silently return.
+    """
+    steps = _step_table(CYCLER_CC_RAW)
+
+    delta_col = "step_time_delta"
+    assert delta_col in steps.columns
+    deltas = steps[delta_col].dropna()
+    negative = deltas[deltas < 0]
+    assert negative.empty, f"negative {delta_col} values: {negative.to_list()}"
+
+
 @pytest.mark.skipif(not CYCLER_SMALL_RAW.is_file(), reason="small fixture missing")
 def test_cycler_small_step_table_runs_on_real_data():
     """Smoke test: a tiny real raw frame flows through the engine.


### PR DESCRIPTION
Closes #132.

## Problem

cellpy 1.0.3 misclassified cycle 9 / step 21 (empty type, negative
`step_time_delta` of -0.00046 s) because its aggregates were computed from
wrongly-ordered rows. The polars engine fixes this (obs doc §2.1), but nothing
guarded the invariant, so the bug class could silently return.

## Change

Add `test_step_time_delta_never_negative` in `tests/test_golden.py`: on the real
vendored fixture, every step's `step_time_delta` must be `>= 0`. Test-only,
additive, no behavior change.

## Tests

`tests/test_golden.py`: 7 passed. ruff check + format clean (pre-commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
