### PR TITLE
Release prep: cellpycore 0.2.1 (anode-mode fixes for cellpy v1.1)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-07-15
+
 - Fix `OldCellpyCellCore.make_core_summary` to pass `test_mode` into
   `make_summary`, so the legacy bridge honors `cycle_mode="anode"` like the native
   path. Without it the bridge always ran NORMAL, silently giving anode half-cells
@@ -18,6 +20,9 @@ All notable changes to this project will be documented in this file.
   on an unrecognized `cycle_mode`. Fixes the silent NORMAL fallback that inverted
   `coulombic_efficiency` and sign-flipped `coulombic_difference` for anode
   half-cells. (#127)
+
+## [0.2.0] - 2026-07-15
+
 - Sync development guide with architecture-plan and current cellpycore layout. (#121)
 - Sync stale statuses in integration design docs (STEP-12, #54, header mapping path,
   make_step_table). (#114)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cellpycore"
-version = "0.2.0"
+version = "0.2.1"
 license = "MIT"
 license-files = ["LICEN[CS]E*"]
 description = "Core engine for cellpy: fast, thread-safe step and cycle summarization of battery-cycling raw data"

--- a/uv.lock
+++ b/uv.lock
@@ -73,7 +73,7 @@ css = [
 
 [[package]]
 name = "cellpycore"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "pandas" },


### PR DESCRIPTION
Release prep for **cellpycore 0.2.1** — the release that must ship before a cellpy
v1.1 (cellpy pins `cellpycore==0.2.0`, which predates the anode-mode fixes).

## Changes

- **Bump** `version` `0.2.0 → 0.2.1` (patch — bug fixes) + `uv lock`.
- **Reconcile HISTORY.** `v0.2.0` was tagged (2026-07-15 00:26) while #112/#114/#121
  still sat under `[Unreleased]`, so those shipped in 0.2.0 unlabeled. Retroactively
  add a `[0.2.0]` section for them, and a new `[0.2.1]` for this session's fixes:
  - #127 harden `cycle_mode`→`TestMode` translator (was: silent NORMAL fallback)
  - #129 legacy bridge summary now passes `test_mode`
  - #132 `step_time_delta` negative-duration guard

## Why 0.2.1 matters

#127 + #129 together fix the anode `coulombic_efficiency` inversion /
`coulombic_difference` sign flip. Released 0.2.0 does **not** contain them, so a
cellpy v1.1 built against `==0.2.0` would ship the regression.

## Verification

`ruff check src/ tests/` clean; `pytest` 257 passed, 3 deselected (same checks
release.yml runs before publishing).

## After merge (maintainer trigger — not done here)

1. `git switch main && git pull --ff-only`
2. `release` (no-arg — tags the already-committed 0.2.1, fires PyPI publish)
3. Re-pin cellpy `[project.dependencies]` → `cellpycore==0.2.1`, `uv lock`, then tag cellpy v1.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
