### PR TITLE
Pass test_mode into make_summary on the legacy bridge (#129)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Fix `OldCellpyCellCore.make_core_summary` to pass `test_mode` into
+  `make_summary`, so the legacy bridge honors `cycle_mode="anode"` like the native
+  path. Without it the bridge always ran NORMAL, silently giving anode half-cells
+  the wrong-direction `coulombic_efficiency` / `coulombic_difference`. This is the
+  end-to-end closure of the Stage-1 §3.1/§3.2 deltas (with #127). (#129)
 - Add a regression guard asserting `step_time_delta` is never negative on the
   golden step table, locking in the 1.0.3 step-misclassification fix (obs doc
   §2.1). (#132)

--- a/src/cellpycore/cell_core.py
+++ b/src/cellpycore/cell_core.py
@@ -1013,10 +1013,16 @@ class OldCellpyCellCore(CellpyCellCore):
         nd = Data()
         nd.raw = native_raw
         nd.steps = native_steps
+        # Honor cycle_mode on the bridge exactly as the native path does (issue
+        # #129): without this the bridge summary always ran NORMAL, so anode
+        # half-cells silently got the wrong-direction coulombic_efficiency /
+        # coulombic_difference.
+        test_mode = _cycle_mode_to_test_mode(self.cycle_mode)
         summarizers.make_summary(
             nd,
             native_schema,
             final_data_points=final_data_points,
+            test_mode=test_mode,
             exclude_step_types=exclude_step_types,
         )
 

--- a/tests/test_golden.py
+++ b/tests/test_golden.py
@@ -171,6 +171,59 @@ def test_step_time_delta_never_negative():
     assert negative.empty, f"negative {delta_col} values: {negative.to_list()}"
 
 
+def test_bridge_summary_respects_cycle_mode():
+    """OldCellpyCellCore.make_core_summary honors ``cycle_mode="anode"`` (issue #129).
+
+    The legacy bridge must pass ``test_mode`` into ``make_summary``; without it the
+    bridge always ran the NORMAL convention, so an anode half-cell silently got
+    the wrong-direction ``coulombic_efficiency`` / ``coulombic_difference``.
+
+    Assert the anode-mode summary is the reciprocal (CE, in %) / negation
+    (coulombic_difference) of the normal-mode summary on the same real data.
+    """
+    import numpy as np
+
+    def _summary(cycle_mode):
+        core = OldCellpyCellCore(initialize=False)
+        data = Data()
+        data.raw = pd.read_parquet(CYCLER_CC_RAW)
+        core.data = data
+        if cycle_mode is not None:
+            core.cycle_mode = cycle_mode
+        core.make_core_step_table(data, nom_cap=1.0)
+        core.make_core_summary(data, find_ir=False, find_end_voltage=False)
+        return data.summary.reset_index(drop=True)
+
+    normal = _summary(None)
+    anode = _summary("anode")
+
+    ce_n = normal["coulombic_efficiency"]
+    ce_a = anode["coulombic_efficiency"]
+    cd_n = normal["coulombic_difference"]
+    cd_a = anode["coulombic_difference"]
+
+    # The bridge must actually respond to cycle_mode (guards against the #129
+    # regression where anode == normal because test_mode was never passed).
+    assert not np.allclose(
+        ce_a.to_numpy(dtype=float), ce_n.to_numpy(dtype=float), equal_nan=True
+    )
+
+    ce_mask = ce_n.notna() & (ce_n != 0)
+    # CE% inverts: normal = 100*dc/cc, anode = 100*cc/dc = 10000/normal.
+    assert np.allclose(
+        ce_a[ce_mask].to_numpy(dtype=float),
+        10000.0 / ce_n[ce_mask].to_numpy(dtype=float),
+        rtol=1e-6,
+    )
+    cd_mask = cd_n.notna() & cd_a.notna()
+    assert np.allclose(
+        cd_a[cd_mask].to_numpy(dtype=float),
+        -cd_n[cd_mask].to_numpy(dtype=float),
+        rtol=1e-6,
+        atol=1e-9,
+    )
+
+
 @pytest.mark.skipif(not CYCLER_SMALL_RAW.is_file(), reason="small fixture missing")
 def test_cycler_small_step_table_runs_on_real_data():
     """Smoke test: a tiny real raw frame flows through the engine.


### PR DESCRIPTION
Closes #129.

## Problem

`OldCellpyCellCore.make_core_summary` (`src/cellpycore/cell_core.py`) called
`summarizers.make_summary(...)` **without** a `test_mode` argument, so the legacy
bridge summary always ran the NORMAL convention. The native path
(`CellpyCellCore.make_core_summary`) does compute and pass
`test_mode = _cycle_mode_to_test_mode(self.cycle_mode)`.

Consequence: even with `cycle_mode="anode"` correctly set on the cell and
correctly translated (after #127), any anode half-cell processed through the
**legacy bridge** silently got the wrong-direction `coulombic_efficiency`
(reciprocal) and `coulombic_difference` (sign-flipped) — the two most user-facing
Stage-1 v1.0.3-vs-v1.0.4a3 deltas (obs doc §3.1/§3.2).

This was pinpointed while investigating #130; see that issue's thread for the
side-by-side engine trace.

## Change

- Compute `test_mode = _cycle_mode_to_test_mode(self.cycle_mode)` in the bridge
  and pass it into `make_summary`, mirroring the native path.
- Add `test_bridge_summary_respects_cycle_mode` (real golden data): asserts the
  anode-mode summary is the reciprocal (CE, in %) / negation
  (`coulombic_difference`) of the normal-mode summary, and — as the direct #129
  regression guard — that anode output actually differs from normal.

With #127 (translator) this closes §3.1/§3.2 end to end: the mode is now both
correctly translated *and* actually applied on the bridge.

## Tests

`tests/test_golden.py`: 8 passed. Full suite: 257 passed, 3 deselected. ruff
check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
